### PR TITLE
Include nginx.template for use at kong start time.

### DIFF
--- a/roles/kong/defaults/main.yml
+++ b/roles/kong/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-kong_version: 0.9.1
+kong_version: 0.9.2
 kong_user: content-api

--- a/roles/kong/files/nginx.template
+++ b/roles/kong/files/nginx.template
@@ -1,0 +1,19 @@
+worker_processes auto;
+daemon on;
+
+pid pids/nginx.pid;
+error_log logs/error.log notice;
+
+worker_rlimit_nofile 16384;
+
+events {
+  worker_connections 16384;
+  multi_accept on;
+}
+
+http {
+  proxy_buffer_size 128k;
+  proxy_buffers 4 256k;
+  proxy_busy_buffers_size 256k;
+  include 'nginx-kong.conf';
+}

--- a/roles/kong/tasks/main.yml
+++ b/roles/kong/tasks/main.yml
@@ -33,5 +33,8 @@
 - name: Copy Kong configure.sh script
   copy: src=configure.sh dest=/usr/local/kong/gu-configure.sh mode=u+x
 
+- name: Copy nginx.template file
+  copy: src=nginx.template dest=/usr/local/kong/nginx.template
+
 - name: Make 'kong user' own Kong
   file: path=/usr/local/kong owner={{kong_user}} recurse=yes state=directory


### PR DESCRIPTION
  proxy_buffer_size 128k;
  proxy_buffers 4 256k;
  proxy_busy_buffers_size 256k;

Are necessary to prevent nginx throwing errors. These were default arguments in previous versions of Kong, but weirdly are not in kong 0.9.1 as they have not been benchmarked.