### PR TITLE
Upgrade Scanamo to 0.7

### DIFF
--- a/app/data/BakeLogs.scala
+++ b/app/data/BakeLogs.scala
@@ -1,10 +1,7 @@
 package data
 
-import com.amazonaws.services.dynamodbv2.model._
-import models.{ RecipeId, _ }
+import models._
 import com.gu.scanamo.syntax._
-
-import scala.collection.JavaConverters._
 
 object BakeLogs {
   import Dynamo._

--- a/app/data/BakeLogs.scala
+++ b/app/data/BakeLogs.scala
@@ -1,35 +1,25 @@
 package data
 
-import cats.data.{ Validated, ValidatedNel }
 import com.amazonaws.services.dynamodbv2.model._
-import com.gu.scanamo.{ DynamoFormat, DynamoReadError, Scanamo }
 import models.{ RecipeId, _ }
-import org.joda.time.DateTime
+import com.gu.scanamo.syntax._
 
 import scala.collection.JavaConverters._
 
 object BakeLogs {
-
-  implicit val dateTimeFormat = DynamoFormat.xmap(DynamoFormat.stringFormat)(d => Validated.valid(new DateTime(d)))(_.toString)
+  import Dynamo._
 
   def save(bakeLog: BakeLog)(implicit dynamo: Dynamo): Unit = {
     // Make sure we don't try to save an empty string to Dynamo
     val safeMessageParts = bakeLog.messageParts.map(part => part.copy(text = if (part.text.nonEmpty) part.text else " "))
     val safeBakeLog = bakeLog.copy(messageParts = safeMessageParts)
-    Scanamo.put(dynamo.client)(tableName)(safeBakeLog)
+    table.put(safeBakeLog).exec()
   }
 
   def list(bakeId: BakeId)(implicit dynamo: Dynamo): Iterable[BakeLog] = {
-    val queryRequest = new QueryRequest(tableName)
-      .withKeyConditionExpression("#bakeId = :bakeId")
-      .withExpressionAttributeNames(Map("#bakeId" -> "bakeId").asJava)
-      .withExpressionAttributeValues(Map(":bakeId" -> BakeId.dynamoFormat.write(bakeId)).asJava)
-      .withScanIndexForward(true) // return oldest logs first
-    val items: Iterable[Option[ValidatedNel[DynamoReadError, BakeLog]]] =
-      dynamo.client.query(queryRequest).getItems.asScala.map { item => Scanamo.from[BakeLog](new GetItemResult().withItem(item)) }
-    items.flatMap(_.flatMap(_.toOption))
+    table.query('bakeId -> bakeId).exec().flatMap(_.toOption)
   }
 
-  private def tableName(implicit dynamo: Dynamo) = dynamo.Tables.bakeLogs.name
+  private def table(implicit dynamo: Dynamo) = dynamo.Tables.bakeLogs.table
 
 }

--- a/app/data/Bakes.scala
+++ b/app/data/Bakes.scala
@@ -1,79 +1,64 @@
 package data
 
-import cats.data.ValidatedNel
-import com.amazonaws.services.dynamodbv2.model._
-import com.gu.scanamo.{ DynamoFormat, DynamoReadError, Scanamo }
-import models.{ RecipeId, _ }
+import com.gu.scanamo.syntax._
+import models._
 import org.joda.time.DateTime
 
-import scala.collection.JavaConverters._
-
 object Bakes {
-  import DynamoFormats._
+  import Dynamo._
 
   def create(recipe: Recipe, buildNumber: Int, startedBy: String)(implicit dynamo: Dynamo): Bake = {
     val bake = Bake(recipe, buildNumber, status = BakeStatus.Running, amiId = None, startedBy = startedBy, startedAt = DateTime.now())
     val dbModel = Bake.domain2db(bake)
-    Scanamo.put(dynamo.client)(tableName)(dbModel)
+    table.put(dbModel).exec()
     bake
   }
 
-  def updateStatus(bakeId: BakeId, status: BakeStatus)(implicit dynamo: Dynamo, fbs: DynamoFormat[BakeStatus]): Unit = {
-    updateItem(bakeId, "SET #status = :status", "#status" -> "status", ":status" -> fbs.write(status))
+  def updateStatus(bakeId: BakeId, status: BakeStatus)(implicit dynamo: Dynamo): Unit = {
+    table
+      .given(attributeExists('recipeId) and attributeExists('buildNumber))
+      .update(
+        ('recipeId -> bakeId.recipeId) and ('buildNumber -> bakeId.buildNumber),
+        set('status -> status)
+      )
+      .exec()
   }
 
-  def updateAmiId(bakeId: BakeId, amiId: AmiId)(implicit dynamo: Dynamo, fai: DynamoFormat[AmiId]): Unit = {
-    updateItem(bakeId, "SET #amiId = :amiId", "#amiId" -> "amiId", ":amiId" -> fai.write(amiId))
+  def updateAmiId(bakeId: BakeId, amiId: AmiId)(implicit dynamo: Dynamo): Unit = {
+    table
+      .given(attributeExists('recipeId) and attributeExists('buildNumber))
+      .update(
+        ('recipeId -> bakeId.recipeId) and ('buildNumber -> bakeId.buildNumber),
+        set('amiId -> amiId)
+      )
   }
 
   def list(recipeId: RecipeId, limit: Int = 20)(implicit dynamo: Dynamo): Iterable[Bake] = {
-    val queryRequest = new QueryRequest(tableName)
-      .withKeyConditionExpression("#recipeId = :recipeId")
-      .withExpressionAttributeNames(Map("#recipeId" -> "recipeId").asJava)
-      .withExpressionAttributeValues(Map(":recipeId" -> new AttributeValue(recipeId.value)).asJava)
-      .withScanIndexForward(false) // return newest (highest build number) first
-      .withLimit(limit)
+    val dbModels = table.limit(limit).query(('recipeId -> recipeId).descending) // return newest (highest build number) first
+      .exec()
+      .flatMap(_.toOption)
     val recipe = Recipes.findById(recipeId)
-    val dbModels: Iterable[Option[ValidatedNel[DynamoReadError, Bake.DbModel]]] =
-      dynamo.client.query(queryRequest).getItems.asScala.map { item => Scanamo.from[Bake.DbModel](new GetItemResult().withItem(item)) }
     for {
       r <- recipe.toIterable
-      dbModel <- dbModels.flatMap(_.flatMap(_.toOption))
+      dbModel <- dbModels
     } yield {
       Bake.db2domain(dbModel, r)
     }
   }
 
   def findById(recipeId: RecipeId, buildNumber: Int)(implicit dynamo: Dynamo): Option[Bake] = {
-    val queryRequest = new QueryRequest(tableName)
-      .withKeyConditionExpression("#recipeId = :recipeId AND #buildNumber = :buildNumber")
-      .withExpressionAttributeNames(Map("#recipeId" -> "recipeId", "#buildNumber" -> "buildNumber").asJava)
-      .withExpressionAttributeValues(Map(":recipeId" -> new AttributeValue(recipeId.value), ":buildNumber" -> new AttributeValue().withN(buildNumber.toString)).asJava)
-      .withScanIndexForward(false) // return newest (highest build number) first
-      .withLimit(1)
+    val dbModel = table.get(('recipeId -> recipeId) and ('buildNumber -> buildNumber))
+      .exec()
+      .flatMap(_.toOption)
     val recipe = Recipes.findById(recipeId)
-    val dbModel: Option[ValidatedNel[DynamoReadError, Bake.DbModel]] =
-      dynamo.client.query(queryRequest).getItems.asScala.map { item => Scanamo.from[Bake.DbModel](new GetItemResult().withItem(item)) }
-        .headOption.flatten
     for {
       r <- recipe
-      dbModel <- dbModel.flatMap(_.toOption)
+      model <- dbModel
     } yield {
-      Bake.db2domain(dbModel, r)
+      Bake.db2domain(model, r)
     }
   }
 
-  private def updateItem(bakeId: BakeId, updateExpression: String, attrNames: (String, String), attrValues: (String, AttributeValue))(implicit dynamo: Dynamo, frid: DynamoFormat[RecipeId], fint: DynamoFormat[Int]): Unit = {
-    val updateRequest = new UpdateItemRequest()
-      .withTableName(tableName)
-      .withConditionExpression("attribute_exists(recipeId) AND attribute_exists(buildNumber)")
-      .withKey(Map("recipeId" -> frid.write(bakeId.recipeId), "buildNumber" -> fint.write(bakeId.buildNumber)).asJava)
-      .withUpdateExpression(updateExpression)
-      .withExpressionAttributeNames(Map(attrNames).asJava)
-      .withExpressionAttributeValues(Map(attrValues).asJava)
-    dynamo.client.updateItem(updateRequest)
-  }
-
-  private def tableName(implicit dynamo: Dynamo) = dynamo.Tables.bakes.name
+  private def table(implicit dynamo: Dynamo) = dynamo.Tables.bakes.table
 
 }

--- a/app/data/BaseImages.scala
+++ b/app/data/BaseImages.scala
@@ -1,6 +1,5 @@
 package data
 
-import com.gu.scanamo._
 import com.gu.scanamo.syntax._
 import models._
 import org.joda.time.DateTime

--- a/app/data/DynamoFormats.scala
+++ b/app/data/DynamoFormats.scala
@@ -1,11 +1,11 @@
 package data
 
-import cats.data.Validated
 import com.gu.scanamo.DynamoFormat
 import org.joda.time.DateTime
 
 object DynamoFormats {
 
-  implicit val dateTimeFormat = DynamoFormat.xmap(DynamoFormat.stringFormat)(d => Validated.valid(new DateTime(d)))(_.toString)
+  implicit val dateTimeFormat =
+    DynamoFormat.coercedXmap[DateTime, String, IllegalArgumentException](DateTime.parse)(_.toString)
 
 }

--- a/app/data/DynamoFormats.scala
+++ b/app/data/DynamoFormats.scala
@@ -1,11 +1,39 @@
 package data
 
+import cats.data.Xor
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import com.gu.scanamo.DynamoFormat
+import com.gu.scanamo.error.DynamoReadError
 import org.joda.time.DateTime
 
 object DynamoFormats {
 
   implicit val dateTimeFormat =
     DynamoFormat.coercedXmap[DateTime, String, IllegalArgumentException](DateTime.parse)(_.toString)
+
+  /*
+  Special format to handle the two different ways that Scanamo can encode `None`:
+   - Legacy (pre-0.3): write it as an explicit `NULL` property
+   - Modern: skip the property completely (and presumably delete it if it is present)
+   */
+  implicit def legacyOptionFormat[T](implicit f: DynamoFormat[T]): DynamoFormat[Option[T]] = new DynamoFormat[Option[T]] {
+
+    def read(av: AttributeValue): Xor[DynamoReadError, Option[T]] = {
+      Option(av) match {
+        case Some(property) =>
+          if (Option(property.isNULL).exists(_.booleanValue))
+            Xor.right(None) // legacy encoding of None
+          else
+            f.read(property).map(t => Some(t))
+        case None =>
+          Xor.right(None) // modern encoding of None
+      }
+    }
+
+    def write(t: Option[T]): AttributeValue = t.map(f.write).orNull
+
+    override val default = Some(None)
+
+  }
 
 }

--- a/app/data/Recipes.scala
+++ b/app/data/Recipes.scala
@@ -49,6 +49,7 @@ object Recipes {
       bakeSchedule = bakeSchedule
     )
     // TODO This is a bit horrible. We have to get the record from Dynamo just to copy the next build number over. Really we want to do a partial update.
+    // This is currently blocked on guardian/scanamo#62.
     val ops = for {
       recipe <- table.get('id -> recipe.id)
       nextBuildNumber = recipe.flatMap(_.toOption).map(_.nextBuildNumber).getOrElse(0)

--- a/app/models/AmiId.scala
+++ b/app/models/AmiId.scala
@@ -1,13 +1,13 @@
 package models
 
-import cats.data.Validated.Valid
+import cats.data.Xor
 import com.gu.scanamo.DynamoFormat
 
-case class AmiId(value: String) extends StringId(value)
+case class AmiId(value: String) extends AnyVal with StringId
 
 object AmiId {
 
   implicit val dynamoFormat: DynamoFormat[AmiId] =
-    DynamoFormat.xmap(DynamoFormat.stringFormat)(value => Valid(AmiId(value)))(_.value)
+    DynamoFormat.xmap[AmiId, String](value => Xor.right(AmiId(value)))(_.value)
 
 }

--- a/app/models/BaseImageId.scala
+++ b/app/models/BaseImageId.scala
@@ -1,16 +1,16 @@
 package models
 
-import cats.data.Validated.Valid
+import cats.data.Xor
 import com.gu.scanamo.DynamoFormat
 import play.api.mvc.PathBindable
 
-case class BaseImageId(value: String) extends StringId(value)
+case class BaseImageId(value: String) extends AnyVal with StringId
 
 object BaseImageId {
 
   implicit val pathBindable: PathBindable[BaseImageId] = implicitly[PathBindable[String]].transform(BaseImageId(_), _.value)
 
   implicit val dynamoFormat: DynamoFormat[BaseImageId] =
-    DynamoFormat.xmap(DynamoFormat.stringFormat)(value => Valid(BaseImageId(value)))(_.value)
+    DynamoFormat.xmap[BaseImageId, String](value => Xor.right(BaseImageId(value)))(_.value)
 
 }

--- a/app/models/RecipeId.scala
+++ b/app/models/RecipeId.scala
@@ -1,17 +1,17 @@
 package models
 
-import cats.data.Validated.Valid
+import cats.data.Xor
 import com.gu.scanamo.DynamoFormat
 import play.api.mvc.PathBindable
 
-case class RecipeId(value: String) extends StringId(value)
+case class RecipeId(value: String) extends AnyVal with StringId
 
 object RecipeId {
 
   implicit val pathBindable: PathBindable[RecipeId] = implicitly[PathBindable[String]].transform(RecipeId(_), _.value)
 
   implicit val dynamoFormat: DynamoFormat[RecipeId] =
-    DynamoFormat.xmap(DynamoFormat.stringFormat)(value => Valid(RecipeId(value)))(_.value)
+    DynamoFormat.xmap[RecipeId, String](value => Xor.right(RecipeId(value)))(_.value)
 
 }
 

--- a/app/models/RoleId.scala
+++ b/app/models/RoleId.scala
@@ -1,13 +1,13 @@
 package models
 
-import cats.data.Validated.Valid
+import cats.data.Xor
 import com.gu.scanamo.DynamoFormat
 
-case class RoleId(value: String) extends StringId(value)
+case class RoleId(value: String) extends AnyVal with StringId
 
 object RoleId {
 
   implicit val dynamoFormat: DynamoFormat[RoleId] =
-    DynamoFormat.xmap(DynamoFormat.stringFormat)(value => Valid(RoleId(value)))(_.value)
+    DynamoFormat.xmap[RoleId, String](value => Xor.right(RoleId(value)))(_.value)
 
 }

--- a/app/models/StringId.scala
+++ b/app/models/StringId.scala
@@ -1,5 +1,12 @@
 package models
 
-abstract class StringId(value: String) {
+/*
+ * See http://docs.scala-lang.org/overviews/core/value-classes.html
+ * for an explanation of why this trait needs to extend Any.
+ *
+ * Note that calling toString will result in object allocation.
+ */
+trait StringId extends Any {
+  def value: String
   override def toString = value
 }

--- a/app/views/editRecipe.scala.html
+++ b/app/views/editRecipe.scala.html
@@ -17,7 +17,7 @@
     @b3.select( form("baseImageId"), availableBaseImages.map(_.id.value).zip(availableBaseImages.map(_.id.value)), '_label -> "Base image" )
 
     <div class="form-group">
-      <label class="control-label col-md-2" for="builtin-roles">Builtin roles</label>
+      <label class="control-label col-md-2" for="builtin-roles">Roles</label>
       <div class="col-md-10" id="builtin-roles">
         @for(role <- availableRoles) {
           <div class="checkbox">

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "amigo"
 version := "1.0-SNAPSHOT"
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact)
 
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
-  "com.gu" %% "scanamo" % "0.1.0",
+  "com.gu" %% "scanamo" % "0.7.0",
   "com.github.cb372" %% "automagic" % "0.1",
   "com.beachape" %% "enumeratum" % "1.3.7",
   "com.typesafe.akka" %% "akka-typed-experimental" % "2.4.2",
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "play-googleauth" % "0.4.0",
   "com.adrianhurt" %% "play-bootstrap3" % "0.4.5-P24",
   "org.quartz-scheduler" % "quartz" % "2.2.3",
-  "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+  "org.scalatest" %% "scalatest" % "2.2.6" % Test
 )
 routesGenerator := InjectedRoutesGenerator
 routesImport += "models._"


### PR DESCRIPTION
* Upgrade Scanamo
* Switch to Scanamo's table API
* Refactor the Dynamo object accordingly
* Add a custom `DynamoFormat[Option[T]]` to work around a change in Scanamo behaviour
* Bump Scala version

At this point I'm not using Scanamo's Free monad goodness as nature intended, but I will experiment with that soon as part of the preparation for my Lambda World talk.

There are still a couple of places where we use the raw Dynamo API instead of Scanamo. These are blocked on Scanamo issues (guardian/scanamo#61, guardian/scanamo#62).

I've tested all the major functionality locally and everything seems to work.