### PR TITLE
Patch enhanced-networking for later kernel numbers

### DIFF
--- a/roles/enhanced-networking/tasks/main.yml
+++ b/roles/enhanced-networking/tasks/main.yml
@@ -10,7 +10,7 @@
   replace:
     path: /tmp/ixgbevf-{{driver_version}}/src/kcompat.h
     regexp: '#if UTS_UBUNTU_RELEASE_ABI > 255'
-    replace: '/*#if UTS_UBUNTU_RELEASE_ABI > 255'
+    replace: '#if UTS_UBUNTU_RELEASE_ABI > 99255'
 
 - name: Make network driver
   command: make install

--- a/roles/enhanced-networking/tasks/main.yml
+++ b/roles/enhanced-networking/tasks/main.yml
@@ -5,6 +5,13 @@
 - name: Extract network driver
   unarchive: src=ixgbevf-{{driver_version}}.tar.gz dest=/tmp/
 
+# https://stackoverflow.com/questions/44833346/cant-get-ixgbevf-to-build-on-current-ubuntu-ami
+- name: Patch network driver
+  replace:
+    path: /tmp/ixgbevf-{{driver_version}}/src/kcompat.h
+    regexp: '#if UTS_UBUNTU_RELEASE_ABI > 255'
+    replace: '/*#if UTS_UBUNTU_RELEASE_ABI > 255'
+
 - name: Make network driver
   command: make install
   args:


### PR DESCRIPTION
There is a problem with the enhanced-networking driver (see https://stackoverflow.com/questions/44833346/cant-get-ixgbevf-to-build-on-current-ubuntu-ami) that causes build failures on later linux kernels.

This has come to light when trying to use the latest Xenial AMI as a base in AMIgo. This small patch fixes it by commenting out the check in the source code.

This has been tested on CODE (works aside from some warning messages): https://amigo.code.dev-gutools.co.uk/recipes/ubuntu-xenial-java8/bakes/5