### PR TITLE
Allow forward slash in parameter values.

### DIFF
--- a/app/models/CustomisedRole.scala
+++ b/app/models/CustomisedRole.scala
@@ -47,7 +47,7 @@ object CustomisedRole {
   import White._
 
   val key: Parser[String] = P(CharsWhile(_ != ':').!)
-  val singleValue: Parser[SingleParamValue] = P(CharPred(c => c.isLetterOrDigit || c == '-' || c == '_').rep.!).map(SingleParamValue(_))
+  val singleValue: Parser[SingleParamValue] = P(CharPred(c => c.isLetterOrDigit || c == '-' || c == '_' || c == '/').rep.!).map(SingleParamValue(_))
   val multiValues: Parser[ListParamValue] = P("[" ~ singleValue.rep(sep = ",") ~ "]").map(
     params => ListParamValue(params.toList))
   val paramValue: Parser[ParamValue] = multiValues | singleValue


### PR DESCRIPTION
Updated as part of work to write a role to allow installation of elasticsearch plugins. It needs to be possible to have `/` in a parameter value. E.g. `plugins:elasticsearch/elasticsearch-cloud-aws/2.7.0`