### PR TITLE
Keep ubuntu in sudoers for bastion role

### DIFF
--- a/roles/bastion-ssh/README.md
+++ b/roles/bastion-ssh/README.md
@@ -11,5 +11,11 @@ this role, not the s3-ssh-keys one:
 bastion-ssh { ssh_keys_bucket: github-public-keys, ssh_keys_prefix: <team> }
 ```
 
-It's recommended to use this role in conjunction with the `cloud-watch-logs` role pointing
+N.B. It's recommended that the ubuntu user is additionally removed from sudoers.  This is not included in the role itself because it may interfere with other roles.
+
+```
+rm /etc/sudoers.d/90-cloud-init-users
+```
+
+It's also recommended to use this role in conjunction with the `cloud-watch-logs` role pointing
 at `/var/log/auth`.

--- a/roles/bastion-ssh/tasks/main.yml
+++ b/roles/bastion-ssh/tasks/main.yml
@@ -11,8 +11,3 @@
   user:
     name: ubuntu
     groups: ubuntu,dialout,cdrom,floppy,audio,dip,video,plugdev,netdev
-
-- name: Remove ubuntu user from sudoers
-  file:
-    state: absent
-    path: /etc/sudoers.d/90-cloud-init-users


### PR DESCRIPTION
It appears the bastion ssh role can interfere with other roles that require sudo access because it removes ubuntu from sudoers.  This is a quick fix for that, which removes that task from the role.

Perhaps the better solution would be to implement some notion of priority to the roles in a recipe and give the bastion role a low priority so that it is executed last.  I would be happy to make those changes subsequently if we think it might be a useful feature? cc: @philwills 