### PR TITLE
Use port 22 instead of 2022 on bastion host

### DIFF
--- a/roles/bastion-ssh/files/sshd_config
+++ b/roles/bastion-ssh/files/sshd_config
@@ -1,4 +1,4 @@
-Port 2022
+Port 22
 Protocol 2
 
 # Supported HostKey algorithms by order of preference.


### PR DESCRIPTION
See discussion here https://github.com/guardian/discussion-platform/pull/295

Not using the default ssh port for a bastion host is likely to reduce the frequency of attacks directed at the instance. However, as our bastions should already be limited to the guardian IP range I think it's reasonable to assume that anyone who's able to hit port 22 on them is motivated enough to try a few different ports.

Using port 2022 is a minor annoyance that we could avoid.