### PR TITLE
Support multiple teams for ssh access

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ packer {
 }
 ```
 
+Optionally, you may want to set `associate_public_ip_address` to true if your subnet does not default to this, to ensure Packer can SSH into your instance.
+
 Once you have your credentials and config sorted out, just do: 
 
 ```

--- a/roles/s3-ssh-keys/README.md
+++ b/roles/s3-ssh-keys/README.md
@@ -1,19 +1,28 @@
 S3 SSH keys
 ===========
 
-Copies an authorized_keys file to the .ssh directory of the `ssh_user` (defaults to ubuntu)
-from the S3 bucket specified with `ssh_keys_bucket` and a directory of `ssh_keys_prefix`.
+Copies an authorized_keys file to the .ssh directory of the `ssh_user`
+(defaults to ubuntu) from the S3 bucket specified with
+`ssh_keys_bucket` and a directory of `ssh_keys_prefix`.
+
 For example specifying
 
-```
-ssh_keys_bucket: my-bucket-name, ssh_keys_prefix: Team-Name
-```
+    ssh_keys_bucket: my-bucket-name, ssh_keys_prefix: Team-Name
 
-would result in the file at `s3://my-bucket-name/Team-Name/authorized_keys` being copied to `.ssh/authorized_keys`
-within the `ubuntu` users home directory.
 
-In addition to downloading the keys during AMI creation, this creates a systemd timer to keep the keys up
-to date. It will re-download the file a minute after startup and every half hour thereafter.
+would result in the file at
+`s3://my-bucket-name/Team-Name/authorized_keys` being copied to
+`.ssh/authorized_keys` within the `ubuntu` users home directory.
 
-To see when the last time the job was run and when it is next scheduled to run, you can use
-`systemctl list-timers`. Logs for the job can be inspected using `journalctl -u update-keys`.
+You can pass a list of team names for the ssh_keys_prefix value to
+compose multiple files. E.g:
+
+    ssh_keys_bucket: my-bucket-name, ssh_keys_prefix: [Team-NameA, Team-NameB]
+
+In addition to downloading the keys during AMI creation, this creates
+a systemd timer to keep the keys up to date. It will re-download the
+file a minute after startup and every half hour thereafter.
+
+To see when the last time the job was run and when it is next
+scheduled to run, you can use `systemctl list-timers`. Logs for the
+job can be inspected using `journalctl -u update-keys`.

--- a/roles/s3-ssh-keys/templates/install-keys.sh.template
+++ b/roles/s3-ssh-keys/templates/install-keys.sh.template
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-aws s3 cp s3://{{ssh_keys_bucket}}/{{ssh_keys_prefix}}/authorized_keys /tmp/authorized_keys
+{# Coerce to list #}
+{% set prefixes = [ssh_keys_prefix] if ssh_keys_prefix is string else ssh_keys_prefix %}
+
+{% for prefix in prefixes %}
+    aws s3 cp s3://{{ssh_keys_bucket}}/{{prefix}}/authorized_keys /tmp/authorized_keys.{{prefix}}
+    cat /tmp/authorized_keys.{{prefix}} >> /tmp/authorized_keys
+{% endfor %}
 
 install -m 600 -o {{ssh_user}} /tmp/authorized_keys /home/{{ssh_user}}/.ssh/authorized_keys


### PR DESCRIPTION
See s3-ssh-keys README change but basically, this supports providing a list of teams for the ssh prefix argument. The immediate use case if for Frontend where it is helpful to be able to re-use existing Github SSH teams (e.g. Identity-SSH-Access) rather than duplicating them.

Note, I didn't realise the full power of Jinja was available so spent a disappointing amount of time trying to coerce a Python list string representation into something usable in bash. :(