### PR TITLE
adding logging bug patch

### DIFF
--- a/roles/pluto/tasks/main.yml
+++ b/roles/pluto/tasks/main.yml
@@ -46,6 +46,14 @@
 - name: Install redis library
   command: /opt/cantemo/python/bin/pip install 'redis==2.10.5'
 
+- name: Download django patch to fix incoherent error bug
+  command: "aws s3 cp s3://{{artifact_bucket}/portal/sites.py.patch /tmp"
+
+- name: Apply django patch to fix incoherent error bug
+  command: /usr/bin/patch sites.py < /tmp/sites.py.patch
+  args:
+    chdir: /opt/cantemo/python/lib/python2.6/site-packages/django/contrib/admin
+
 - name: Get Pluto RPM
   command: "aws s3 cp s3://{{artifact_bucket}}/pluto/pluto-3.0-201609081627.rpm /tmp"
 


### PR DESCRIPTION
@kenoir 
Portal has an annoying bug, whereby if a plugin fails to start up properly because of an exception the actual error is not shown in the log, but a generic one about "model User does not exist."

This introduces a patch which prevents the secondary exception and thereby allows the actual problem to be logged.  I use it for all testing and it is in place on the FourthPortalDev image that we use.