### PR TITLE
Bake: Add link to go back to recipe + reorganize bake info

### DIFF
--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -1,19 +1,29 @@
 @(bake: Bake, bakeLogs: Iterable[BakeLog])
 @layout("AMIgo"){
 
-  <h1>@bake.bakeId</h1>
+  <h1><a href="@routes.RecipeController.showRecipe(bake.recipe.id)">@bake.recipe.id</a></h1>
 
   <div class="panel panel-default">
-    <div class="panel-heading">Status</div>
-    <div class="panel-body"><span id="status">@bake.status</span></div>
-  </div>
-
-  <div class="panel panel-default">
-    <div class="panel-heading">AMI</div>
-    <div class="panel-body panel-body--flex"><span id="ami-id">@bake.amiId.getOrElse("(none)")</span>
-      <button class="btn btn-primary" title="Copy to clipboard" id="copy-button" data-clipboard-target="#ami-id">
-        <img src="@routes.Assets.versioned("images/clippy.svg")" width="13" alt="Copy to clipboard">
-      </button></div>
+    <div class="panel-heading">Info</div>
+    <ul class="list-group">
+      <li class="list-group-item bake--info">
+        <span class="bake--info--title">Number: </span>
+        <span><b>#@bake.buildNumber</b></span>
+      </li>
+      <li class="list-group-item bake--info">
+        <span class="bake--info--title">Status: </span>
+        <span><b>@bake.status</b></span>
+      </li>
+      <li class="list-group-item bake--info">
+        <span class="bake--info--title">AMI: </span>
+        <span id="ami-id"><b>@bake.amiId.getOrElse("(none)")</b></span>
+        <span class="bake--info--right">
+          <button class="btn btn-primary" title="Copy to clipboard" id="copy-button" data-clipboard-target="#ami-id">
+            <img src="@routes.Assets.versioned("images/clippy.svg")" width="13" alt="Copy to clipboard">
+          </button>
+        </span>
+      </li>
+    </ul>
   </div>
 
   <div>

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -23,14 +23,27 @@ body { padding-top: 70px; }
     display: inline-block;
 }
 
-.panel-body--flex {
+.bake--info {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
+    justify-content: flex-start;
+    align-items: left;
 }
 
-.panel-body--flex:after, .panel-body--flex:before {
+.bake--info--title {
+    width: 5em;
+}
+
+.bake--info:after, .bake--info:before {
     display: none;
+}
+
+.bake--info span {
+    margin-top: auto;
+    margin-bottom: auto;
+}
+
+.bake--info--right {
+    margin-left: auto;
 }
 
 .block-link {


### PR DESCRIPTION
Fixing a small navigation annoyance. Once on a bake page it is not possible to directly come back to the recipe. [Example](https://amigo.gutools.co.uk/recipes/ubuntu-xenial-java8/bakes/196)

This patch is adding a link to the recipe as well as reorganising the bake info

Before:
![screen shot 2017-03-20 at 16 42 49](https://cloud.githubusercontent.com/assets/233326/24111155/718f7df8-0d8d-11e7-9c63-39fa8cdc1a0b.png)

After:
![screen shot 2017-03-20 at 16 42 22](https://cloud.githubusercontent.com/assets/233326/24111161/79584c86-0d8d-11e7-85ae-66edd0cb234d.png)

 