### PR TITLE
Fix s3-ssh-keys role for when more than one team is declared

### DIFF
--- a/roles/s3-ssh-keys/templates/install-keys.sh.template
+++ b/roles/s3-ssh-keys/templates/install-keys.sh.template
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
+TEMPORARY_AGGREGATING_DIR=`mktemp -d`
+
 {# Coerce to list #}
 {% set prefixes = [ssh_keys_prefix] if ssh_keys_prefix is string else ssh_keys_prefix %}
 
 {% for prefix in prefixes %}
-    aws s3 cp s3://{{ssh_keys_bucket}}/{{prefix}}/authorized_keys /tmp/authorized_keys.{{prefix}}
-    cat /tmp/authorized_keys.{{prefix}} > /tmp/authorized_keys
+    aws s3 cp s3://{{ssh_keys_bucket}}/{{prefix}}/authorized_keys $TEMPORARY_AGGREGATING_DIR/authorized_keys.{{prefix}}
 {% endfor %}
 
-install -m 600 -o {{ssh_user}} /tmp/authorized_keys /home/{{ssh_user}}/.ssh/authorized_keys
+# We use awk here to ensure we put a new line between files when concatenating
+awk '{print $0}' $TEMPORARY_AGGREGATING_DIR/authorized_keys.* | sort | uniq > $TEMPORARY_AGGREGATING_DIR/all_authorized_keys
+
+install -m 600 -o {{ssh_user}} $TEMPORARY_AGGREGATING_DIR/all_authorized_keys /home/{{ssh_user}}/.ssh/authorized_keys


### PR DESCRIPTION
PR #180 introduced a new bug for the case when more than one team prefix is declared - the docs for `s3-ssh-keys` say this is supported:

```
ssh_keys_prefix: [Team-NameA, Team-NameB]
```

...but when overwrite (`>`) is used rather than append (`>>`) for concatenating together the keys of multiple teams this means that only the last team wins - the keys from all other teams are overwritten.

Instead in this commit we use a unique temporary aggregating directory, to allow us to join various key files together, without accumulating unwanted previous versions of the key data.

cc @amyhughes