### PR TITLE
Install logstash plugins from S3

### DIFF
--- a/roles/logstash-deb/README.md
+++ b/roles/logstash-deb/README.md
@@ -1,0 +1,21 @@
+# logstash-deb
+
+Install logstash and optionally install logstash plugins. 
+
+Basic use allows the version of logstash to be specified:
+
+```
+version: 6.1.1
+```
+
+You can additionally install plugins:
+
+```
+version: 6.1.1, plugins: [logstash-input-kinesis]
+```
+
+It is also possible to install plugins from gems in an S3 bucket (that is configured in the AMIgo configuration):
+
+```
+version: 6.1.1, s3_plugins: [logstash-input-kinesis-2.0.7.gem]
+```

--- a/roles/logstash-deb/tasks/main.yml
+++ b/roles/logstash-deb/tasks/main.yml
@@ -8,3 +8,11 @@
 - name: Install Logstash plugins
   command: "{{ ls_home }}/bin/logstash-plugin install {{ item }}"
   with_items: "{{ plugins | default([]) }}"
+
+- name: Download a plugin gem from an S3 bucket
+  command: /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}{{ item }} /tmp/{{ s3_bucket }}/{{ s3_prefix }}{{ item }}
+  with_items: "{{ s3_plugins|default([]) }}"
+
+- name: Install a plugin gem from an S3 bucket
+  command: "{{ ls_home }}/bin/logstash-plugin install /tmp/{{ s3_bucket }}/{{ s3_prefix }}{{ item }}"
+  with_items: "{{ s3_plugins|default([]) }}"


### PR DESCRIPTION
I've raised a PR against the `logstash-input-kinesis` plugin but until it is merged this provides a way to build an AMI with a custom plugin. The custom plugin is hosted in the amigo data S3 bucket and retrieved and installed from that location during build time.

This is much the same method that we use to install packages from S3.

This has been tested on AMIgo code and found working.