### PR TITLE
Add transitive role dependencies

### DIFF
--- a/app/controllers/RoleController.scala
+++ b/app/controllers/RoleController.scala
@@ -4,10 +4,10 @@ import com.gu.googleauth.GoogleAuthConfig
 import data._
 import play.api.mvc._
 
-class RoleController(val authConfig: GoogleAuthConfig) extends Controller with AuthActions {
+class RoleController(val authConfig: GoogleAuthConfig)(implicit dynamo: Dynamo) extends Controller with AuthActions {
 
   def listRoles = AuthAction {
-    Ok(views.html.roles(Roles.list))
+    Ok(views.html.roles(Roles.list, Recipes.list()))
   }
 
 }

--- a/app/data/Roles.scala
+++ b/app/data/Roles.scala
@@ -3,7 +3,7 @@ package data
 import java.nio.file.{ Files, Paths }
 
 import ansible.RoleParser
-import models.{ Dependency, RoleId, RoleSummary }
+import models._
 
 import scala.collection.JavaConverters._
 
@@ -34,5 +34,9 @@ object Roles {
 
   def usedBy(allRoles: Seq[RoleSummary], roleToAnalyse: RoleSummary): Seq[RoleId] = {
     allRoles.filter(_.dependsOn.contains(roleToAnalyse.roleId)).distinct.map((r: RoleSummary) => r.roleId).sortBy(_.value)
+  }
+
+  def usedByRecipes(allRecipes: Seq[Recipe], roleToAnalyse: RoleSummary): Seq[RecipeId] = {
+    allRecipes.filter(_.roles.map(_.roleId).contains(roleToAnalyse.roleId)).map(_.id)
   }
 }

--- a/app/data/Roles.scala
+++ b/app/data/Roles.scala
@@ -5,6 +5,7 @@ import java.nio.file.{ Files, Paths }
 import ansible.RoleParser
 import models.{ RoleId, RoleSummary }
 
+import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 
 object Roles {
@@ -19,4 +20,18 @@ object Roles {
 
   def findById(id: RoleId) = list.find(_ == id)
 
+  def transitiveDependencies(roles: Seq[RoleSummary], role: RoleSummary): Set[RoleId] = {
+    @tailrec
+    def go(rs: Seq[RoleSummary], dep: Seq[RoleId], acc: Seq[RoleId]): Set[RoleId] = {
+      dep match {
+        case h :: t =>
+          val currDependencies: List[RoleId] = roles.find(r => r.roleId == h).get.dependsOn.toList
+          val totalDependencies = (t ++ currDependencies).distinct
+          go(rs, totalDependencies, h +: acc)
+        case _ =>
+          acc.toSet
+      }
+    }
+    go(roles, role.dependsOn.toList, role.dependsOn.toList)
+  }
 }

--- a/app/models/Dependency.scala
+++ b/app/models/Dependency.scala
@@ -1,0 +1,3 @@
+package models
+
+case class Dependency(roleId: RoleId, dependencies: Set[Dependency])

--- a/app/views/fragments/dependencyList.scala.html
+++ b/app/views/fragments/dependencyList.scala.html
@@ -1,0 +1,11 @@
+@import models.Dependency
+@(dependencies: Set[Dependency])
+
+<ul>
+  @for(dep <- dependencies) {
+    <li>
+        <a href="#@dep.roleId">@dep.roleId</a>
+        @views.html.fragments.dependencyList(dep.dependencies)
+    </li>
+}
+</ul>

--- a/app/views/roles.scala.html
+++ b/app/views/roles.scala.html
@@ -38,6 +38,9 @@
               <li role="presentation" class="tab-label">
                 <a aria-controls="dependencies" role="tab" data-toggle="tab" data-target="#dependencies-@role.roleId">Dependencies</a>
               </li>
+              <li role="presentation" class="tab-label">
+                <a aria-controls="usedby" role="tab" data-toggle="tab" data-target="#usedby-@role.roleId">Used by</a>
+              </li>
             </ul>
 
             <div class="tab-content">
@@ -62,22 +65,29 @@
 
                     @views.html.fragments.dependencyList(Roles.transitiveDependencies(roles.toSeq, role).dependencies)
                 }</p>
-                 <p>
-                  @defining(Roles.usedBy(roles.toSeq, role)) { usedBy =>
-                    @if(usedBy.isEmpty) {
-                          This role is not used by any other role
-                      } else {
-                          This role is used by the following roles:
-                          <ul>
-                              @usedBy.map { role =>
-                                  <li><a href="#@role">@role</a></li>
-                              }
-                          </ul>
-                          }
-                  }
-                  </p>
-                  <p>
-                  @defining(Roles.usedByRecipes(recipes.toSeq, role)) { usedBy =>
+              </div>
+
+            <div role="tabpanel" class="tab-pane" id="usedby-@role.roleId">
+                <h2>Used by</h2>
+                <div class="role-usage">
+                    <h4>Roles</h4>
+
+                    @defining(Roles.usedBy(roles.toSeq, role)) { usedBy =>
+                        @if(usedBy.isEmpty) {
+                              This role is not used by any other role
+                        } else {
+                            This role is used by the following roles:
+                            <ul>
+                            @usedBy.map { role =>
+                                <li><a href="#@role">@role</a></li>
+                            }
+                            </ul>
+                        }
+                      }
+                </div>
+                <div class="role-usage">
+                    <h4>Recipes</h4>
+                    @defining(Roles.usedByRecipes(recipes.toSeq, role)) { usedBy =>
                       @if(usedBy.isEmpty) {
                           This role is not used by any recipe
                       } else {
@@ -88,8 +98,8 @@
                           }
                           </ul>
                       }
-                  }
-                  </p>
+                    }
+                </div>
               </div>
             </div>
 

