### PR TITLE
Introduce new role for installing AWS's ssm agent

### DIFF
--- a/roles/ssm-agent/README.md
+++ b/roles/ssm-agent/README.md
@@ -1,0 +1,4 @@
+ssm agent
+==========
+
+Install [ssm agent](https://github.com/aws/amazon-ssm-agent).

--- a/roles/ssm-agent/tasks/main.yml
+++ b/roles/ssm-agent/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Create /tmp/ssm
+  file:
+    path: /tmp/ssm
+    state: directory
+    mode: 0755
+
+- name: Download amazon-ssm-agent.deb
+  get_url:
+    url: https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb 
+    dest: /tmp/ssm/amazon-ssm-agent.deb
+    mode: 0644
+
+- name: Install ssm-agent
+  apt:
+    deb: /tmp/ssm/amazon-ssm-agent.deb


### PR DESCRIPTION
This change creates the role ssm-agent which downloads and install AWS's ssm agent (https://github.com/aws/amazon-ssm-agent).

To be used with the security-hq recipe.

