### PR TITLE
Switch over to AWS link local NTP

### DIFF
--- a/app/models/BaseImage.scala
+++ b/app/models/BaseImage.scala
@@ -30,7 +30,7 @@ case object Ubuntu extends LinuxDist {
       // Wait for cloud-init to finish first: https://github.com/mitchellh/packer/issues/2639
       "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
       "apt-get --yes install software-properties-common",
-      "apt-add-repository ppa:ansible/ansible",
+      "apt-add-repository --yes ppa:ansible/ansible",
       "apt-get --yes update",
       "apt-get --yes install ansible"
     ))

--- a/roles/chrony/meta/main.yml
+++ b/roles/chrony/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - apt

--- a/roles/chrony/tasks/main.yml
+++ b/roles/chrony/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Install chrony package
+  apt: name=chrony state=present
+
+- name: Use Amazon NTP server pool
+  replace: dest=/etc/chrony/chrony.conf regexp=debian.pool.ntp.org replace=amazon.pool.ntp.org
+
+- name: Add local link NTP server
+  lineinfile: path=/etc/chrony/chrony.conf insertafter='^(server|pool)' line='server 169.254.169.123 prefer iburst'

--- a/roles/ubuntu-init/meta/main.yml
+++ b/roles/ubuntu-init/meta/main.yml
@@ -2,5 +2,4 @@
 dependencies:
   - apt
   - enhanced-networking
-  - ntp
   - aws-tools


### PR DESCRIPTION
AWS have announced a new Time Sync Service (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html) that is available on link local addresses.

 - The Link Local address is only available inside VPCs. The change retains other NTP servers for any legacy infrastructure that still isn't in a VPC and simply prefers the new link local address when available
 - It will no longer be necessary for instances to be able to access the internet for time sync
 - Chrony is now the preferred time sync service so this is now used instead of NTP
 - This PR introduces configuration to use the link local config in a new `chrony` role, although it also switches the old `ntp` role out in the `ubuntu-init` so when this PR is merged it will immediately impact any new image

The `chronyc sources -v` command can be used to check the current status of chrony.

I'm pretty confident about this change but am aware it is fairly wide in scope. I'm happy to discuss a more gradual rollout if that is considered more sensible. The packages cannot be used together, but a new ubuntu-init-chrony could be temporarily introduced for testing.

*Update:* This PR now simply removes `ntp` from ubuntu-init. Each base image can then include the time service as it sees fit.