### PR TITLE
Sshd security

### DIFF
--- a/roles/ssh-deny-root/README.md
+++ b/roles/ssh-deny-root/README.md
@@ -1,0 +1,4 @@
+SSH Deny root
+=============
+
+This role ensures a line is present in the ssh config which denies access specifically for root.

--- a/roles/ssh-deny-root/tasks/main.yml
+++ b/roles/ssh-deny-root/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-- lineinfile:
+- name: "Deny root login over ssh"
+  lineinfile:
     path: /etc/ssh/sshd_config
     regexp: '^PermitRootLogin '
     line: 'PermitRootLogin no'

--- a/roles/ssh-deny-root/tasks/main.yml
+++ b/roles/ssh-deny-root/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^DenyUsers '
+    line: 'DenyUsers root'

--- a/roles/ssh-deny-root/tasks/main.yml
+++ b/roles/ssh-deny-root/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 - lineinfile:
     path: /etc/ssh/sshd_config
-    regexp: '^DenyUsers '
-    line: 'DenyUsers root'
+    regexp: '^PermitRootLogin '
+    line: 'PermitRootLogin no'

--- a/roles/ssh-ubuntu-only/README.md
+++ b/roles/ssh-ubuntu-only/README.md
@@ -1,0 +1,4 @@
+SSH Allow ubuntu
+================
+
+This role ensures a line is present in the ssh config which permits access specifically for ubunty ONLY.

--- a/roles/ssh-ubuntu-only/tasks/main.yml
+++ b/roles/ssh-ubuntu-only/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^AllowUsers '
+    line: 'AllowUsers ubuntu'

--- a/roles/ssh-ubuntu-only/tasks/main.yml
+++ b/roles/ssh-ubuntu-only/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-- lineinfile:
+- name: "Allow ONLY ubuntu over ssh"
+  lineinfile:
     path: /etc/ssh/sshd_config
     regexp: '^AllowUsers '
     line: 'AllowUsers ubuntu'

--- a/roles/ubuntu-init/meta/main.yml
+++ b/roles/ubuntu-init/meta/main.yml
@@ -3,3 +3,4 @@ dependencies:
   - apt
   - enhanced-networking
   - aws-tools
+  - ssh-deny-root


### PR DESCRIPTION
Two new roles:

Allow only ubuntu to ssh on to the box.  This is intended for teams who have adopted the ssm-scala approach to temporary ssh credentials.

Do not allow root to ssh on to the box.  This is a patch for a security risk and should be adopted everywhere.