### PR TITLE
Implement roles page

### DIFF
--- a/app/ansible/RoleParser.scala
+++ b/app/ansible/RoleParser.scala
@@ -1,0 +1,67 @@
+package ansible
+
+import java.nio.file.{ Files, Path }
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import models.{ Markdown, RoleId, RoleSummary, Yaml }
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+object RoleParser {
+
+  private val yamlFactory = new YAMLFactory()
+
+  def createRoleSummary(roleDir: Path): Option[RoleSummary] = {
+    val roleId = RoleId(roleDir.getFileName.toString)
+    val dependsOn = parseDependencies(roleDir.resolve("meta/main.yml"))
+    val tasksMain = readYamlFile(roleDir.resolve("tasks/main.yml"))
+    val readme = readReadme(roleDir.resolve("README.md"))
+
+    for {
+      yaml <- tasksMain
+    } yield {
+      RoleSummary(roleId, dependsOn, yaml, readme)
+    }
+  }
+
+  def readReadme(path: Path): Option[Markdown] = {
+    if (Files.isRegularFile(path)) {
+      Try(Files.readAllLines(path)).toOption
+        .map(lines => Markdown(lines.asScala.mkString("\n")))
+    } else None
+  }
+
+  def parseDependencies(metaMainYaml: Path): Set[RoleId] = {
+    readYamlFile(metaMainYaml).map(parseDependenciesFromYaml).getOrElse(Set.empty)
+  }
+
+  /**
+   * Extracts the role IDs from YAML that looks like this:
+   *
+   * {{{
+   * ---
+   * dependencies:
+   *   - foo
+   *   - { role: bar, baz: wow }
+   * }}}
+   */
+  def parseDependenciesFromYaml(yaml: Yaml): Set[RoleId] = {
+    val mapper = new ObjectMapper(yamlFactory)
+    val jmap = mapper.readValue(yaml.content, classOf[java.util.Map[String, Any]])
+    val deps = jmap.asScala.get("dependencies").map(_.asInstanceOf[java.util.List[Any]].asScala).getOrElse(Nil)
+    deps.collect {
+      case roleId: String => Some(RoleId(roleId))
+      case customisedRole: java.util.Map[String, String] => customisedRole.asScala.get("role").map(RoleId(_))
+    }.flatten.toSet
+  }
+
+  private def readYamlFile(path: Path): Option[Yaml] = {
+    if (Files.isRegularFile(path)) {
+      Try(Files.readAllLines(path)).toOption
+        .map(lines => Yaml(lines.asScala.mkString("\n")))
+    } else None
+  }
+
+}

