### PR TITLE
Exit immediately if we are unable to call describe-tags

### DIFF
--- a/roles/aws-await-tags/templates/await_tags.sh
+++ b/roles/aws-await-tags/templates/await_tags.sh
@@ -7,7 +7,7 @@ for i in {1..12}
 do
     NUM_TAGS=$(aws ec2 describe-tags --filters Name=resource-type,Values=instance Name=resource-id,Values=${INSTANCE_ID} --region eu-west-1 | jq ".Tags | length")
 
-    if [[ -z $NUM_TAGS ]]; then
+    if [[ -z "$NUM_TAGS" ]]; then
         echo "Unable to call describe tags. Exiting immediately"
         exit 255
     fi

--- a/roles/aws-await-tags/templates/await_tags.sh
+++ b/roles/aws-await-tags/templates/await_tags.sh
@@ -7,6 +7,11 @@ for i in {1..12}
 do
     NUM_TAGS=$(aws ec2 describe-tags --filters Name=resource-type,Values=instance Name=resource-id,Values=${INSTANCE_ID} --region eu-west-1 | jq ".Tags | length")
 
+    if [[ -z $NUM_TAGS ]]; then
+        echo "Unable to call describe tags. Exiting immediately"
+        exit 255
+    fi
+
     if (( $NUM_TAGS > 0 )); then
         echo "AWS tags loaded"
         exit 0


### PR DESCRIPTION
Facia uses the base role that has await tags in it but does not have permission in the CloudFormation to call describe-tags in the API. It doesn't need it since it injects the stack, app and stage through the launch configuration. Unfortunately, the script still waits a minute even though each call fails because it doesn't have permission.

This PR changes the script to exit early if we don't have permission. If we have permission but the tags are not yet present we get back an empty list so it still waits as expected.