### PR TITLE
Show roles dependencies in recipes

### DIFF
--- a/app/controllers/BaseImageController.scala
+++ b/app/controllers/BaseImageController.scala
@@ -28,14 +28,14 @@ class BaseImageController(
         image.amiId,
         image.linuxDist.getOrElse(Ubuntu)
       ))
-      Ok(views.html.editBaseImage(image, form, Roles.listIds))
+      Ok(views.html.editBaseImage(image, form, Roles.list))
     }
   }
 
   def updateBaseImage(id: BaseImageId) = AuthAction(BodyParsers.parse.urlFormEncoded) { implicit request =>
     BaseImages.findById(id).fold[Result](NotFound) { image =>
       Forms.editBaseImage.bindFromRequest.fold({ formWithErrors =>
-        BadRequest(views.html.editBaseImage(image, formWithErrors, Roles.listIds))
+        BadRequest(views.html.editBaseImage(image, formWithErrors, Roles.list))
       }, {
         case (description, amiId, linuxDist) =>
           val customisedRoles = ControllerHelpers.parseEnabledRoles(request.body)

--- a/app/controllers/BaseImageController.scala
+++ b/app/controllers/BaseImageController.scala
@@ -18,7 +18,7 @@ class BaseImageController(
   }
 
   def showBaseImage(id: BaseImageId) = AuthAction { implicit request =>
-    BaseImages.findById(id).fold[Result](NotFound)(image => Ok(views.html.showBaseImage(image)))
+    BaseImages.findById(id).fold[Result](NotFound)(image => Ok(views.html.showBaseImage(Roles.list, image)))
   }
 
   def editBaseImage(id: BaseImageId) = AuthAction {

--- a/app/controllers/RecipeController.scala
+++ b/app/controllers/RecipeController.scala
@@ -43,14 +43,14 @@ class RecipeController(
   def editRecipe(id: RecipeId) = AuthAction {
     Recipes.findById(id).fold[Result](NotFound) { recipe =>
       val form = Forms.editRecipe.fill((recipe.description, recipe.baseImage.id, recipe.bakeSchedule))
-      Ok(views.html.editRecipe(recipe, form, BaseImages.list().toSeq, Roles.listIds))
+      Ok(views.html.editRecipe(recipe, form, BaseImages.list().toSeq, Roles.list))
     }
   }
 
   def updateRecipe(id: RecipeId) = AuthAction(BodyParsers.parse.urlFormEncoded) { implicit request =>
     Recipes.findById(id).fold[Result](NotFound) { recipe =>
       Forms.editRecipe.bindFromRequest.fold({ formWithErrors =>
-        BadRequest(views.html.editRecipe(recipe, formWithErrors, BaseImages.list().toSeq, Roles.listIds))
+        BadRequest(views.html.editRecipe(recipe, formWithErrors, BaseImages.list().toSeq, Roles.list))
       }, {
         case (description, baseImageId, bakeSchedule) =>
           BaseImages.findById(baseImageId) match {
@@ -64,7 +64,7 @@ class RecipeController(
               })
             case None =>
               val formWithError = Forms.editRecipe.fill((description, baseImageId, bakeSchedule)).withError("baseImageId", "Unknown base image")
-              BadRequest(views.html.editRecipe(recipe, formWithError, BaseImages.list().toSeq, Roles.listIds))
+              BadRequest(views.html.editRecipe(recipe, formWithError, BaseImages.list().toSeq, Roles.list))
           }
       })
     }

--- a/app/controllers/RecipeController.scala
+++ b/app/controllers/RecipeController.scala
@@ -33,7 +33,8 @@ class RecipeController(
         views.html.showRecipe(
           recipe,
           bakes.take(20),
-          RecipeUsage(recipe, bakes)(prismAgents)
+          RecipeUsage(recipe, bakes)(prismAgents),
+          Roles.list
         )
       )
     }

--- a/app/data/Roles.scala
+++ b/app/data/Roles.scala
@@ -20,6 +20,10 @@ object Roles {
   def findById(id: RoleId) = list.find(_ == id)
 
   def transitiveDependencies(allRoles: Seq[RoleSummary], roleToAnalyse: RoleSummary): Dependency = {
+    transitiveDependencies(allRoles, roleToAnalyse.roleId)
+  }
+
+  def transitiveDependencies(allRoles: Seq[RoleSummary], roleToAnalyse: RoleId): Dependency = {
     def dependencies(roleId: RoleId): Set[RoleId] = {
       val summaries: Set[RoleSummary] = allRoles.find(_.roleId == roleId).toSet
       summaries.flatMap(_.dependsOn)
@@ -29,7 +33,7 @@ object Roles {
       val children = dependencies(roleId).map(go)
       Dependency(roleId, children)
     }
-    go(roleToAnalyse.roleId)
+    go(roleToAnalyse)
   }
 
   def usedBy(allRoles: Seq[RoleSummary], roleToAnalyse: RoleSummary): Seq[RoleId] = {

--- a/app/data/Roles.scala
+++ b/app/data/Roles.scala
@@ -21,7 +21,7 @@ object Roles {
 
   def transitiveDependencies(allRoles: Seq[RoleSummary], roleToAnalyse: RoleSummary): Dependency = {
     def dependencies(roleId: RoleId): Set[RoleId] = {
-      val summaries: Set[RoleSummary] = allRoles.find(r => r.roleId == roleId).toSet
+      val summaries: Set[RoleSummary] = allRoles.find(_.roleId == roleId).toSet
       summaries.flatMap(_.dependsOn)
     }
 
@@ -33,10 +33,16 @@ object Roles {
   }
 
   def usedBy(allRoles: Seq[RoleSummary], roleToAnalyse: RoleSummary): Seq[RoleId] = {
-    allRoles.filter(_.dependsOn.contains(roleToAnalyse.roleId)).distinct.map((r: RoleSummary) => r.roleId).sortBy(_.value)
+    allRoles
+      .filter(_.dependsOn.contains(roleToAnalyse.roleId))
+      .distinct
+      .map((r: RoleSummary) => r.roleId)
+      .sortBy(_.value)
   }
 
   def usedByRecipes(allRecipes: Seq[Recipe], roleToAnalyse: RoleSummary): Seq[RecipeId] = {
-    allRecipes.filter(_.roles.map(_.roleId).contains(roleToAnalyse.roleId)).map(_.id)
+    allRecipes
+      .filter(_.roles.map(_.roleId).contains(roleToAnalyse.roleId))
+      .map(_.id)
   }
 }

--- a/app/views/editBaseImage.scala.html
+++ b/app/views/editBaseImage.scala.html
@@ -1,4 +1,5 @@
-@(image: BaseImage, form: Form[_], availableRoles: Seq[RoleId])(implicit messages: play.api.i18n.Messages)
+@import data.Roles
+@(image: BaseImage, form: Form[_], availableRoles: Seq[RoleSummary])(implicit messages: play.api.i18n.Messages)
 
 @implicitFieldConstructor = @{ b3.horizontal.fieldConstructor("col-md-2", "col-md-10") }
 
@@ -13,12 +14,16 @@
     <div class="form-group">
       <label class="control-label col-md-2" for="builtin-roles">Builtin roles</label>
       <div class="col-md-10" id="builtin-roles">
-        @for(role <- availableRoles) {
+        @for(role <- availableRoles.map(_.roleId)) {
           <div class="checkbox">
             @if(image.builtinRoles.exists(_.roleId == role)) {
               <div>
                 <label for="role-@role">
-                  <input class="show-role-variables" type="checkbox" id="role-@role" name="roles" data-role="@role" value="@role" checked> @role
+                  <input class="show-role-variables" type="checkbox" id="role-@role" name="roles" data-role="@role" value="@role" checked>
+                  @role
+                  <ul class="list-inline dependency-list">
+                    @views.html.fragments.inlineDependencyList(Roles.transitiveDependencies(availableRoles, role).dependencies)
+                  </ul>
                 </label>
               </div>
               <div>
@@ -29,7 +34,11 @@
             } else {
               <div>
                 <label for="role-@role">
-                  <input class="show-role-variables" type="checkbox" id="role-@role" name="roles" data-role="@role" value="@role"> @role
+                  <input class="show-role-variables" type="checkbox" id="role-@role" name="roles" data-role="@role" value="@role">
+                  @role
+                  <ul class="list-inline dependency-list">
+                    @views.html.fragments.inlineDependencyList(Roles.transitiveDependencies(availableRoles, role).dependencies)
+                  </ul>
                 </label>
               </div>
               <div>

--- a/app/views/editBaseImage.scala.html
+++ b/app/views/editBaseImage.scala.html
@@ -18,7 +18,7 @@
           <div class="checkbox">
             @if(image.builtinRoles.exists(_.roleId == role)) {
               <div>
-                <label for="role-@role">
+                <label for="role-@role" class="role-font">
                   <input class="show-role-variables" type="checkbox" id="role-@role" name="roles" data-role="@role" value="@role" checked>
                   @role
                   <ul class="list-inline dependency-list">
@@ -33,7 +33,7 @@
               </div>
             } else {
               <div>
-                <label for="role-@role">
+                <label for="role-@role" class="role-font">
                   <input class="show-role-variables" type="checkbox" id="role-@role" name="roles" data-role="@role" value="@role">
                   @role
                   <ul class="list-inline dependency-list">

--- a/app/views/editRecipe.scala.html
+++ b/app/views/editRecipe.scala.html
@@ -23,7 +23,7 @@
         @for(roleId <- availableRoles.map(_.roleId)) {
           <div class="checkbox">
             @if(recipe.roles.exists(_.roleId == roleId)) {
-                  <label for="role-@roleId">
+                  <label for="role-@roleId" class="role-font">
                     <input class="show-role-variables" type="checkbox" id="role-@roleId" name="roles" data-role="@roleId" value="@roleId" checked>
                     @roleId
                     <ul class="list-inline dependency-list">
@@ -37,8 +37,7 @@
               </div>
             } else {
               <div>
-
-                <label for="role-@roleId">
+                <label for="role-@roleId" class="role-font">
                     <input class="show-role-variables" type="checkbox" id="role-@roleId" name="roles" data-role="@roleId" value="@roleId">
                     @roleId
                     <ul class="list-inline dependency-list">

--- a/app/views/editRecipe.scala.html
+++ b/app/views/editRecipe.scala.html
@@ -1,4 +1,5 @@
-@(recipe: Recipe, form: Form[_], availableBaseImages: Seq[BaseImage], availableRoles: Seq[RoleId])(implicit messages: play.api.i18n.Messages)
+@import data.Roles
+@(recipe: Recipe, form: Form[_], availableBaseImages: Seq[BaseImage], availableRoles: Seq[RoleSummary])(implicit messages: play.api.i18n.Messages)
 
 @implicitFieldConstructor = @{ b3.horizontal.fieldConstructor("col-md-2", "col-md-10") }
 
@@ -19,27 +20,34 @@
     <div class="form-group">
       <label class="control-label col-md-2" for="builtin-roles">Roles</label>
       <div class="col-md-10" id="builtin-roles">
-        @for(role <- availableRoles) {
+        @for(roleId <- availableRoles.map(_.roleId)) {
           <div class="checkbox">
-            @if(recipe.roles.exists(_.roleId == role)) {
+            @if(recipe.roles.exists(_.roleId == roleId)) {
+                  <label for="role-@roleId">
+                    <input class="show-role-variables" type="checkbox" id="role-@roleId" name="roles" data-role="@roleId" value="@roleId" checked>
+                    @roleId
+                    <ul class="list-inline dependency-list">
+                        @views.html.fragments.inlineDependencyList(Roles.transitiveDependencies(availableRoles, roleId).dependencies)
+                    </ul>
+                  </label>
               <div>
-                <label for="role-@role">
-                  <input class="show-role-variables" type="checkbox" id="role-@role" name="roles" data-role="@role" value="@role" checked> @role
-                </label>
-              </div>
-              <div>
-                <input type="text" class="form-control" id="role-@role-variables" name="role-@role-variables"
-                       value="@recipe.roles.find(_.roleId == role).map(_.variablesToFormInputText)"
+                <input type="text" class="form-control" id="role-@roleId-variables" name="role-@roleId-variables"
+                       value="@recipe.roles.find(_.roleId == roleId).map(_.variablesToFormInputText)"
                        placeholder="Custom variables (optional) e.g. foo: bar, baz: wow">
               </div>
             } else {
               <div>
-                <label for="role-@role">
-                  <input class="show-role-variables" type="checkbox" id="role-@role" name="roles" data-role="@role" value="@role"> @role
+
+                <label for="role-@roleId">
+                    <input class="show-role-variables" type="checkbox" id="role-@roleId" name="roles" data-role="@roleId" value="@roleId">
+                    @roleId
+                    <ul class="list-inline dependency-list">
+                        @views.html.fragments.inlineDependencyList(Roles.transitiveDependencies(availableRoles, roleId).dependencies)
+                    </ul>
                 </label>
               </div>
               <div>
-                <input type="text" class="form-control" style="visibility:hidden" id="role-@role-variables" name="role-@role-variables" placeholder="Custom variables (optional) e.g. foo: bar, baz: wow">
+                <input type="text" class="form-control" style="visibility:hidden" id="role-@roleId-variables" name="role-@roleId-variables" placeholder="Custom variables (optional) e.g. foo: bar, baz: wow">
               </div>
             }
           </div>

--- a/app/views/fragments/customisedRoles.scala.html
+++ b/app/views/fragments/customisedRoles.scala.html
@@ -1,4 +1,6 @@
-@(roles: Iterable[CustomisedRole])
+@import data.Roles
+@(allRoles: Seq[RoleSummary],
+  roles: Iterable[CustomisedRole])
 
 <ul class="list-group">
   @for(role <- roles) {
@@ -10,6 +12,7 @@
       } else {
         <code>@role.variablesToString</code>
       }
+      @views.html.fragments.dependencyList(Roles.transitiveDependencies(allRoles, role.roleId).dependencies)
     </li>
   }
 </ul>

--- a/app/views/fragments/customisedRoles.scala.html
+++ b/app/views/fragments/customisedRoles.scala.html
@@ -4,7 +4,7 @@
 
 <ul class="list-group">
   @for(role <- roles) {
-    <li class="list-group-item">
+    <li class="list-group-item role-font">
       <a href="@routes.RoleController.listRoles#@role.roleId">@role.roleId</a>
 
       @if(role.variables.isEmpty) {

--- a/app/views/fragments/dependencyList.scala.html
+++ b/app/views/fragments/dependencyList.scala.html
@@ -1,7 +1,7 @@
 @import models.Dependency
 @(dependencies: Set[Dependency])
 
-<ul>
+<ul style="list-style-type:disc" class="dependencyFont">
   @for(dep <- dependencies) {
     <li>
         <a href="#@dep.roleId">@dep.roleId</a>

--- a/app/views/fragments/dependencyList.scala.html
+++ b/app/views/fragments/dependencyList.scala.html
@@ -1,7 +1,7 @@
 @import models.Dependency
 @(dependencies: Set[Dependency])
 
-<ul style="list-style-type:disc" class="dependencyFont">
+<ul class="nested-dependencies-list dependencyFont role-font">
   @for(dep <- dependencies) {
     <li>
         <a href="#@dep.roleId">@dep.roleId</a>

--- a/app/views/fragments/inlineDependencyList.scala.html
+++ b/app/views/fragments/inlineDependencyList.scala.html
@@ -1,0 +1,7 @@
+@import models.Dependency
+@(dependencies: Set[Dependency])
+
+@for(dep <- dependencies) {
+    <li><code>@dep.roleId</code></li>
+    @views.html.fragments.inlineDependencyList(dep.dependencies)
+}

--- a/app/views/fragments/inlineDependencyList.scala.html
+++ b/app/views/fragments/inlineDependencyList.scala.html
@@ -2,6 +2,6 @@
 @(dependencies: Set[Dependency])
 
 @for(dep <- dependencies) {
-    <li><code>@dep.roleId</code></li>
+    <li>@dep.roleId</li>
     @views.html.fragments.inlineDependencyList(dep.dependencies)
 }

--- a/app/views/roles.scala.html
+++ b/app/views/roles.scala.html
@@ -6,7 +6,7 @@
 
   <div class="row">
     <div class="col-md-3">
-      <div class="list-group">
+      <div class="list-group role-font">
       @for(role <- roles) {
         <a href="#@role.roleId" data-role-id="@role.roleId" class="list-group-item role-id">
         @role.roleId

--- a/app/views/roles.scala.html
+++ b/app/views/roles.scala.html
@@ -1,5 +1,4 @@
 @import data.Roles
-@import data.Recipes
 @(roles: Iterable[RoleSummary], recipes: Iterable[Recipe])
 @layout("AMIgo"){
 

--- a/app/views/showBaseImage.scala.html
+++ b/app/views/showBaseImage.scala.html
@@ -1,4 +1,4 @@
-@(image: BaseImage)(implicit flash: Flash)
+@(allRoles: Seq[RoleSummary], image: BaseImage)(implicit flash: Flash)
 @simpleLayout("AMIgo"){
 
   <h1>@image.id.value</h1>
@@ -29,7 +29,7 @@
   <div class="panel panel-default">
     <div class="panel-heading">Builtin roles</div>
     <div class="panel-body">
-    @fragments.customisedRoles(image.builtinRoles)
+    @fragments.customisedRoles(allRoles, image.builtinRoles)
     </div>
   </div>
 

--- a/app/views/showRecipe.scala.html
+++ b/app/views/showRecipe.scala.html
@@ -1,7 +1,8 @@
 @(
         recipe: Recipe,
         recentBakes: Iterable[Bake],
-        usage: prism.RecipeUsage
+        usage: prism.RecipeUsage,
+        allRoles: Seq[RoleSummary]
 )(implicit flash: Flash),
 @simpleLayout("AMIgo"){
 
@@ -40,7 +41,7 @@
   <div class="panel panel-default">
     <div class="panel-heading">Roles</div>
     <div class="panel-body">
-    @fragments.customisedRoles(recipe.roles)
+    @fragments.customisedRoles(allRoles, recipe.roles)
     </div>
   </div>
 

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -99,4 +99,15 @@ td.recipe-usage {
     display: inline-block;
     margin-left: 16px;
 }
-​
+
+.role-font {
+    font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
+}
+
+.nested-dependencies-list {
+    list-style: none;
+}
+
+.nested-dependencies-list > li:before {
+    content: "\2192 \0020";
+}

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -85,3 +85,7 @@ td.recipe-usage {
 .role-usage {
     margin-top: 34px;
 }
+
+.dependencyFont li{
+    font-size: 12px;
+}

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -91,8 +91,10 @@ td.recipe-usage {
 }
 
 .dependency-list > li {
-    padding-left: 0;
-    padding-right: 0;
+    color: #777;
+    padding: 2px 4px;
+    background-color: #eee;
+    font-size: 90%;
 }
 
 .dependency-list {

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -89,3 +89,14 @@ td.recipe-usage {
 .dependencyFont li{
     font-size: 12px;
 }
+
+.dependency-list > li {
+    padding-left: 0;
+    padding-right: 0;
+}
+
+.dependency-list {
+    display: inline-block;
+    margin-left: 16px;
+}
+​


### PR DESCRIPTION
Show the indirect Role dependencies in Recipes.
This is shown in the "View recipe" view, "Edit recipe" view as well as the relevant base image (view and edit) ones.

So this now looks likes this (in view recipe):
![screen shot 2017-03-31 at 15 49 41](https://cloud.githubusercontent.com/assets/3422315/24555608/baf3e336-1629-11e7-8e88-03c8fc163435.jpg)

And in the Edit recipe view:
![screen shot 2017-03-31 at 15 48 44](https://cloud.githubusercontent.com/assets/3422315/24555622/c9213e36-1629-11e7-84a4-d77cd0db725d.jpg)
(Please note in this view if a dependency is included twice, it is shown twice.
(many thanks to @gustavpursche for his css help!)



**Update**:

After consulting a UX person (Mario) he suggested that there should be some consistency in the roles in the list and edit view so that the user doesn't get confused. 
Also he suggested adding arrows instead of bullets when depicting dependencies.
So in the spirit of those changes, all the roles are depicted using a monospace font. 
Here is how it looks now.
View recipe:
![screen shot 2017-04-03 at 16 05 36](https://cloud.githubusercontent.com/assets/3422315/24616144/2dac9c3c-1888-11e7-9073-ebf32bfd8e36.jpg)

View role:
![screen shot 2017-04-03 at 16 05 47](https://cloud.githubusercontent.com/assets/3422315/24616143/2dab9dfa-1888-11e7-8aa6-ce612602db3b.jpg)

Edit recipe:
![screen shot 2017-04-04 at 14 22 04](https://cloud.githubusercontent.com/assets/3422315/24659013/632131b4-1943-11e7-85f6-e956b97e9ed3.jpg)

