### PR TITLE
Make the Bastion SSH role depend on s3-ssh-keys

### DIFF
--- a/roles/bastion-ssh/README.md
+++ b/roles/bastion-ssh/README.md
@@ -3,5 +3,13 @@
 Additional SSH configuration for use when running as a Bastion host bridging private subnets
 with another network.
 
+This role depends on the s3-ssh-keys role which will keep the list of SSH keys on the Bastion
+up to date. Due to the way parameters are passed to Ansible, you should add the parameters to
+this role, not the s3-ssh-keys one:
+
+```
+bastion-ssh { ssh_keys_bucket: github-public-keys, ssh_keys_prefix: <team> }
+```
+
 It's recommended to use this role in conjunction with the `cloud-watch-logs` role pointing
 at `/var/log/auth`.

--- a/roles/bastion-ssh/meta/main.yml
+++ b/roles/bastion-ssh/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
+  - apt
   - s3-ssh-keys

--- a/roles/bastion-ssh/meta/main.yml
+++ b/roles/bastion-ssh/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - s3-ssh-keys


### PR DESCRIPTION
This avoids the problem building recipes that use both roles. If s3-ssh-keys runs after the bastion role it can't add the ssh user because sudo has been revoked.