### PR TITLE
Cloudwatch logs role

### DIFF
--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -42,7 +42,7 @@ class AppComponents(context: Context)
     val awsCreds = new AWSCredentialsProviderChain(
       new ProfileCredentialsProvider("deployTools"),
       new ProfileCredentialsProvider(),
-      new InstanceProfileCredentialsProvider
+      InstanceProfileCredentialsProvider.getInstance()
     )
     val region = configuration.getString("aws.region").map(Regions.fromName).getOrElse(Regions.EU_WEST_1)
     val dynamoClient: AmazonDynamoDBClient = new AmazonDynamoDBClient(awsCreds).withRegion(region)

--- a/roles/cloud-watch-logs/README.md
+++ b/roles/cloud-watch-logs/README.md
@@ -1,0 +1,47 @@
+This role will install the [cloudwatch](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html) agent.
+
+It also provide a utility script to configure your logs in `/opt/cloudwatch-logs/configure-logs`
+The arguments are:
+ - an id, to distinguish between log file (for instance `application` and `gc`)
+ - the stack
+ - the stage
+ - the app
+ - the full path to the log
+
+
+Here's an example user data that makes use of it:
+
+```yaml
+UserData:
+"Fn::Base64":
+  !Sub
+    - |
+      #!/bin/bash -ev
+      aws --region ${AWS::Region} s3 cp s3://mobile-dist/${Stack}/${Stage}/${App}/${App}_1.0-latest_all.deb /tmp
+      dpkg -i /tmp/${App}_1.0-latest_all.deb
+      /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/${App}/application.log
+    - App: !FindInMap [ Constants, App, Value ]
+      Stack: !FindInMap [ Constants, Stack, Value ]
+```
+
+You will need to give the following policies to your instance:
+
+```json
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Effect": "Allow",
+    "Action": [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams"
+    ],
+    "Resource": [
+      "arn:aws:logs:*:*:*"
+    ]
+  }
+ ]
+}```
+

--- a/roles/cloud-watch-logs/files/aws-region
+++ b/roles/cloud-watch-logs/files/aws-region
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'

--- a/roles/cloud-watch-logs/files/awslogs.conf
+++ b/roles/cloud-watch-logs/files/awslogs.conf
@@ -1,0 +1,2 @@
+[general]
+state_file = /var/awslogs/state/agent-state

--- a/roles/cloud-watch-logs/files/configure-logs
+++ b/roles/cloud-watch-logs/files/configure-logs
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+id=$1
+stack=$2
+stage=$3
+app=$4
+file=$5
+
+cat > /var/awslogs/etc/config/$app-$id.conf <<__END__
+[$app-$id]
+datetime_format = %Y-%m-%d %H:%M:%S
+file = $file
+initial_position = start_of_file
+log_group_name = $stack-$app-$stage
+log_stream_name = $stack-$app-$stage-{instance_id}
+__END__
+
+systemctl restart awslogs

--- a/roles/cloud-watch-logs/meta/main.yml
+++ b/roles/cloud-watch-logs/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - aws-tools

--- a/roles/cloud-watch-logs/tasks/main.yml
+++ b/roles/cloud-watch-logs/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- name: Create opt directory
+  file: path=/opt/cloudwatch-logs/ state=directory mode=0755
+
+- name: Download script
+  get_url: url="https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py" dest=/opt/cloudwatch-logs/ mode=0754
+
+- name: copy ec2 configuration script
+  copy:
+    src: configure-logs
+    dest: /opt/cloudwatch-logs/
+    mode: 0754
+
+- name: copy ec2 region script
+  copy:
+    src: aws-region
+    dest: /opt/cloudwatch-logs/
+    mode: 0754
+
+- name: Autodetect aws region
+  command: /opt/cloudwatch-logs/aws-region
+  register: ec2_region
+
+- name: copy cloudwatch log configuration file
+  copy:
+    src: awslogs.conf
+    dest: /tmp/
+    mode: 0444
+
+- name: Start and configure log agent
+  command: python /opt/cloudwatch-logs/awslogs-agent-setup.py -n -r {{ec2_region.stdout}} -c /tmp/awslogs.conf
+
+- name: Enable the log agent at restart
+  command: systemctl enable awslogs


### PR DESCRIPTION
This allow us to bake images with the cloudwatch-log agent.

It also provide a utility script to reduce the boiler plate in the user-data within the cloudformation.
It assumes the distribution is using systemd

The readme should explain it all, so if it isn't clear please let me know I'll do my best to improve it.