### PR TITLE
Show dependencies in all the locations

### DIFF
--- a/app/controllers/BaseImageController.scala
+++ b/app/controllers/BaseImageController.scala
@@ -18,7 +18,7 @@ class BaseImageController(
   }
 
   def showBaseImage(id: BaseImageId) = AuthAction { implicit request =>
-    BaseImages.findById(id).fold[Result](NotFound)(image => Ok(views.html.showBaseImage(image)))
+    BaseImages.findById(id).fold[Result](NotFound)(image => Ok(views.html.showBaseImage(image, Roles.list)))
   }
 
   def editBaseImage(id: BaseImageId) = AuthAction {

--- a/app/controllers/RecipeController.scala
+++ b/app/controllers/RecipeController.scala
@@ -33,7 +33,8 @@ class RecipeController(
         views.html.showRecipe(
           recipe,
           bakes.take(20),
-          RecipeUsage(recipe, bakes)(prismAgents)
+          RecipeUsage(recipe, bakes)(prismAgents),
+          Roles.list
         )
       )
     }

--- a/app/controllers/RoleController.scala
+++ b/app/controllers/RoleController.scala
@@ -7,7 +7,7 @@ import play.api.mvc._
 class RoleController(val authConfig: GoogleAuthConfig)(implicit dynamo: Dynamo) extends Controller with AuthActions {
 
   def listRoles = AuthAction {
-    Ok(views.html.roles(Roles.list, Recipes.list()))
+    Ok(views.html.roles(Roles.list, Recipes.list(), BaseImages.list().toSeq))
   }
 
 }

