### PR TITLE
New stack to handle KMS keys for Image Copier

### DIFF
--- a/imageCopier/imageCopier.yaml
+++ b/imageCopier/imageCopier.yaml
@@ -5,9 +5,6 @@ Parameters:
   AmigoTopicArn:
     Description: The SNS topic to subscribe to
     Type: String
-  KmsKeyARN:
-    Description: ARN of KMS key to encrypt the AMI copies
-    Type: String
   EncryptedTagValue:
     Description: The value of the Encrypted tag on the created AMI
     Type: String
@@ -71,7 +68,7 @@ Resources:
           - kms:CreateGrant
           - kms:GenerateDataKey*
           - kms:DescribeKey
-          Resource: !Ref KmsKeyARN
+          Resource: !ImportValue amigo-imagecopier-key
 
   ImageCopyPolicy:
     Type: AWS::IAM::Policy
@@ -120,5 +117,5 @@ Resources:
       Environment:
         Variables:
           ACCOUNT_ID: !Ref AWS::AccountId
-          KMS_KEY_ARN: !Ref KmsKeyARN
+          KMS_KEY_ARN: !ImportValue amigo-imagecopier-key
           ENCRYPTED_TAG_VALUE: !Ref EncryptedTagValue

--- a/imageCopier/imageCopierKmsKey.yaml
+++ b/imageCopier/imageCopierKmsKey.yaml
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: AMIgo kms key creator
+
+Resources:
+  KmsKey:
+    Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    Properties:
+      EnableKeyRotation: True
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: amigo-kms-key
+        Statement:
+        - Sid: Enable IAM User Permissions
+          Effect: Allow
+          Principal:
+            AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+          Action: kms:*
+          Resource: "*"
+
+Outputs:
+  AmigoImageCopierKey:
+    Description: Amigo image copier key arn
+    Value: !GetAtt KmsKey.Arn
+    Export:
+      Name: amigo-imagecopier-key

--- a/imageCopier/imageCopierKmsKey.yaml
+++ b/imageCopier/imageCopierKmsKey.yaml
@@ -6,6 +6,7 @@ Resources:
     Type: AWS::KMS::Key
     DeletionPolicy: Retain
     Properties:
+      Description: Used by AMIgo image copier lambda to encrypt AMIs
       EnableKeyRotation: True
       KeyPolicy:
         Version: 2012-10-17


### PR DESCRIPTION
The image copier lambda requires a KMS key unique to each account it runs in.

The best way to do this is to create an additional stack that only creates KMS keys for the Image copier and then deploy this second stack in all accounts that use the image copier lambda. 

The cloudformation added here describes and creates that second stack. 
