### PR TITLE
Add a housekeeping script for Kong

### DIFF
--- a/roles/kong/defaults/main.yml
+++ b/roles/kong/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 kong_version: 0.9.2
 kong_user: content-api
+postgres_version: 9.5

--- a/roles/kong/files/truncate-ratelimiting_metrics.sh
+++ b/roles/kong/files/truncate-ratelimiting_metrics.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+#
+# Removes old entries from Kong's ratelimiting_metrics table
+# to prevent the table from growing indefinitely.
+#
+# Looks up the DB host and password from /etc/kong.conf.
+#
+# This script must be run as a user that can read /etc/kong.conf
+# i.e. the kong user or root.
+
+host=$(grep -o -P '(?<=pg_host = )(.*?)(?= )' /etc/kong.conf)
+password=$(grep -o -P '(?<=pg_password = )(.*?)(?= )' /etc/kong.conf)
+
+PGPASSWORD=$password psql -U kong -h $host -c "delete from ratelimiting_metrics where period_date < now() - '24 hours'::interval"

--- a/roles/kong/tasks/main.yml
+++ b/roles/kong/tasks/main.yml
@@ -7,6 +7,7 @@
     - libpcre3
     - dnsmasq
     - procps
+    - postgresql-client-{{postgres_version}}
 
 - name: Create user for Kong
   user: name={{kong_user}} system=yes
@@ -45,5 +46,12 @@
 - name: Prepend shims directory to sudoers PATH
   lineinfile: dest=/etc/sudoers regexp='^Defaults(.*)secure_path="(.*)"' line='Defaults\1secure_path="/usr/local/kong/shims:\2"' backrefs=yes
 
+- name: Copy truncate-ratelimiting_metrics.sh
+  copy: src=truncate-ratelimiting_metrics.sh dest=/usr/local/kong/truncate-ratelimiting_metrics.sh mode=u+x
+
 - name: Make 'kong user' own Kong
   file: path=/usr/local/kong owner={{kong_user}} recurse=yes state=directory
+
+- name: Install truncation script crontab
+  cron: name="truncate ratelimiting_metrics table" minute=0 hour=0
+        user={{kong_user}} job="/usr/local/kong/truncate-ratelimiting_metrics.sh"


### PR DESCRIPTION
This script runs as a nightly cron job and deletes old entries from one of Kong's DB tables. Without it, the table will grow indefinitely until the DB machine fills its disk.

Also install the `psql` command on the Kong machine.

This has been tested in CODE.