--- a/app/controllers/BaseImageController.scala
+++ b/app/controllers/BaseImageController.scala
@@ -26,14 +26,14 @@ class BaseImageController(
   def editBaseImage(id: BaseImageId) = AuthAction {
     BaseImages.findById(id).fold[Result](NotFound) { image =>
       val form = Forms.editBaseImage.fill((image.description, image.amiId))
-      Ok(views.html.editBaseImage(image, form, Roles.list))
+      Ok(views.html.editBaseImage(image, form, Roles.listIds))
     }
   }
 
   def updateBaseImage(id: BaseImageId) = AuthAction(BodyParsers.parse.urlFormEncoded) { implicit request =>
     BaseImages.findById(id).fold[Result](NotFound) { image =>
       Forms.editBaseImage.bindFromRequest.fold({ formWithErrors =>
-        BadRequest(views.html.editBaseImage(image, formWithErrors, Roles.list))
+        BadRequest(views.html.editBaseImage(image, formWithErrors, Roles.listIds))
       }, {
         case (description, amiId) =>
           val customisedRoles = ControllerHelpers.parseEnabledRoles(request.body)
@@ -44,18 +44,18 @@ class BaseImageController(
   }
 
   def newBaseImage = AuthAction {
-    Ok(views.html.newBaseImage(Forms.createBaseImage, Roles.list))
+    Ok(views.html.newBaseImage(Forms.createBaseImage, Roles.listIds))
   }
 
   def createBaseImage = AuthAction(BodyParsers.parse.urlFormEncoded) { implicit request =>
     Forms.createBaseImage.bindFromRequest.fold({ formWithErrors =>
-      BadRequest(views.html.newBaseImage(formWithErrors, Roles.list))
+      BadRequest(views.html.newBaseImage(formWithErrors, Roles.listIds))
     }, {
       case (id, description, amiId) =>
         BaseImages.findById(id) match {
           case Some(existingImage) =>
             val formWithError = Forms.createBaseImage.fill((id, description, amiId)).withError("id", "This base image ID is already in use")
-            Conflict(views.html.newBaseImage(formWithError, Roles.list))
+            Conflict(views.html.newBaseImage(formWithError, Roles.listIds))
           case None =>
             val customisedRoles = ControllerHelpers.parseEnabledRoles(request.body)
             BaseImages.create(id, description, amiId, customisedRoles, createdBy = request.user.fullName)

--- a/app/controllers/RecipeController.scala
+++ b/app/controllers/RecipeController.scala
@@ -33,14 +33,14 @@ class RecipeController(
   def editRecipe(id: RecipeId) = AuthAction {
     Recipes.findById(id).fold[Result](NotFound) { recipe =>
       val form = Forms.editRecipe.fill((recipe.description, recipe.baseImage.id, recipe.bakeSchedule))
-      Ok(views.html.editRecipe(recipe, form, BaseImages.list().toSeq, Roles.list))
+      Ok(views.html.editRecipe(recipe, form, BaseImages.list().toSeq, Roles.listIds))
     }
   }
 
   def updateRecipe(id: RecipeId) = AuthAction(BodyParsers.parse.urlFormEncoded) { implicit request =>
     Recipes.findById(id).fold[Result](NotFound) { recipe =>
       Forms.editRecipe.bindFromRequest.fold({ formWithErrors =>
-        BadRequest(views.html.editRecipe(recipe, formWithErrors, BaseImages.list().toSeq, Roles.list))
+        BadRequest(views.html.editRecipe(recipe, formWithErrors, BaseImages.list().toSeq, Roles.listIds))
       }, {
         case (description, baseImageId, bakeSchedule) =>
           BaseImages.findById(baseImageId) match {
@@ -51,25 +51,25 @@ class RecipeController(
               Redirect(routes.RecipeController.showRecipe(id)).flashing("info" -> "Successfully updated recipe")
             case None =>
               val formWithError = Forms.editRecipe.fill((description, baseImageId, bakeSchedule)).withError("baseImageId", "Unknown base image")
-              BadRequest(views.html.editRecipe(recipe, formWithError, BaseImages.list().toSeq, Roles.list))
+              BadRequest(views.html.editRecipe(recipe, formWithError, BaseImages.list().toSeq, Roles.listIds))
           }
       })
     }
   }
 
   def newRecipe = AuthAction {
-    Ok(views.html.newRecipe(Forms.createRecipe, BaseImages.list().toSeq, Roles.list))
+    Ok(views.html.newRecipe(Forms.createRecipe, BaseImages.list().toSeq, Roles.listIds))
   }
 
   def createRecipe = AuthAction(BodyParsers.parse.urlFormEncoded) { implicit request =>
     Forms.createRecipe.bindFromRequest.fold({ formWithErrors =>
-      BadRequest(views.html.newRecipe(formWithErrors, BaseImages.list().toSeq, Roles.list))
+      BadRequest(views.html.newRecipe(formWithErrors, BaseImages.list().toSeq, Roles.listIds))
     }, {
       case (id, description, baseImageId, bakeSchedule) =>
         Recipes.findById(id) match {
           case Some(existingRecipe) =>
             val formWithError = Forms.createRecipe.fill((id, description, baseImageId, bakeSchedule)).withError("id", "This recipe ID is already in use")
-            Conflict(views.html.newBaseImage(formWithError, Roles.list))
+            Conflict(views.html.newBaseImage(formWithError, Roles.listIds))
           case None =>
             BaseImages.findById(baseImageId) match {
               case Some(baseImage) =>
@@ -79,7 +79,7 @@ class RecipeController(
                 Redirect(routes.RecipeController.showRecipe(id)).flashing("info" -> "Successfully created recipe")
               case None =>
                 val formWithError = Forms.createRecipe.fill((id, description, baseImageId, bakeSchedule)).withError("baseImageId", "Unknown base image")
-                BadRequest(views.html.newRecipe(formWithError, BaseImages.list().toSeq, Roles.list))
+                BadRequest(views.html.newRecipe(formWithError, BaseImages.list().toSeq, Roles.listIds))
             }
         }
     })

--- a/app/data/Roles.scala
+++ b/app/data/Roles.scala
@@ -2,20 +2,20 @@ package data
 
 import java.nio.file.{ Files, Paths }
 
-import models.RoleId
+import ansible.RoleParser
+import models.{ RoleId, RoleSummary }
 
 import scala.collection.JavaConverters._
 
-/**
- * Proof of concept that just loads the list of roles from the local disk
- */
 object Roles {
 
   private val rootDir = Paths.get("roles")
 
-  val list: Seq[RoleId] = Files.list(rootDir).iterator.asScala.toSeq
-    .map(path => RoleId(path.getFileName.toString))
-    .sortBy(_.value)
+  val list: Seq[RoleSummary] = Files.list(rootDir).iterator.asScala.toSeq
+    .flatMap(RoleParser.createRoleSummary)
+    .sortBy(_.roleId.value)
+
+  val listIds: Seq[RoleId] = list.map(_.roleId)
 
   def findById(id: RoleId) = list.find(_ == id)
 

--- a/app/models/RoleSummary.scala
+++ b/app/models/RoleSummary.scala
@@ -1,0 +1,7 @@
+package models
+
+case class RoleSummary(
+  roleId: RoleId,
+  dependsOn: Set[RoleId],
+  tasksMain: Yaml,
+  readme: Option[Markdown])

--- a/app/models/TextFormat.scala
+++ b/app/models/TextFormat.scala
@@ -1,0 +1,6 @@
+package models
+
+sealed abstract class TextContent(content: String)
+case class Yaml(content: String) extends TextContent(content)
+case class Markdown(content: String) extends TextContent(content)
+

--- a/app/views/baseImages.scala.html
+++ b/app/views/baseImages.scala.html
@@ -1,5 +1,5 @@
 @(images: Iterable[BaseImage])
-@layout("AMIgo"){
+@simpleLayout("AMIgo"){
 
   <h1>Base images</h1>
 

--- a/app/views/editBaseImage.scala.html
+++ b/app/views/editBaseImage.scala.html
@@ -2,7 +2,7 @@
 
 @implicitFieldConstructor = @{ b3.horizontal.fieldConstructor("col-md-2", "col-md-10") }
 
-@layout("AMIgo"){
+@simpleLayout("AMIgo"){
 
   @b3.form(routes.BaseImageController.updateBaseImage(image.id)) {
     @b3.static("ID"){@image.id.value}

--- a/app/views/editRecipe.scala.html
+++ b/app/views/editRecipe.scala.html
@@ -2,7 +2,7 @@
 
 @implicitFieldConstructor = @{ b3.horizontal.fieldConstructor("col-md-2", "col-md-10") }
 
-@layout("AMIgo"){
+@simpleLayout("AMIgo"){
 
   @b3.form(routes.RecipeController.updateRecipe(recipe.id)) {
     @b3.static("ID"){@recipe.id.value}

--- a/app/views/fragments/customisedRoles.scala.html
+++ b/app/views/fragments/customisedRoles.scala.html
@@ -3,7 +3,7 @@
 <ul class="list-group">
   @for(role <- roles) {
     <li class="list-group-item">
-      @role.roleId
+      <a href="@routes.RoleController.listRoles#@role.roleId">@role.roleId</a>
 
       @if(role.variables.isEmpty) {
         <em>(No custom variables)</em>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -6,8 +6,13 @@
 
     <img src="http://publicdomainvectors.org/photos/1385029480.png" width="200" height="200">
 
-    <p>TODO explanatory text</p>
+    <p>AMIgo is a self-serve AMI bakery.</p>
 
+    <p>To get started, take a look at the available <em><a href="@routes.BaseImageController.listBaseImages">base images</a></em> and <em><a href="@routes.RoleController.listRoles">roles</a></em>.</p>
+
+    <p>A <em>base image</em> and one or more <em>roles</em> are combined to make a <em>recipe</em>.</p>
+
+    <p>Take a look at the available <em><a href="@routes.RecipeController.listRecipes">recipes</a></em> or <a href="@routes.RecipeController.newRecipe">create a new one</a>.</p>
   </div>
 
 }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,4 +1,4 @@
-@layout("AMIgo"){
+@simpleLayout("AMIgo"){
 
   <div class="hola">
 

--- a/app/views/layout.scala.html
+++ b/app/views/layout.scala.html
@@ -1,4 +1,4 @@
-@(title: String)(content: Html)(implicit flash: Flash = Flash())
+@(title: String)(content: Html)(extraScripts: Html = Html(""))(implicit flash: Flash = Flash())
 
 <!DOCTYPE html>
 
@@ -46,7 +46,9 @@
     </div>
 
     <script src="//code.jquery.com/jquery-2.2.1.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
+    @*<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>*@
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.js" crossorigin="anonymous"></script>
     <script src="@routes.Assets.versioned("javascripts/amigo.js")" type="text/javascript"></script>
+    @extraScripts
   </body>
 </html>

--- a/app/views/newBaseImage.scala.html
+++ b/app/views/newBaseImage.scala.html
@@ -2,7 +2,7 @@
 
 @implicitFieldConstructor = @{ b3.horizontal.fieldConstructor("col-md-2", "col-md-10") }
 
-@layout("AMIgo"){
+@simpleLayout("AMIgo"){
 
   @b3.form(routes.BaseImageController.createBaseImage) {
     @b3.text(form("id"), '_label -> "ID", 'placeholder -> "my-lovely-image" )

--- a/app/views/newRecipe.scala.html
+++ b/app/views/newRecipe.scala.html
@@ -2,7 +2,7 @@
 
 @implicitFieldConstructor = @{ b3.horizontal.fieldConstructor("col-md-2", "col-md-10") }
 
-@layout("AMIgo"){
+@simpleLayout("AMIgo"){
 
   @b3.form(routes.RecipeController.createRecipe) {
     @b3.text( form("id"), '_label -> "ID", 'placeholder -> "my-lovely-recipe" )

--- a/app/views/recipes.scala.html
+++ b/app/views/recipes.scala.html
@@ -1,5 +1,5 @@
 @(recipes: Iterable[Recipe])
-@layout("AMIgo"){
+@simpleLayout("AMIgo"){
 
   <h1>Recipes</h1>
 

--- a/app/views/roles.scala.html
+++ b/app/views/roles.scala.html
@@ -1,21 +1,78 @@
-@(roles: Iterable[RoleId])
+@(roles: Iterable[RoleSummary])
 @layout("AMIgo"){
 
   <h1>Roles</h1>
 
-  <div>TODO show more info about the roles, e.g. a list of tasks.</div>
+  <div class="row">
+    <div class="col-md-3">
+      <div class="list-group">
+      @for(role <- roles) {
+        <a href="#@role.roleId" data-role-id="@role.roleId" class="list-group-item role-id">
+        @role.roleId
+        </a>
+      }
+      </div>
+    </div>
 
-  <table class="table table-striped">
-    <thead>
-      <th>Name</th>
-    </thead>
-    <tbody>
-    @for(id <- roles) {
-      <tr>
-        <td>@id.value (TODO link)</td>
-      </tr>
-    }
-    </tbody>
-  </table>
+    <div class="col-md-9">
+      <div id="sticky-anchor"></div>
+      <div class="sticky">
+        <div id="explanation">
+          Choose a role from the list to see more details.
+        </div>
 
+        @for(role <- roles) {
+          <div id="detail-@role.roleId" style="display: none;">
+
+            <ul class="nav nav-tabs" role="tablist">
+              <li role="presentation" class="tab-label active">
+                <a aria-controls="tasks" role="tab" data-toggle="tab" data-target="#tasks-@role.roleId">Tasks</a>
+              </li>
+              <li role="presentation" class="tab-label">
+                <a aria-controls="dependencies" role="tab" data-toggle="tab" data-target="#dependencies-@role.roleId">Dependencies</a>
+              </li>
+              @for(readme <- role.readme) {
+                <li role="presentation" class="tab-label">
+                  <a aria-controls="readme" role="tab" data-toggle="tab" data-target="#readme-@role.roleId">README</a>
+                </li>
+              }
+            </ul>
+
+            <div class="tab-content">
+              <div role="tabpanel" class="tab-pane active" id="tasks-@role.roleId">
+                <h2>Tasks</h2>
+                <pre><code>@role.tasksMain.content</code></pre>
+              </div>
+
+              <div role="tabpanel" class="tab-pane" id="dependencies-@role.roleId">
+                <h2>Dependencies</h2>
+
+                @if(role.dependsOn.isEmpty) {
+                  This role does not depend on any other roles.
+                } else {
+                  This role depends on:
+                  <ul>
+                    @for(roleId <- role.dependsOn.toList.sortBy(_.value)) {
+                      <li><a href="#@roleId">@roleId</a></li>
+                    }
+                  </ul>
+                }
+              </div>
+
+              @for(readme <- role.readme) {
+                <div role="tabpanel" class="tab-pane markdown" id="readme-@role.roleId">
+                  <pre>@readme.content</pre>
+                </div>
+              }
+            </div>
+
+          </div>
+        }
+      </div>
+    </div>
+  </div>
+
+} {
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.4.3/showdown.min.js" type="text/javascript"></script>
+  <script src="@routes.Assets.versioned("javascripts/roles.js")" type="text/javascript"></script>
 }

--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -1,5 +1,5 @@
 @(bake: Bake, bakeLogs: Iterable[BakeLog])
-@layout("AMIgo"){
+@simpleLayout("AMIgo"){
 
   <h1>Bake!</h1>
   <h2>Recipe: @bake.recipe.id.value</h2>

--- a/app/views/showBaseImage.scala.html
+++ b/app/views/showBaseImage.scala.html
@@ -1,5 +1,5 @@
 @(image: BaseImage)(implicit flash: Flash)
-@layout("AMIgo"){
+@simpleLayout("AMIgo"){
 
   <h1>@image.id.value</h1>
 

--- a/app/views/showRecipe.scala.html
+++ b/app/views/showRecipe.scala.html
@@ -1,5 +1,5 @@
 @(recipe: Recipe, recentBakes: Iterable[Bake])(implicit flash: Flash)
-@layout("AMIgo"){
+@simpleLayout("AMIgo"){
 
   <h1>@recipe.id.value</h1>
 

--- a/app/views/simpleLayout.scala.html
+++ b/app/views/simpleLayout.scala.html
@@ -1,0 +1,3 @@
+@(title: String)(content: Html)(implicit flash: Flash = Flash())
+
+@layout(title)(content)()(flash)

--- a/public/javascripts/amigo.js
+++ b/public/javascripts/amigo.js
@@ -35,8 +35,30 @@ function enablePostLinks() {
   });
 }
 
+function relocateStickyComponents() {
+  var windowTop = $(window).scrollTop();
+  $('.sticky').each(function () {
+    var $this = $(this);
+    var $anchor = $this.prev(); // the component that you want to make sticky must be preceded by an empty div
+    var componentTop = $anchor.offset().top;
+    if (windowTop > componentTop - 60) {
+      $this.addClass('stick');
+      $anchor.height($this.outerHeight());
+    } else {
+      $this.removeClass('stick');
+      $anchor.height(0);
+    }
+  });
+}
+
+function initStickyComponents() {
+  $(window).scroll(relocateStickyComponents);
+  relocateStickyComponents();
+}
+
 $(function(){
   enablePostLinks();
   makeTableRowsClickable();
   makeRoleVariablesVisibilityToggleable();
+  initStickyComponents();
 });

--- a/public/javascripts/roles.js
+++ b/public/javascripts/roles.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var markdownConverter = new showdown.Converter();
+
+function updateActiveRole() {
+  var activeRole = window.location.hash.substring(1);
+  $('.list-group-item.role-id').each(function(){
+    var $this = $(this);
+    var roleId = $this.data('role-id');
+    if (roleId === activeRole) {
+      $this.addClass('active');
+      $('#explanation').hide();
+      $('#detail-'+roleId).show();
+    } else {
+      $this.removeClass('active');
+      $('#detail-'+roleId).hide();
+    }
+  });
+}
+
+function updateActiveRoleOnHashChange() {
+  $(window).bind('hashchange', updateActiveRole);
+}
+
+function initTabs() {
+  $('.tab-label').find('a').click(function (e) {
+    e.preventDefault();
+    $(this).tab('show');
+  });
+}
+
+function renderMarkdown() {
+  $('.markdown').each(function() {
+    this.innerHTML = markdownConverter.makeHtml($(this).find('pre').text());
+  });
+}
+
+$(function(){
+  updateActiveRole();
+  updateActiveRoleOnHashChange();
+  initTabs();
+  renderMarkdown();
+});

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -4,3 +4,11 @@ body { padding-top: 70px; }
     padding: 40px 15px;
     text-align: center;
 }
+
+.sticky.stick {
+    margin-top: 0 !important;
+    position: fixed;
+    top: 60px;
+    z-index: 10000;
+    border-radius: 0 0 0.5em 0.5em;
+}

--- a/roles/apt/README.md
+++ b/roles/apt/README.md
@@ -1,0 +1,6 @@
+# apt
+
+Makes sure that the `apt` cache is up to date and upgrades all installed packages to the latest version.
+
+Any role that involves installing a package using `apt` should depend on this role, 
+to ensure that the `apt` package cache is up to date before the package gets installed.

--- a/roles/aws-tools/README.md
+++ b/roles/aws-tools/README.md
@@ -1,0 +1,3 @@
+# aws-tools
+
+Installs latest AWS CLI and CloudFormation tools.

--- a/roles/disk-available-cronjob/README.md
+++ b/roles/disk-available-cronjob/README.md
@@ -1,0 +1,5 @@
+# disk-available-cronjob
+
+Sets up a cronjob that sends the instance's available disk space to a CloudWatch metric every few minutes.
+
+This makes it possible to set up a CloudWatch alarm to alert you when your machines are running low on disk space.

--- a/roles/enhanced-networking/README.md
+++ b/roles/enhanced-networking/README.md
@@ -1,0 +1,6 @@
+# enhanced-networking
+
+Upgrades the network driver so we can use [EC2 Advanced Networking](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html).
+
+Supposedly this improves network performance, but we've never done any benchmarking to check if this is actually the case.
+

--- a/roles/logstash/README.md
+++ b/roles/logstash/README.md
@@ -1,0 +1,8 @@
+# Logstash
+
+Installs the Logstash sidecar on the machine.
+
+This is useful if you need to send logs from a 3rd-party process (e.g. nginx or Elasticsearch) to your ELK stack.
+
+For your application logs, it's probably better to send them to Kinesis stream and have ELK pick them up from there.
+The Logstash sidecar process is known to have some reliability issues.

--- a/roles/node/README.md
+++ b/roles/node/README.md
@@ -1,0 +1,7 @@
+# Node.js
+
+Installs Node.js.
+
+## Variables
+
+* `node_version` - which version of Node.js to install. Default value is `4.x`. Valid values include `4.x` and `6.x`.

--- a/roles/ubuntu-init/README.md
+++ b/roles/ubuntu-init/README.md
@@ -1,0 +1,3 @@
+# ubuntu-init
+
+Does some bare-bones configuration of Ubuntu. You most likely want this as a builtin role of your base image.

--- a/roles/useful-packages/README.md
+++ b/roles/useful-packages/README.md
@@ -1,0 +1,4 @@
+# useful-packages
+
+Installs some mildly controversial packages that some people think are useful and others think are unnecessary.
+

--- a/test/ansible/RoleParserSpec.scala
+++ b/test/ansible/RoleParserSpec.scala
@@ -1,0 +1,18 @@
+package ansible
+
+import models.{ RoleId, Yaml }
+import org.scalatest._
+
+class RoleParserSpec extends FlatSpec with Matchers {
+
+  it should "extract dependencies" in {
+    val yaml = Yaml(
+      """
+        |---
+        |dependencies:
+        |  - foo
+        |  - { role: bar, baz: wow }
+      """.stripMargin)
+    RoleParser.parseDependenciesFromYaml(yaml) should be(Set(RoleId("foo"), RoleId("bar")))
+  }
+}


### PR DESCRIPTION
Fixes #15 

Make the roles list page show something useful. For each role, display:

* the contents of the `tasks/main.yml` file
* which roles this role depends on
* the `README.md` file, if there is one, rendered as HTML

<img width="1193" alt="screen shot 2016-08-26 at 14 05 47" src="https://cloud.githubusercontent.com/assets/106760/18008689/fd7ff75a-6ba0-11e6-9900-2ca4ac2ce985.png">

<img width="1198" alt="screen shot 2016-08-26 at 14 06 02" src="https://cloud.githubusercontent.com/assets/106760/18008693/067f90e0-6ba1-11e6-87ef-9686bea9bda7.png">

Also:

* Write README files for most of the roles
* Add some explanatory text on the home page