### PR TITLE
Add link to helpful cron tool and sort recipes

### DIFF
--- a/app/views/baseImages.scala.html
+++ b/app/views/baseImages.scala.html
@@ -18,7 +18,7 @@
       <th>Description</th>
     </thead>
     <tbody>
-    @for(image <- images) {
+    @for(image <- images.toList.sortBy(_.id.value)) {
       <tr>
         <td class="has-block-link"><a href="@routes.BaseImageController.showBaseImage(image.id)" class="block-link">@image.id</a></td>
         <td class="has-block-link"><a href="@routes.BaseImageController.showBaseImage(image.id)" class="block-link">@image.description</a></td>

--- a/app/views/editRecipe.scala.html
+++ b/app/views/editRecipe.scala.html
@@ -11,7 +11,7 @@
 
     @b3.text( form("bakeSchedule"), '_label -> "Bake schedule", 'placeholder -> "e.g. \"0 0 3 * * ?\" to run every night at 3am" )
     <div class="col-md-offset-2">
-      <span class="help-block">This should be a weird Quartz cron expression (<a target="_blank" href="http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/crontrigger.html">docs</a>)</span>
+      <span class="help-block">This should be a weird Quartz cron expression (<a target="_blank" href="http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/crontrigger.html">docs</a>) (<a href="http://www.freeformatter.com/cron-expression-generator-quartz.html">online evaluator</a>)</span>
     </div>
 
     @b3.select( form("baseImageId"), availableBaseImages.map(_.id.value).zip(availableBaseImages.map(_.id.value)), '_label -> "Base image" )

--- a/app/views/recipes.scala.html
+++ b/app/views/recipes.scala.html
@@ -22,7 +22,7 @@
       <th>Usage</th>
     </thead>
     <tbody>
-    @for(recipe <- recipes.toList.sortBy(_.id)) {
+    @for(recipe <- recipes.toList.sortBy(_.id.value)) {
       <tr>
         <td class="has-block-link"><a href="@routes.RecipeController.showRecipe(recipe.id)" class="block-link">@recipe.id</a></td>
         <td class="has-block-link"><a href="@routes.RecipeController.showRecipe(recipe.id)" class="block-link">@recipe.description</a></td>

--- a/app/views/recipes.scala.html
+++ b/app/views/recipes.scala.html
@@ -22,7 +22,7 @@
       <th>Usage</th>
     </thead>
     <tbody>
-    @for(recipe <- recipes) {
+    @for(recipe <- recipes.toList.sortBy(_.id)) {
       <tr>
         <td class="has-block-link"><a href="@routes.RecipeController.showRecipe(recipe.id)" class="block-link">@recipe.id</a></td>
         <td class="has-block-link"><a href="@routes.RecipeController.showRecipe(recipe.id)" class="block-link">@recipe.description</a></td>


### PR DESCRIPTION
This sorts the recipes in alphabetical order (at the moment I think it's related to the order in dynamo?). Fixes #130.
Also I've added a link to this online tool that helps make sense of quartz expressions: http://www.freeformatter.com/cron-expression-generator-quartz.html