### PR TITLE
Remove AWS creds used to pull Pluto artifacts

### DIFF
--- a/roles/pluto/tasks/main.yml
+++ b/roles/pluto/tasks/main.yml
@@ -1,10 +1,4 @@
 ---
-- name: Ensure AWS creds folder exists
-  file: path=/root/.aws state=directory mode=0755
-
-- name: Create AWS credentials file
-  template: src=credentials.template dest=/root/.aws/credentials
-
 - name: Get Portal Tar
   command: "aws s3 cp s3://{{artifact_bucket}}/portal/RedHat_Portal_2.0.8-devel.tar /tmp"
 

--- a/roles/pluto/templates/credentials.template
+++ b/roles/pluto/templates/credentials.template
@@ -1,3 +1,0 @@
-[default]
-aws_access_key_id={{aws_access_key}}
-aws_secret_access_key={{aws_secret_key}}


### PR DESCRIPTION
Depends: https://github.com/guardian/editorial-tools-platform/pull/40