### PR TITLE
Install Ansible from the PPA

### DIFF
--- a/app/packer/PackerBuildConfigGenerator.scala
+++ b/app/packer/PackerBuildConfigGenerator.scala
@@ -53,6 +53,7 @@ object PackerBuildConfigGenerator {
         // Wait for cloud-init to finish first: https://github.com/mitchellh/packer/issues/2639
         "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
         "apt-get --yes install software-properties-common",
+        "apt-add-repository ppa:ansible/ansible",
         "apt-get --yes update",
         "apt-get --yes install ansible"
       )),


### PR DESCRIPTION
We disabled this because they didn't have a package for Xenial.

Now they do, so we can get a consistent Ansible version (currently 2.1.0.0-1) on all Ubuntu versions.

Good news for @Reettaphant! This means you don't need to do your workarounds for Ansible 1.x any more. e.g. you can now use `unarchive src=http://...` 