### PR TITLE
Install pip if installing cloudwatch logs

### DIFF
--- a/roles/cloud-watch-logs/meta/main.yml
+++ b/roles/cloud-watch-logs/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - aws-tools
+  - { role: packages, packages: [python-pip] }


### PR DESCRIPTION
pip is installed if not already installed by the cloudwatch logs script on init. This slows down boot and can cause the `dpkg` lock to be taken. By pre-installing it we can avoid these issues.