### PR TITLE
Add open JDK repository on Trusty (14.04)

### DIFF
--- a/roles/java8/tasks/main.yml
+++ b/roles/java8/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Add open JDK repository on Trusty (14.04)
+  apt_repository: repo='ppa:openjdk-r/ppa'
+  when: ansible_os_family == "Debian" and ansible_distribution_version == "14.04"
+
 - name: Install Java 8 JRE and JDK
   apt: name={{item}} state=latest
   with_items:


### PR DESCRIPTION
This change adds an action to role `java8`, that only affect Trusty (14.04), by adding a missing repository preventing the role to fail when running recipes on that image.