### PR TITLE
Upgrade configuration-magic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies ++= Seq(
   "com.github.cb372" %% "automagic" % "0.1",
   "com.beachape" %% "enumeratum" % "1.3.7",
   "com.typesafe.akka" %% "akka-typed-experimental" % "2.4.2",
-  "com.gu" %% "configuration-magic-play2-4" % "1.2.0",
+  "com.gu" %% "configuration-magic-play2-4" % "1.3.0",
   "com.gu" %% "play-googleauth" % "0.4.0",
   "com.adrianhurt" %% "play-bootstrap3" % "0.4.5-P24",
   "org.quartz-scheduler" % "quartz" % "2.2.3",


### PR DESCRIPTION
This fixes an AWS SDK version conflict caused by the Scanamo upgrade. Configuration-magic doesn't make any calls to the EC2 API when you're running on your local machine, so the problem only manifested itself in production. My favourite kind of bug.