### PR TITLE
Await aws tags

### DIFF
--- a/roles/aws-await-tags/README.md
+++ b/roles/aws-await-tags/README.md
@@ -7,7 +7,7 @@ We use EC2 [Tagging](https://docs.aws.amazon.com/cli/latest/reference/ec2/descri
 to look up the `Stack`, `App` and `Stage` for a given instance.
 
 Unfortunately, the API is eventually consistent and can return empty tags on some AWS
-instance types that boot fast enough. This can cause major problems will apps that are
+instance types that boot fast enough. This can cause major problems with apps that are
 written to assume a lack of tags means run in `DEV` mode.
 
 The correct solution to the problem is to change the application to receive the information
@@ -17,4 +17,6 @@ This role exists so we can get the safety of consistently reading tags before we
 a chance to change the code in all the projects.
 
 It simply adds a script to Cloud Init [Scripts Per Boot](http://cloudinit.readthedocs.io/en/latest/topics/modules.html#scripts-per-boot)
-that tries to get the tags in a loop, failing if none are available after 1 minute.
+that tries to get the tags in a loop.
+
+NB: if tags are not found the `user-data` script **will still run**.

--- a/roles/aws-await-tags/README.md
+++ b/roles/aws-await-tags/README.md
@@ -1,0 +1,20 @@
+Await Tags
+==========
+
+This role should ideally not be used for new projects.
+
+We use EC2 [Tagging](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-tags.html)
+to look up the `Stack`, `App` and `Stage` for a given instance.
+
+Unfortunately, the API is eventually consistent and can return empty tags on some AWS
+instance types that boot fast enough. This can cause major problems will apps that are
+written to assume a lack of tags means run in `DEV` mode.
+
+The correct solution to the problem is to change the application to receive the information
+via another mechanism eg subbing in environment variables in launch configuration.
+
+This role exists so we can get the safety of consistently reading tags before we have had
+a chance to change the code in all the projects.
+
+It simply adds a script to Cloud Init [Scripts Per Boot](http://cloudinit.readthedocs.io/en/latest/topics/modules.html#scripts-per-boot)
+that tries to get the tags in a loop, failing if none are available after 1 minute.

--- a/roles/aws-await-tags/tasks/main.yml
+++ b/roles/aws-await-tags/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: add await tags script
+  template: src=await_tags.sh dest=/var/lib/cloud/scripts/per-boot/await_tags.sh
+  mode: u=rwx

--- a/roles/aws-await-tags/tasks/main.yml
+++ b/roles/aws-await-tags/tasks/main.yml
@@ -1,4 +1,3 @@
 ---
 - name: add await tags script
-  template: src=await_tags.sh dest=/var/lib/cloud/scripts/per-boot/await_tags.sh
-  mode: u=rwx
+  template: src=await_tags.sh dest=/var/lib/cloud/scripts/per-boot/await_tags.sh mode="u=rwx,g=rx,o=rx"

--- a/roles/aws-await-tags/templates/await_tags.sh
+++ b/roles/aws-await-tags/templates/await_tags.sh
@@ -16,5 +16,5 @@ do
 done
 
 # Ideally we should exit 1 here but cloud-init seems to ignore the failure and press on regardless...
-# so lets just shout loudly in the syslog and hope someone is watching
-echo "!! AWS Tags not found after 1 minute !!"
+# so lets just complain in the syslog and hope someone is watching
+echo "AWS Tags not found after 1 minute"

--- a/roles/aws-await-tags/templates/await_tags.sh
+++ b/roles/aws-await-tags/templates/await_tags.sh
@@ -15,4 +15,6 @@ do
     sleep 5
 done
 
+# Ideally we should exit 1 here but cloud-init seems to ignore the failure and press on regardless...
+# so lets just shout loudly in the syslog and hope someone is watching
 echo "!! AWS Tags not found after 1 minute !!"

--- a/roles/aws-await-tags/templates/await_tags.sh
+++ b/roles/aws-await-tags/templates/await_tags.sh
@@ -1,15 +1,18 @@
 #!/bin/bash -e
+echo "Awaiting AWS tags..."
+
 INSTANCE_ID=$(curl --silent http://169.254.169.254/latest/meta-data/instance-id)
 
 for i in {1..12}
 do
-    NUM_TAGS=$(aws ec2 describe-tags --filters Name=resource-type,Values=instance Name=resource-id,Values=$INSTANCE_ID --region eu-west-1 | jq ".Tags | length")
+    NUM_TAGS=$(aws ec2 describe-tags --filters Name=resource-type,Values=instance Name=resource-id,Values=${INSTANCE_ID} --region eu-west-1 | jq ".Tags | length")
 
     if (( $NUM_TAGS > 0 )); then
+        echo "AWS tags loaded"
         exit 0
     fi
 
-sleep 5
+    sleep 5
 done
 
-exit 1
+echo "!! AWS Tags not found after 1 minute !!"

--- a/roles/aws-await-tags/templates/await_tags.sh
+++ b/roles/aws-await-tags/templates/await_tags.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+INSTANCE_ID=$(curl --silent http://169.254.169.254/latest/meta-data/instance-id)
+
+for i in {1..12}
+do
+    NUM_TAGS=$(aws ec2 describe-tags --filters Name=resource-type,Values=instance Name=resource-id,Values=$INSTANCE_ID --region eu-west-1 | jq ".Tags | length")
+
+    if (( $NUM_TAGS > 0 )); then
+        exit 0
+    fi
+
+sleep 5
+done
+
+exit 1


### PR DESCRIPTION
We have seen some issues in PROD on Ed Tools caused by tags not being available when the user data script is run.

The real fix is to change the apps to not call Describe Tags to find out Stack, App, Stage etc. In the meantime we can use this role that will block calling the main script until tags are available (or 1 minute has elapsed).