--- a/app/views/roles.scala.html
+++ b/app/views/roles.scala.html
@@ -1,3 +1,4 @@
+@import data.Roles
 @(roles: Iterable[RoleSummary])
 @layout("AMIgo"){
 
@@ -56,9 +57,9 @@
                 @if(role.dependsOn.isEmpty) {
                   This role does not depend on any other roles.
                 } else {
-                  This role depends on:
+                  This role depends on (including transitive dependencies):
                   <ul>
-                    @for(roleId <- role.dependsOn.toList.sortBy(_.value)) {
+                    @for(roleId <- Roles.transitiveDependencies(roles.toSeq, role)) {
                       <li><a href="#@roleId">@roleId</a></li>
                     }
                   </ul>

--- a/app/views/roles.scala.html
+++ b/app/views/roles.scala.html
@@ -1,5 +1,6 @@
 @import data.Roles
-@(roles: Iterable[RoleSummary])
+@import data.Recipes
+@(roles: Iterable[RoleSummary], recipes: Iterable[Recipe])
 @layout("AMIgo"){
 
   <h1>Roles</h1>
@@ -66,13 +67,27 @@
                     @if(usedBy.isEmpty) {
                           This role is not used by any other role
                       } else {
-                          This role is used by:
+                          This role is used by the following roles:
                           <ul>
                               @usedBy.map { role =>
                                   <li><a href="#@role">@role</a></li>
                               }
                           </ul>
                           }
+                  }
+                  </p>
+                  <p>
+                  @defining(Roles.usedByRecipes(recipes.toSeq, role)) { usedBy =>
+                      @if(usedBy.isEmpty) {
+                          This role is not used by any recipe
+                      } else {
+                          This role is used by the following recipes:
+                          <ul>
+                             @usedBy.map { recipe =>
+                            <li><a href="../recipes/@recipe">@recipe</a></li>
+                          }
+                          </ul>
+                      }
                   }
                   </p>
               </div>

--- a/app/views/roles.scala.html
+++ b/app/views/roles.scala.html
@@ -54,16 +54,27 @@
               <div role="tabpanel" class="tab-pane" id="dependencies-@role.roleId">
                 <h2>Dependencies</h2>
 
-                @if(role.dependsOn.isEmpty) {
+                <p>@if(role.dependsOn.isEmpty) {
                   This role does not depend on any other roles.
                 } else {
-                  This role depends on (including transitive dependencies):
-                  <ul>
-                    @for(roleId <- Roles.transitiveDependencies(roles.toSeq, role)) {
-                      <li><a href="#@roleId">@roleId</a></li>
-                    }
-                  </ul>
-                }
+                    This role depends on (including transitive dependencies):
+
+                    @views.html.fragments.dependencyList(Roles.transitiveDependencies(roles.toSeq, role).dependencies)
+                }</p>
+                 <p>
+                  @defining(Roles.usedBy(roles.toSeq, role)) { usedBy =>
+                    @if(usedBy.isEmpty) {
+                          This role is not used by any other role
+                      } else {
+                          This role is used by:
+                          <ul>
+                              @usedBy.map { role =>
+                                  <li><a href="#@role">@role</a></li>
+                              }
+                          </ul>
+                          }
+                  }
+                  </p>
               </div>
             </div>
 

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -81,3 +81,7 @@ body { padding-top: 70px; }
 td.recipe-usage {
     white-space: nowrap;
 }
+
+.role-usage {
+    margin-top: 34px;
+}

--- a/test/data/RolesTest.scala
+++ b/test/data/RolesTest.scala
@@ -1,0 +1,37 @@
+package data
+
+import models._
+import org.scalatest.{ Matchers, FlatSpec }
+
+class RolesTest extends FlatSpec with Matchers {
+
+  it should "find all transitive dependencies" in {
+    val r0 = RoleSummary(RoleId("id0"), Set(RoleId("id1"), RoleId("id2")), null, null)
+    val r1 = RoleSummary(RoleId("id1"), Set(RoleId("id2")), null, null)
+    val r2 = RoleSummary(RoleId("id2"), Set(RoleId("id3")), null, null)
+    val r3 = RoleSummary(RoleId("id3"), Set.empty, null, null)
+
+    val roles = List(r0, r1, r2, r3)
+    Roles.transitiveDependencies(roles, r0) should contain only (RoleId("id1"), RoleId("id2"), RoleId("id3"))
+  }
+
+  it should "return direct dependencies if there are no transitive" in {
+    val r0 = RoleSummary(RoleId("id0"), Set(RoleId("id1"), RoleId("id2")), null, null)
+    val r1 = RoleSummary(RoleId("id1"), Set(RoleId("id2")), null, null)
+    val r2 = RoleSummary(RoleId("id2"), Set.empty, null, null)
+    val r3 = RoleSummary(RoleId("id3"), Set(RoleId("id2")), null, null)
+
+    val roles = List(r0, r1, r2, r3)
+    Roles.transitiveDependencies(roles, r0) should contain only (RoleId("id1"), RoleId("id2"))
+  }
+
+  it should "return empty if there are no dependencies" in {
+    val r0 = RoleSummary(RoleId("id0"), Set(RoleId("id1"), RoleId("id2")), null, null)
+    val r1 = RoleSummary(RoleId("id1"), Set(RoleId("id2")), null, null)
+    val r2 = RoleSummary(RoleId("id2"), Set.empty, null, null)
+    val r3 = RoleSummary(RoleId("id3"), Set(RoleId("id2")), null, null)
+
+    val roles = List(r0, r1, r2, r3)
+    Roles.transitiveDependencies(roles, r2).isEmpty should be (true)
+  }
+}

--- a/test/data/RolesTest.scala
+++ b/test/data/RolesTest.scala
@@ -1,5 +1,6 @@
 package data
 
+import data.Roles.Dependency
 import models._
 import org.scalatest.{ Matchers, FlatSpec }
 
@@ -12,7 +13,7 @@ class RolesTest extends FlatSpec with Matchers {
     val r3 = RoleSummary(RoleId("id3"), Set.empty, null, null)
 
     val roles = List(r0, r1, r2, r3)
-    Roles.transitiveDependencies(roles, r0) should contain only (RoleId("id1"), RoleId("id2"), RoleId("id3"))
+    Roles.transitiveDependencies(roles, r0).dependencies should contain only (Dependency(RoleId("id1"), Set(Dependency(RoleId("id2"), Set(Dependency(RoleId("id3"), Set()))))), Dependency(RoleId("id2"), Set(Dependency(RoleId("id3"), Set()))))
   }
 
   it should "return direct dependencies if there are no transitive" in {
@@ -22,7 +23,7 @@ class RolesTest extends FlatSpec with Matchers {
     val r3 = RoleSummary(RoleId("id3"), Set(RoleId("id2")), null, null)
 
     val roles = List(r0, r1, r2, r3)
-    Roles.transitiveDependencies(roles, r0) should contain only (RoleId("id1"), RoleId("id2"))
+    Roles.transitiveDependencies(roles, r0).dependencies should contain only (Dependency(RoleId("id1"), Set(Dependency(RoleId("id2"), Set()))), Dependency(RoleId("id2"), Set()))
   }
 
   it should "return empty if there are no dependencies" in {
@@ -32,6 +33,6 @@ class RolesTest extends FlatSpec with Matchers {
     val r3 = RoleSummary(RoleId("id3"), Set(RoleId("id2")), null, null)
 
     val roles = List(r0, r1, r2, r3)
-    Roles.transitiveDependencies(roles, r2).isEmpty should be (true)
+    Roles.transitiveDependencies(roles, r2).dependencies.isEmpty should be(true)
   }
 }

--- a/test/data/RolesTest.scala
+++ b/test/data/RolesTest.scala
@@ -1,8 +1,9 @@
 package data
 
-import data.Roles.Dependency
+import models.Dependency
 import models._
-import org.scalatest.{ Matchers, FlatSpec }
+import org.joda.time.DateTime
+import org.scalatest.{ FlatSpec, Matchers }
 
 class RolesTest extends FlatSpec with Matchers {
 
@@ -34,5 +35,14 @@ class RolesTest extends FlatSpec with Matchers {
 
     val roles = List(r0, r1, r2, r3)
     Roles.transitiveDependencies(roles, r2).dependencies.isEmpty should be(true)
+  }
+
+  it should "find recipes that use this role" in {
+    val rec1 = Recipe(RecipeId("r1"), None, null, List(CustomisedRole(RoleId("apt"), Map.empty), CustomisedRole(RoleId("java8"), Map.empty)), "creator", DateTime.now(), "modifiedBy", DateTime.now(), None)
+    val rec2 = Recipe(RecipeId("r2"), None, null, List(CustomisedRole(RoleId("apt"), Map.empty)), "creator", DateTime.now(), "modifiedBy", DateTime.now(), None)
+    val rec3 = Recipe(RecipeId("r3"), None, null, List(CustomisedRole(RoleId("java8"), Map.empty)), "creator", DateTime.now(), "modifiedBy", DateTime.now(), None)
+    val allRecipes = List(rec1, rec2, rec3)
+    val usedByRecipes = Roles.usedByRecipes(allRecipes, RoleSummary(RoleId("java8"), Set.empty, null, null))
+    usedByRecipes should contain only (rec1.id, rec3.id)
   }
 }


### PR DESCRIPTION
In the list of dependencies for each role, show also the transitive ones.
Add a tab with all the Roles and Recipes that use the specific Role.

Before:
For example previously the `disk-available-cronjob` role would show only the `cloud-watch-motitoring` as a dependency.
![screen shot 2017-03-22 at 15 20 37](https://cloud.githubusercontent.com/assets/3422315/24205382/254edf10-0f13-11e7-91de-d530245b4950.jpg)

After:
It would also show `apt` and `perl-useful-packages` which are dependencies of `cloud-watch-motitoring`.
![screen shot 2017-03-28 at 17 28 47](https://cloud.githubusercontent.com/assets/3422315/24416363/70e53a78-13dc-11e7-9230-46d7cd2314c3.jpg)

"Used by" tab:
![screen shot 2017-03-28 at 17 28 57](https://cloud.githubusercontent.com/assets/3422315/24416379/7aa315b2-13dc-11e7-8bdb-f78363ef7de4.jpg)



