### PR TITLE
Make encrypted copies visible in AMIgo

### DIFF
--- a/app/controllers/BakeController.scala
+++ b/app/controllers/BakeController.scala
@@ -1,24 +1,20 @@
 package controllers
 
-import akka.Done
 import akka.stream.scaladsl.Source
 import com.gu.googleauth.GoogleAuthConfig
 import data._
 import event._
-import event.BakeEvent.{ AmiCreated, PackerProcessExited }
 import packer._
 import models._
 import play.api.Logger
 import play.api.i18n.{ I18nSupport, MessagesApi }
 import play.api.libs.EventSource
 import play.api.mvc._
-import prism.Prism
-
-import scala.concurrent.Future
+import services.PrismAgents
 
 class BakeController(
     eventsSource: Source[BakeEvent, _],
-    prism: Prism,
+    prism: PrismAgents,
     val authConfig: GoogleAuthConfig,
     val messagesApi: MessagesApi,
     ansibleVars: Map[String, String],

--- a/app/controllers/RecipeController.scala
+++ b/app/controllers/RecipeController.scala
@@ -31,10 +31,13 @@ class RecipeController(
   def showRecipe(id: RecipeId) = AuthAction { implicit request =>
     Recipes.findById(id).fold[Result](NotFound) { recipe =>
       val bakes = Bakes.list(recipe.id)
+      val recentBakes = bakes.take(20)
+      val recentCopies = prismAgents.copiedImages(recentBakes.flatMap(_.amiId).map(_.value).toSet)
       Ok(
         views.html.showRecipe(
           recipe,
-          bakes.take(20),
+          recentBakes,
+          recentCopies,
           RecipeUsage(recipe, bakes)(prismAgents),
           Roles.list,
           debugAvailable

--- a/app/controllers/RecipeController.scala
+++ b/app/controllers/RecipeController.scala
@@ -38,6 +38,7 @@ class RecipeController(
           recipe,
           recentBakes,
           recentCopies,
+          prismAgents.accounts,
           RecipeUsage(recipe, bakes)(prismAgents),
           Roles.list,
           debugAvailable

--- a/app/prism/RecipeUsage.scala
+++ b/app/prism/RecipeUsage.scala
@@ -11,7 +11,12 @@ object RecipeUsage {
   def noUsage(): RecipeUsage = RecipeUsage(Seq.empty[Instance], Seq.empty[LaunchConfiguration])
 
   def apply(recipe: Recipe, bakes: Iterable[Bake])(implicit prismAgents: PrismAgents): RecipeUsage = {
-    val amiIds = bakes.flatMap(_.amiId.map(_.value)).toList
+    println(s"Finding usages for $recipe / $bakes")
+    val bakedAmiIds = bakes.flatMap(_.amiId.map(_.value)).toList
+    println(s"Got baked AMIs: $bakedAmiIds")
+    val copiedAmiIds = prismAgents.copiedImages(bakedAmiIds.toSet).values.flatten.map(_.imageId)
+    println(s"Got copied AMIs: $copiedAmiIds")
+    val amiIds = bakedAmiIds ++ copiedAmiIds
     val instances = prismAgents.allInstances.filter(instance => amiIds.contains(instance.imageId))
     val launchConfigurations = prismAgents.allLaunchConfigurations.filter(lc => amiIds.contains(lc.imageId))
     RecipeUsage(instances, launchConfigurations)

--- a/app/prism/RecipeUsage.scala
+++ b/app/prism/RecipeUsage.scala
@@ -11,11 +11,8 @@ object RecipeUsage {
   def noUsage(): RecipeUsage = RecipeUsage(Seq.empty[Instance], Seq.empty[LaunchConfiguration])
 
   def apply(recipe: Recipe, bakes: Iterable[Bake])(implicit prismAgents: PrismAgents): RecipeUsage = {
-    println(s"Finding usages for $recipe / $bakes")
     val bakedAmiIds = bakes.flatMap(_.amiId.map(_.value)).toList
-    println(s"Got baked AMIs: $bakedAmiIds")
     val copiedAmiIds = prismAgents.copiedImages(bakedAmiIds.toSet).values.flatten.map(_.imageId)
-    println(s"Got copied AMIs: $copiedAmiIds")
     val amiIds = bakedAmiIds ++ copiedAmiIds
     val instances = prismAgents.allInstances.filter(instance => amiIds.contains(instance.imageId))
     val launchConfigurations = prismAgents.allLaunchConfigurations.filter(lc => amiIds.contains(lc.imageId))

--- a/app/schedule/ScheduledBakeRunner.scala
+++ b/app/schedule/ScheduledBakeRunner.scala
@@ -1,13 +1,14 @@
 package schedule
 
-import data.{ Bakes, Recipes, Dynamo }
+import data.{ Bakes, Dynamo, Recipes }
 import event.EventBus
 import models.RecipeId
-import packer.{ PackerRunner, PackerConfig }
+import packer.{ PackerConfig, PackerRunner }
 import play.api.Logger
 import prism.Prism
+import services.PrismAgents
 
-class ScheduledBakeRunner(enabled: Boolean, prism: Prism, eventBus: EventBus, ansibleVars: Map[String, String])(implicit dynamo: Dynamo, packerConfig: PackerConfig) {
+class ScheduledBakeRunner(enabled: Boolean, prism: PrismAgents, eventBus: EventBus, ansibleVars: Map[String, String])(implicit dynamo: Dynamo, packerConfig: PackerConfig) {
 
   def bake(recipeId: RecipeId): Unit = {
     if (!enabled) {

--- a/app/views/showRecipe.scala.html
+++ b/app/views/showRecipe.scala.html
@@ -1,7 +1,9 @@
 @import data.Roles
+@import prism.Prism.Image
 @(
         recipe: Recipe,
         recentBakes: Iterable[Bake],
+        recentCopies: Map[String, Seq[Image]],
         usage: prism.RecipeUsage,
         allRoles: Seq[RoleSummary],
         debugAvailable: Boolean
@@ -76,6 +78,19 @@
             }
             </td>
           </tr>
+          @for(copy <- bake.amiId.flatMap(id => recentCopies.get(id.value)).getOrElse(Nil)){
+            <tr>
+              <td></td>
+              <td></td>
+              <td>@copy.state</td>
+              <td class="absolute-container">
+                <code id="ami-id">@copy.imageId</code>
+                <button class="btn btn-primary btn-xs absolute-right" title="Copy to clipboard" id="copy-button" data-clipboard-target="#ami-id">
+                  <img src="@routes.Assets.versioned("images/clippy.svg")" width="13" alt="Copy to clipboard">
+                </button>
+              </td>
+            </tr>
+          }
         }
         </tbody>
       </table>

--- a/app/views/showRecipe.scala.html
+++ b/app/views/showRecipe.scala.html
@@ -1,9 +1,11 @@
 @import data.Roles
 @import prism.Prism.Image
+@import prism.Prism.AWSAccount
 @(
         recipe: Recipe,
         recentBakes: Iterable[Bake],
         recentCopies: Map[String, Seq[Image]],
+        accounts: Seq[AWSAccount],
         usage: prism.RecipeUsage,
         allRoles: Seq[RoleSummary],
         debugAvailable: Boolean
@@ -60,6 +62,9 @@
         <thead>
           <th>Started</th>
           <th>Build number</th>
+          @if(recentCopies.nonEmpty) {
+            <th>Encrypted copy account</th>
+          }
           <th>Status</th>
           <th>AMI</th>
         </thead>
@@ -68,6 +73,9 @@
           <tr>
           <td class="has-block-link"><a class="block-link" href="@routes.BakeController.showBake(bake.recipe.id, bake.buildNumber)">@fragments.timestamp(bake.startedAt, bake.startedBy)</a></td>
           <td class="has-block-link"><a class="block-link" href="@routes.BakeController.showBake(bake.recipe.id, bake.buildNumber)">@bake.buildNumber</a></td>
+          @if(recentCopies.nonEmpty) {
+            <td class="has-block-link"></td>
+          }
           <td class="has-block-link"><a class="block-link" href="@routes.BakeController.showBake(bake.recipe.id, bake.buildNumber)">@bake.status</a></td>
             <td class="absolute-container has-block-link">
             @if(bake.amiId.isDefined) {
@@ -82,7 +90,10 @@
             <tr>
               <td></td>
               <td></td>
-              <td>@copy.state</td>
+              <td>@defining(accounts.find(_.accountNumber == copy.ownerId)){ maybeOwnerAcc =>
+                @maybeOwnerAcc.map{ ownerAcc => @ownerAcc.accountName (@ownerAcc.accountNumber) }.getOrElse(copy.ownerId)
+              }</td>
+              <td>@copy.state.capitalize</td>
               <td class="absolute-container">
                 <code id="ami-id">@copy.imageId</code>
                 <button class="btn btn-primary btn-xs absolute-right" title="Copy to clipboard" id="copy-button" data-clipboard-target="#ami-id">

--- a/app/views/showRecipe.scala.html
+++ b/app/views/showRecipe.scala.html
@@ -79,8 +79,8 @@
           <td class="has-block-link"><a class="block-link" href="@routes.BakeController.showBake(bake.recipe.id, bake.buildNumber)">@bake.status</a></td>
             <td class="absolute-container has-block-link">
             @if(bake.amiId.isDefined) {
-              <a class="block-link" href="@routes.BakeController.showBake(bake.recipe.id, bake.buildNumber)"><code id="ami-id">@bake.amiId</code></a>
-              <button class="btn btn-primary btn-xs absolute-right" title="Copy to clipboard" id="copy-button" data-clipboard-target="#ami-id">
+              <a class="block-link" href="@routes.BakeController.showBake(bake.recipe.id, bake.buildNumber)"><code>@bake.amiId</code></a>
+              <button class="btn btn-primary btn-xs absolute-right copy-button" title="Copy to clipboard" data-clipboard-text="@bake.amiId">
                 <img src="@routes.Assets.versioned("images/clippy.svg")" width="13" alt="Copy to clipboard">
               </button>
             }
@@ -95,8 +95,8 @@
               }</td>
               <td>@copy.state.capitalize</td>
               <td class="absolute-container">
-                <code id="ami-id">@copy.imageId</code>
-                <button class="btn btn-primary btn-xs absolute-right" title="Copy to clipboard" id="copy-button" data-clipboard-target="#ami-id">
+                <code>@copy.imageId</code>
+                <button class="btn btn-primary btn-xs absolute-right copy-button" title="Copy to clipboard" data-clipboard-text="@copy.imageId">
                   <img src="@routes.Assets.versioned("images/clippy.svg")" width="13" alt="Copy to clipboard">
                 </button>
               </td>
@@ -110,17 +110,11 @@
 
   <script src="@routes.Assets.versioned("javascripts/clipboard.min.js")"></script>
   <script>
-          var copy = document.getElementById('copy-button');
-          var clipboard = new Clipboard(copy);
-
-          copy.addEventListener('click', function (e) {
-            console.log('HAPPENING!')
-            e.preventDefault();
-          })
+          var clipboard = new Clipboard('.copy-button');
 
           clipboard.on('success', function(e) {
             console.log(e);
-            copy.classList.add('btn--success');
+            e.trigger.classList.add('btn--success');
           });
           clipboard.on('error', function(e) {
             console.log(e);

--- a/test/prism/PrismSpec.scala
+++ b/test/prism/PrismSpec.scala
@@ -5,7 +5,8 @@ import play.api.mvc.{ Action, Results }
 import play.api.test.WsTestClient
 import play.core.server.Server
 import play.api.routing.sird._
-import prism.Prism.{ Instance, LaunchConfiguration }
+import prism.Prism.{ AWSAccount, Instance, LaunchConfiguration }
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -32,8 +33,8 @@ class PrismSpec extends FlatSpec with Matchers {
 
   it should "fetch all AWS account numbers" in {
     withPrismClient { prism =>
-      val accounts = Await.result(prism.findAllAWSAccountNumbers(), 10.seconds)
-      accounts should be(Seq("1234", "5678"))
+      val accounts = Await.result(prism.findAllAWSAccounts(), 10.seconds)
+      accounts should be(Seq(AWSAccount("foo", "1234"), AWSAccount("bar", "5678")))
     }
   }
 


### PR DESCRIPTION
It's pretty confusing that the usage and bake history don't currently display copies of AMIs that are in other accounts. This fixes that by adding a little more magic to both of them.

For example the bake history now looks like this:
![screen shot 2018-02-09 at 18 36 45](https://user-images.githubusercontent.com/1236466/36043741-3bc8a3ac-0dc8-11e8-9984-e4f866d1f241.png)

As an added bonus I fixed the copy to clipboard functionality so that it works!

### So what changes have I made?
In short I've added a new prism agent that queries prism for all AMIs that have the `CopiedFromAMI` tag set. That is the tag that is set with the original AMI ID when the lambda kicks off a copy. This is then correlated with the list of AMIgo AMI IDs to create the list of copies.

In order to display human friendly accounts I've also expanded the data gathered from prism for accounts to include the name as well as number. This can then be used as a lookup table.