--- a/app/data/Roles.scala
+++ b/app/data/Roles.scala
@@ -19,7 +19,7 @@ object Roles {
 
   def findById(id: RoleId) = list.find(_ == id)
 
-  def transitiveDependencies(allRoles: Seq[RoleSummary], roleToAnalyse: RoleSummary): Dependency = {
+  def transitiveDependencies(allRoles: Seq[RoleSummary], roleToAnalyse: RoleId): Dependency = {
     def dependencies(roleId: RoleId): Set[RoleId] = {
       val summaries: Set[RoleSummary] = allRoles.find(r => r.roleId == roleId).toSet
       summaries.flatMap(_.dependsOn)
@@ -29,7 +29,13 @@ object Roles {
       val children = dependencies(roleId).map(go)
       Dependency(roleId, children)
     }
-    go(roleToAnalyse.roleId)
+    go(roleToAnalyse)
+  }
+
+  def customisedTransitiveDependency(allRoles: Seq[RoleSummary], customisedRoles: Iterable[CustomisedRole]): Iterable[(CustomisedRole, Dependency)] = {
+    customisedRoles.map { role =>
+      role -> transitiveDependencies(allRoles, role.roleId)
+    }
   }
 
   def usedBy(allRoles: Seq[RoleSummary], roleToAnalyse: RoleSummary): Seq[RoleId] = {
@@ -38,5 +44,9 @@ object Roles {
 
   def usedByRecipes(allRecipes: Seq[Recipe], roleToAnalyse: RoleSummary): Seq[RecipeId] = {
     allRecipes.filter(_.roles.map(_.roleId).contains(roleToAnalyse.roleId)).map(_.id)
+  }
+
+  def usedByBaseImages(allBaseImages: Seq[BaseImage], roleToAnalyse: RoleSummary): Seq[BaseImage] = {
+    allBaseImages.filter(_.builtinRoles.map(_.roleId).contains(roleToAnalyse.roleId))
   }
 }

--- a/app/views/fragments/customisedRoles.scala.html
+++ b/app/views/fragments/customisedRoles.scala.html
@@ -1,14 +1,22 @@
-@(roles: Iterable[CustomisedRole])
+@(roles: Iterable[(CustomisedRole, Dependency)])
 
 <ul class="list-group">
-  @for(role <- roles) {
+  @for((role, deps) <- roles) {
     <li class="list-group-item">
-      <a href="@routes.RoleController.listRoles#@role.roleId">@role.roleId</a>
+      <div>
+        <a href="@routes.RoleController.listRoles#@role.roleId">@role.roleId</a>
 
-      @if(role.variables.isEmpty) {
-        <em>(No custom variables)</em>
-      } else {
-        <code>@role.variablesToString</code>
+        @if(role.variables.isEmpty) {
+          <em>(No custom variables)</em>
+        } else {
+          <code>@role.variablesToString</code>
+        }
+      </div>
+      @if(deps.dependencies.nonEmpty) {
+        <div>
+          Depends on:
+          @views.html.fragments.dependencyList(deps.dependencies)
+        </div>
       }
     </li>
   }

--- a/app/views/roles.scala.html
+++ b/app/views/roles.scala.html
@@ -1,6 +1,6 @@
 @import data.Roles
 @import data.Recipes
-@(roles: Iterable[RoleSummary], recipes: Iterable[Recipe])
+@(roles: Iterable[RoleSummary], recipes: Iterable[Recipe], baseImages: Seq[BaseImage])
 @layout("AMIgo"){
 
   <h1>Roles</h1>
@@ -17,8 +17,7 @@
     </div>
 
     <div class="col-md-9">
-      <div id="sticky-anchor"></div>
-      <div class="sticky">
+      <div>
         <div id="explanation">
           Choose a role from the list to see more details.
         </div>
@@ -63,7 +62,7 @@
                 } else {
                     This role depends on (including transitive dependencies):
 
-                    @views.html.fragments.dependencyList(Roles.transitiveDependencies(roles.toSeq, role).dependencies)
+                    @views.html.fragments.dependencyList(Roles.transitiveDependencies(roles.toSeq, role.roleId).dependencies)
                 }</p>
               </div>
 
@@ -98,6 +97,21 @@
                           }
                           </ul>
                       }
+                    }
+                </div>
+                <div class="role-usage">
+                    <h4>Base images</h4>
+                    @defining(Roles.usedByBaseImages(baseImages, role)) { usedBy =>
+                        @if(usedBy.isEmpty) {
+                            This role is not used by any base images
+                        } else {
+                            This role is included by the following base images:
+                            <ul>
+                            @usedBy.map { baseImage =>
+                                <li><a href="@routes.BaseImageController.showBaseImage(baseImage.id)">@baseImage.id</a></li>
+                            }
+                            </ul>
+                        }
                     }
                 </div>
               </div>

--- a/app/views/showBaseImage.scala.html
+++ b/app/views/showBaseImage.scala.html
@@ -1,4 +1,5 @@
-@(image: BaseImage)(implicit flash: Flash)
+@import data.Roles
+@(image: BaseImage, allRoles: Seq[RoleSummary])(implicit flash: Flash)
 @simpleLayout("AMIgo"){
 
   <h1>@image.id.value</h1>
@@ -29,7 +30,7 @@
   <div class="panel panel-default">
     <div class="panel-heading">Builtin roles</div>
     <div class="panel-body">
-    @fragments.customisedRoles(image.builtinRoles)
+    @fragments.customisedRoles(image.builtinRoles.map(role => role -> Roles.transitiveDependencies(allRoles, role.roleId)))
     </div>
   </div>
 

--- a/app/views/showRecipe.scala.html
+++ b/app/views/showRecipe.scala.html
@@ -1,7 +1,9 @@
+@import data.Roles
 @(
         recipe: Recipe,
         recentBakes: Iterable[Bake],
-        usage: prism.RecipeUsage
+        usage: prism.RecipeUsage,
+        allRoles: Seq[RoleSummary]
 )(implicit flash: Flash),
 @simpleLayout("AMIgo"){
 
@@ -40,7 +42,9 @@
   <div class="panel panel-default">
     <div class="panel-heading">Roles</div>
     <div class="panel-body">
-    @fragments.customisedRoles(recipe.roles)
+    @fragments.customisedRoles(Roles.customisedTransitiveDependency(allRoles, recipe.roles))
+      <h4>Inherited from base image @recipe.baseImage.id</h4>
+      @fragments.customisedRoles(Roles.customisedTransitiveDependency(allRoles, recipe.baseImage.builtinRoles))
     </div>
   </div>
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -8,8 +8,8 @@ aws.region = "eu-west-1"
 
 google {
   # These are dev credentials, only valid when running on localhost
-  clientId = "849625180647-e57d27lnufnfd5f4r0v3srjkv0ulbbq9.apps.googleusercontent.com"
-  clientSecret = "fxpUiRnyFPeC6peb9BUgsC9y"
+  clientId = "676799371869-9bh2reer5ajh58vkcfjv04jvcrjlngj1.apps.googleusercontent.com"
+  clientSecret = "C8aAXNPE3-9EF4EbjYbN9bvp"
   redirectUrl = "http://localhost:9000/oauth2callback"
 }
 

--- a/test/data/RolesTest.scala
+++ b/test/data/RolesTest.scala
@@ -14,7 +14,7 @@ class RolesTest extends FlatSpec with Matchers {
     val r3 = RoleSummary(RoleId("id3"), Set.empty, null, null)
 
     val roles = List(r0, r1, r2, r3)
-    Roles.transitiveDependencies(roles, r0).dependencies should contain only (Dependency(RoleId("id1"), Set(Dependency(RoleId("id2"), Set(Dependency(RoleId("id3"), Set()))))), Dependency(RoleId("id2"), Set(Dependency(RoleId("id3"), Set()))))
+    Roles.transitiveDependencies(roles, r0.roleId).dependencies should contain only (Dependency(RoleId("id1"), Set(Dependency(RoleId("id2"), Set(Dependency(RoleId("id3"), Set()))))), Dependency(RoleId("id2"), Set(Dependency(RoleId("id3"), Set()))))
   }
 
   it should "return direct dependencies if there are no transitive" in {
@@ -24,7 +24,7 @@ class RolesTest extends FlatSpec with Matchers {
     val r3 = RoleSummary(RoleId("id3"), Set(RoleId("id2")), null, null)
 
     val roles = List(r0, r1, r2, r3)
-    Roles.transitiveDependencies(roles, r0).dependencies should contain only (Dependency(RoleId("id1"), Set(Dependency(RoleId("id2"), Set()))), Dependency(RoleId("id2"), Set()))
+    Roles.transitiveDependencies(roles, r0.roleId).dependencies should contain only (Dependency(RoleId("id1"), Set(Dependency(RoleId("id2"), Set()))), Dependency(RoleId("id2"), Set()))
   }
 
   it should "return empty if there are no dependencies" in {
@@ -34,7 +34,7 @@ class RolesTest extends FlatSpec with Matchers {
     val r3 = RoleSummary(RoleId("id3"), Set(RoleId("id2")), null, null)
 
     val roles = List(r0, r1, r2, r3)
-    Roles.transitiveDependencies(roles, r2).dependencies.isEmpty should be(true)
+    Roles.transitiveDependencies(roles, r2.roleId).dependencies.isEmpty should be(true)
   }
 
   it should "find recipes that use this role" in {


### PR DESCRIPTION
A common and fair criticism of AMIgo is that is can be hard to see what a particular recipe *actually* pulls in due to roles included in the base image and roles pulled in via dependencies.

This PR:
 - lists roles inherited from the base image when viewing recipes
 - changes the way included roles are displayed to include their dependencies on both recipe and base image pages
 - the `used by` page for a role now lists any base images that pull in a role

It is quite verbose, but I consider this better than having to view multiple pages to get the information that you need and it is now obvious when roles are implicitly pulled in.

Here's a picture of the roles section before:
![screen shot 2017-11-09 at 16 55 34](https://user-images.githubusercontent.com/1236466/32618168-dac134b2-c56e-11e7-8c1b-2a5dd6a69295.png)

and after:
![screen shot 2017-11-09 at 16 47 32](https://user-images.githubusercontent.com/1236466/32617876-177c5a9a-c56e-11e7-8b2f-1a1474f6682f.png)
