### PR TITLE
Add `iam:PassRole` to packer permissions

### DIFF
--- a/cloudformation.json
+++ b/cloudformation.json
@@ -148,7 +148,8 @@
                 "ec2:DescribeImages",
                 "ec2:RegisterImage",
                 "ec2:CreateTags",
-                "ec2:ModifyImageAttribute"
+                "ec2:ModifyImageAttribute",
+                "iam:PassRole"
               ],
               "Resource": "*"
             }


### PR DESCRIPTION
This allows Packer to start a machine with an instance profile. See the bottom of https://www.packer.io/docs/builders/amazon.html