### PR TITLE
Add a role to install Logstash

### DIFF
--- a/roles/logstash/defaults/main.yml
+++ b/roles/logstash/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+logstash_version: 1.5.6
+logstash_user: logstash
+logstash_config_file: /etc/logstash.conf

--- a/roles/logstash/meta/main.yml
+++ b/roles/logstash/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - java8

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Download and extract Logstash
+  unarchive: src=https://download.elastic.co/logstash/logstash/logstash-{{logstash_version}}.tar.gz dest=/opt/ copy=no
+
+- name: Create softlink for Logstash
+  file: src=/opt/logstash-{{logstash_version}} dest=/opt/logstash state=link
+
+- name: Create user for Logstash
+  user: name={{logstash_user}} system=yes createhome=yes
+
+- name: Create systemd file for Logstash
+  template: src=logstash.service.template dest=/etc/systemd/system/logstash.service

--- a/roles/logstash/templates/logstash.service.template
+++ b/roles/logstash/templates/logstash.service.template
@@ -1,0 +1,13 @@
+[Unit]
+Description=Logstash
+
+[Service]
+User={{logstash_user}}
+Group={{logstash_user}}
+Restart=on-failure
+Environment='HOME=/home/{{logstash_user}}'
+WorkingDirectory=/home/{{logstash_user}}
+ExecStart=/opt/logstash/bin/logstash -f {{logstash_config_file}}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
CAPI still needs Logstash to send non-application logs (GC logs, Elasticsearch slowlog, etc.)

This role has been tested in DEV and seems to work as expected, but may need minor tweaks after I try it with the CAPI apps.