### PR TITLE
Move install of rsyslog and sysfsutils to mongo30

### DIFF
--- a/roles/install-rsyslog-config/meta/main.yml
+++ b/roles/install-rsyslog-config/meta/main.yml
@@ -1,4 +1,0 @@
----
-dependencies:
-  - install-sysfsutils
-  - mongo30

--- a/roles/install-rsyslog-config/tasks/main.yml
+++ b/roles/install-rsyslog-config/tasks/main.yml
@@ -1,9 +1,0 @@
----
-- name: install rsyslog config
-  shell: |
-      cat > /etc/rsyslog.d/31-mongo-scripts.conf <<EOF
-      local1.*    /var/log/mongodb/scripts.log
-      EOF
-
-- name: restart rsyslog
-  service: name=rsyslog state=restarted

--- a/roles/install-sysfsutils/tasks/main.yml
+++ b/roles/install-sysfsutils/tasks/main.yml
@@ -1,3 +1,0 @@
----
-- name: install sysfsutils
-  apt: name=sysfsutils state=present

--- a/roles/mongo30/tasks/main.yml
+++ b/roles/mongo30/tasks/main.yml
@@ -14,3 +14,15 @@
     name: mongodb-org
     allow_unauthenticated: yes
 
+- name: install sysfsutils
+  apt: name=sysfsutils state=present
+
+- name: install rsyslog config
+  shell: |
+      cat > /etc/rsyslog.d/31-mongo-scripts.conf <<EOF
+      local1.*    /var/log/mongodb/scripts.log
+      EOF
+
+- name: restart rsyslog
+  service: name=rsyslog state=restarted
+


### PR DESCRIPTION
As discussed I've moved rsyslog and sysfsutils to mongo30.

@Reettaphant @philmcmahon I can merge this into @Reettaphant branch if you're happy with this.
