### PR TITLE
add optional date format for cloudwatch log parsing

### DIFF
--- a/roles/cloud-watch-logs/README.md
+++ b/roles/cloud-watch-logs/README.md
@@ -7,6 +7,7 @@ The arguments are:
  - the stage
  - the app
  - the full path to the log
+ - an optional date format, see "datetime_format" [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html)
 
 
 Here's an example user data that makes use of it:

--- a/roles/cloud-watch-logs/files/configure-logs
+++ b/roles/cloud-watch-logs/files/configure-logs
@@ -5,10 +5,12 @@ stack=$2
 stage=$3
 app=$4
 file=$5
+#optional date format parameter
+date_format=${6:-%Y-%m-%d %H:%M:%S}
 
 cat > /var/awslogs/etc/config/$app-$id.conf <<__END__
 [$app-$id]
-datetime_format = %Y-%m-%d %H:%M:%S
+datetime_format = $date_format
 file = $file
 initial_position = start_of_file
 log_group_name = $stack-$app-$stage


### PR DESCRIPTION
I'm trying to add auth.log to cloudwatch, and the date format isn't quite the same as the default play log.

This should allow us to pass whatever format we want at the time the image is booting, pushing any log, including system logs.