### PR TITLE
Amigo - modify kong truncate-ratelimiting_metrics script.

### DIFF
--- a/roles/kong/files/truncate-ratelimiting_metrics.sh
+++ b/roles/kong/files/truncate-ratelimiting_metrics.sh
@@ -2,6 +2,8 @@
 #
 # Removes old entries from Kong's ratelimiting_metrics table
 # to prevent the table from growing indefinitely.
+# Intended to run periodically throughout the day as opposed to once. This avoids deleting a really large number
+# of rows from Postgres all at once and causing issues with Postgres.
 #
 # Looks up the DB host and password from /etc/kong.conf.
 #
@@ -12,3 +14,5 @@ host=$(grep -o -P '(?<=pg_host = )(.*?)(?= )' /etc/kong.conf)
 password=$(grep -o -P '(?<=pg_password = )(.*?)(?= )' /etc/kong.conf)
 
 PGPASSWORD=$password psql -U kong -h $host -c "delete from ratelimiting_metrics where period_date < now() - '24 hours'::interval"
+
+

--- a/roles/kong/tasks/main.yml
+++ b/roles/kong/tasks/main.yml
@@ -53,5 +53,5 @@
   file: path=/usr/local/kong owner={{kong_user}} recurse=yes state=directory
 
 - name: Install truncation script crontab
-  cron: name="truncate ratelimiting_metrics table" minute=0 hour=0
+  cron: name="truncate ratelimiting_metrics table" minute=0 hour=*/2
         user={{kong_user}} job="/usr/local/kong/truncate-ratelimiting_metrics.sh"


### PR DESCRIPTION
 - Run truncate script every two hours rather than every 24 hours to reduce impact on Postgres.
 - Rewrite query to make it clearer how to limit a delete query.

see: http://docs.ansible.com/ansible/cron_module.html for ansible cron docs.