### PR TITLE
get latest chromedriver version in browser-testing role

### DIFF
--- a/roles/browser-testing/README.md
+++ b/roles/browser-testing/README.md
@@ -5,5 +5,5 @@ This feature installs Google Chrome, Chromedriver and the virtual frame buffer, 
 The install script does the following:
  - Installs Xvfb
  - Installs the latest version of Google Chrome and associated packages
- - Installs Chromedriver 2.21
+ - Installs latest Chromedriver version
  - Creates and enables an Xvfb service

--- a/roles/browser-testing/tasks/main.yml
+++ b/roles/browser-testing/tasks/main.yml
@@ -13,7 +13,7 @@
   shell: apt-get install -f -y
 
 - name: Download Chromedriver
-  shell: wget http://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE)/chromedriver_linux64.zip /tmp/chromedriver.zip
+  shell: wget http://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE)/chromedriver_linux64.zip -O /tmp/chromedriver.zip
 
 - name: Unzip Chromedriver
   unarchive: src=/tmp/chromedriver.zip dest=/usr/local/bin/

--- a/roles/browser-testing/tasks/main.yml
+++ b/roles/browser-testing/tasks/main.yml
@@ -13,7 +13,7 @@
   shell: apt-get install -f -y
 
 - name: Download Chromedriver
-  get_url: url=http://chromedriver.storage.googleapis.com/{{chromedriver_version}}/chromedriver_linux64.zip dest=/tmp/chromedriver.zip
+  shell: wget http://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE)/chromedriver_linux64.zip /tmp/chromedriver.zip
 
 - name: Unzip Chromedriver
   unarchive: src=/tmp/chromedriver.zip dest=/usr/local/bin/


### PR DESCRIPTION
locates the latest version from https://chromedriver.storage.googleapis.com/index.html rather than relying on parameters