### PR TITLE
New role that disables missed daily tasks at boot time

### DIFF
--- a/roles/disable-missed-daily-tasks/files/apt-daily.timer.conf
+++ b/roles/disable-missed-daily-tasks/files/apt-daily.timer.conf
@@ -1,0 +1,2 @@
+[Timer]
+Persistent=false

--- a/roles/disable-missed-daily-tasks/tasks/main.yml
+++ b/roles/disable-missed-daily-tasks/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Create directories
+  file: path=/etc/systemd/system/apt-daily.timer.d state=directory owner=root group=root
+
+- name: Install file that skips running missed daily tasks on startup
+  copy: src=apt-daily.timer.conf dest=/etc/systemd/system/apt-daily.timer.d/apt-daily.timer.conf owner=root group=root


### PR DESCRIPTION
With Xenial there is a task that does apt related tasks at boot time. This can mean that attempts to install packages at boot time can fail resulting in instances not coming up. See this for some more details: http://stackoverflow.com/questions/36896806/how-can-i-be-sure-a-freshly-started-vm-is-ready-for-provisioning

This PR adds a new role that disables this boot time behaviour so that provisioning of instances never fails (because of this at least).

The intention is to add this to the base Xenial image to avoid surprising people.