### PR TITLE
Allow access to this key from the default ASG service linked role

### DIFF
--- a/imageCopier/imageCopierKmsKey.yaml
+++ b/imageCopier/imageCopierKmsKey.yaml
@@ -18,6 +18,29 @@ Resources:
             AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
           Action: kms:*
           Resource: "*"
+        - Sid: Allow use of the key
+          Effect: Allow
+          Principal:
+            AWS:
+            - !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling
+          Action:
+          - kms:Encrypt
+          - kms:Decrypt
+          - kms:ReEncrypt*
+          - kms:GenerateDataKey*
+          - kms:DescribeKey
+          Resource: "*"
+        - Sid: Allow attachment of persistent resources
+          Effect: Allow
+          Principal:
+            AWS:
+            - !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling
+          Action:
+          - kms:CreateGrant
+          Resource: "*"
+          Condition:
+            Bool:
+              kms:GrantIsForAWSResource: true
 
 Outputs:
   AmigoImageCopierKey:


### PR DESCRIPTION
AWS are making changes to the way that ASGs gain access to other AWS resources. Of note an ASG used to be able to magically access any KMS CMK and this is no longer true. 

This change gives the default ASG Service Linked Role access to the KMS key that we are using to encrypt root volumes.