### PR TITLE
Pin version of curator and bump retention time to 14 days

### DIFF
--- a/roles/elasticsearch-housekeeping-cronjob/README.md
+++ b/roles/elasticsearch-housekeeping-cronjob/README.md
@@ -1,2 +1,2 @@
 # elasticsearch-housekeeping-cronjob
-This removes logs older than 7 days
+This removes logs older than 7 days. Works with the ElasticSearch 1.7 role only.

--- a/roles/elasticsearch-housekeeping-cronjob/files/housekeeping.sh
+++ b/roles/elasticsearch-housekeeping-cronjob/files/housekeeping.sh
@@ -10,4 +10,4 @@
 /usr/local/bin/curator --master-only delete indices --timestring '%Y.%m.%d' --time-unit days --older-than 14 2>&1 | cut -d " " -f 3- | logger -t curator
 
 # Optimise older indexes
-/usr/local/bin/curator --master-only optimize indices --timestring '%Y.%m.%d' --time-unit days --older-than 14 2>&1 | cut -d " " -f 3- | logger -t curator
+/usr/local/bin/curator --master-only optimize indices --timestring '%Y.%m.%d' --time-unit days --older-than 1 2>&1 | cut -d " " -f 3- | logger -t curator

--- a/roles/elasticsearch-housekeeping-cronjob/files/housekeeping.sh
+++ b/roles/elasticsearch-housekeeping-cronjob/files/housekeeping.sh
@@ -4,10 +4,10 @@
 # We cut the first 2 columns from the output and pipe it into syslog
 
 # Delete old kibana index snapshots
-/usr/local/bin/curator --master-only delete snapshots --repository s3_backup --timestring '%Y%m%d%H%M' --time-unit days --older-than 7 2>&1 | cut -d " " -f 3- | logger -t curator
+/usr/local/bin/curator --master-only delete snapshots --repository s3_backup --timestring '%Y%m%d%H%M' --time-unit days --older-than 14 2>&1 | cut -d " " -f 3- | logger -t curator
 
 # Cleanup indexes
-/usr/local/bin/curator --master-only delete indices --timestring '%Y.%m.%d' --time-unit days --older-than 7 2>&1 | cut -d " " -f 3- | logger -t curator
+/usr/local/bin/curator --master-only delete indices --timestring '%Y.%m.%d' --time-unit days --older-than 14 2>&1 | cut -d " " -f 3- | logger -t curator
 
 # Optimise older indexes
-/usr/local/bin/curator --master-only optimize indices --timestring '%Y.%m.%d' --time-unit days --older-than 1 2>&1 | cut -d " " -f 3- | logger -t curator
+/usr/local/bin/curator --master-only optimize indices --timestring '%Y.%m.%d' --time-unit days --older-than 14 2>&1 | cut -d " " -f 3- | logger -t curator

--- a/roles/elasticsearch-housekeeping-cronjob/tasks/main.yml
+++ b/roles/elasticsearch-housekeeping-cronjob/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
  - name: Install elasticsearch curator
-   pip: name=elasticsearch-curator
+   pip: name=elasticsearch-curator version=3.5.1
 
  - name: Create directory for housekeeping script
    file: path=/opt/bin state=directory


### PR DESCRIPTION
NB: I've applied the same changes on the production boxes themselves.

Fixes a problem where the cron scripts to delete indices were not running so the ES boxes ran out of disk space.

Due to the CLI for Curator changing significantly (and with [potential incompatibility problems](https://pypi.python.org/pypi/elasticsearch-curator#compatibility-matrix) as well), I've pinned us to the older version and added a note that this role only works with the older ElasticSearch.

I've also bumped up the retention period to 14 days now that we have space.