### PR TITLE
Fix: Reference to uninitialized values + add compiler options

### DIFF
--- a/app/controllers/BaseImageController.scala
+++ b/app/controllers/BaseImageController.scala
@@ -72,6 +72,13 @@ object BaseImageController {
 
   object Forms {
 
+    val amiId = nonEmptyText(maxLength = 16).transform[AmiId](AmiId.apply, _.value)
+
+    val linuxDist: Mapping[LinuxDist] =
+      nonEmptyText(maxLength = 16)
+        .verifying(s"Must be one of ${LinuxDist.all.keys}", LinuxDist.create(_).nonEmpty)
+        .transform(LinuxDist.create(_).get, _.name)
+
     val editBaseImage = Form(tuple(
       "description" -> text(maxLength = 10000),
       "amiId" -> amiId,
@@ -84,13 +91,6 @@ object BaseImageController {
       "amiId" -> amiId,
       "linuxDist" -> linuxDist
     ))
-
-    val amiId = nonEmptyText(maxLength = 16).transform[AmiId](AmiId.apply, _.value)
-
-    val linuxDist: Mapping[LinuxDist] =
-      nonEmptyText(maxLength = 16)
-        .verifying(s"Must be one of ${LinuxDist.all.keys}", LinuxDist.create(_).nonEmpty)
-        .transform(LinuxDist.create(_).get, _.name)
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ scalaVersion := "2.11.8"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact)
 
+scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Xfatal-warnings")
+
 def getTravisBranch(): String = {
   sys.env.get("TRAVIS_PULL_REQUEST") match {
     case Some("false") => sys.env.getOrElse("TRAVIS_BRANCH", "unknown-branch")


### PR DESCRIPTION
Fixing the 'Reference to uninitialized values' error occurring when trying to create/edit a base image: https://amigo.gutools.co.uk/base-images/new
```
[warn] /.../amigo/app/controllers/BaseImageController.scala:77: Reference to uninitialized value amiId
[warn]       "amiId" -> amiId,
...
[warn] /.../amigo/app/controllers/BaseImageController.scala:83: Reference to uninitialized value amiId
[warn]       "linuxDist" -> linuxDist
...
```

Also adding compiler options like `-Xfatal-warnings` to prevent this kind of issue to happen again