### PR TITLE
Allow parameter values to have a dot.

### DIFF
--- a/app/models/CustomisedRole.scala
+++ b/app/models/CustomisedRole.scala
@@ -47,7 +47,7 @@ object CustomisedRole {
   import White._
 
   val key: Parser[String] = P(CharsWhile(_ != ':').!)
-  val singleValue: Parser[SingleParamValue] = P(CharPred(c => c.isLetterOrDigit || c == '-' || c == '_' || c == '/').rep.!).map(SingleParamValue(_))
+  val singleValue: Parser[SingleParamValue] = P(CharPred(c => c.isLetterOrDigit || c == '-' || c == '_' || c == '/' || c == '.').rep.!).map(SingleParamValue(_))
   val multiValues: Parser[ListParamValue] = P("[" ~ singleValue.rep(sep = ",") ~ "]").map(
     params => ListParamValue(params.toList))
   val paramValue: Parser[ParamValue] = multiValues | singleValue


### PR DESCRIPTION
Follow up from this [PR](https://github.com/guardian/amigo/pull/108). Elasticsearch plugins can have `.` in them so it needs to be possible to specify parameter values with a `.` in order to write an elasticsearch install plugins role.