### PR TITLE
Add friendly-hostnames role for giving servers human readable names

### DIFF
--- a/roles/friendly-hostnames/README.md
+++ b/roles/friendly-hostnames/README.md
@@ -1,0 +1,32 @@
+Friendly Hostnames
+===========
+
+Most servers are like 
+[cattle](https://devops.stackexchange.com/questions/653/what-is-the-definition-of-cattle-not-pets) 
+and it isn't necessary to name them. Sometimes you want to treat them more like a pet, giving them a human readable name.  
+Perhaps they hold data meaning there is a risk associated with indiscriminately killing them and replacing them with 
+another. You may benefit from knowing which server you have up at a given time.
+
+The feature sets the hostname for your server and applies an AWS "Name" tag. The name is chosen from a list of names, 
+defaulting to ~3000 names at `https://s3-eu-west-1.amazonaws.com/ophan-dist/ophan/elasticsearch/hostnames.txt`.
+        
+You will need to run the following script in your cloud init
+
+```
+/opt/features/friendly-hostnames/set-friendly-hostname.sh
+```
+
+A hostname will be chosen at random and formatted to a 
+[valid hostname](https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames), 
+only including the characters [^A-Za-z].  
+
+If you would like to override the default list and supply your own names you will need to specify your hostnames URL, 
+for example
+
+```
+hostnames_url: https://example.com/hostnames.txt
+```
+
+You might need to consider the [birthday problem](https://en.wikipedia.org/wiki/Birthday_problem) when choosing your 
+list size. For a cluster of size `s`, and a probability of `p` of a name clash (hopefully low, less than `0.05`), you'll
+need a hostnames list of length `s^2 / 2 * p`.

--- a/roles/friendly-hostnames/defaults/main.yml
+++ b/roles/friendly-hostnames/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+ssh_user: ubuntu
+hostnames_url: https://s3-eu-west-1.amazonaws.com/ophan-dist/ophan/elasticsearch/hostnames.txt

--- a/roles/friendly-hostnames/files/set-friendly-hostname.sh
+++ b/roles/friendly-hostnames/files/set-friendly-hostname.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+FRIENDLY_HOSTNAME=`iconv -f utf8 -t ascii//TRANSLIT /usr/share/hostnames | sed s/[^A-Za-z]*//g | awk 'length>4 && length<30' | shuf -n 1`
+
+echo "127.0.1.1 $FRIENDLY_HOSTNAME" >> /etc/hosts
+echo $FRIENDLY_HOSTNAME > /etc/hostname
+hostname $FRIENDLY_HOSTNAME
+rm /usr/share/hostnames
+
+INSTANCE_ID="`wget -qO- http://instance-data/latest/meta-data/instance-id`"
+REGION="`wget -qO- http://instance-data/latest/meta-data/placement/availability-zone | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:'`"
+
+aws ec2 --region $REGION create-tags --resources $INSTANCE_ID --tags Key=Name,Value=$FRIENDLY_HOSTNAME

--- a/roles/friendly-hostnames/meta/main.yml
+++ b/roles/friendly-hostnames/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - aws-tools

--- a/roles/friendly-hostnames/tasks/main.yml
+++ b/roles/friendly-hostnames/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Install friendly hostnames
+  get_url: url={{hostnames_url}} dest=/opt/features/friendly-hostnames/hostnames.txt mode="a+r"
+
+- name: Copy script for assigning hostnames and make executable
+  copy: src=set-friendly-hostname.sh dest=/opt/features/friendly-hostnames/set-friendly-hostname.sh mode="a+x"


### PR DESCRIPTION
The feature sets the hostname for your server and applies an AWS "Name" tag. The name is chosen from a list of names, defaulting to ~3000 names at 
```
https://s3-eu-west-1.amazonaws.com/ophan-dist/ophan/elasticsearch/hostnames.txt
```
