### PR TITLE
correct packer url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ All data (base images, recipes, bakes, bake logs) are stored in DynamoDB. The Dy
 
 ## How to run locally
 
-AMIgo requires Packer to be [installed](https://www.packer.io/intro/getting-started/setup.html)
+AMIgo requires Packer to be [installed](https://www.packer.io/intro/getting-started/install.html)
 
 To run the Play app, you will need credentials in either the `deployTools` profile or the default profile.
 


### PR DESCRIPTION
it's moved to https://www.packer.io/intro/getting-started/install.html by the looked - the old one was 404ing.