### PR TITLE
Don't upload the lambda code with public ACL flag

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -22,3 +22,4 @@ deployments:
     parameters:
       bucket: deploy-tools-dist
       cacheControl: public, max-age=600
+      publicReadAcl: false


### PR DESCRIPTION
I was trying to work out why an earlier deploy worked when it shouldn't and realised that the public ACL flag is being set by default.