### PR TITLE
Add a usage page for recipes

### DIFF
--- a/app/controllers/RecipeController.scala
+++ b/app/controllers/RecipeController.scala
@@ -8,7 +8,7 @@ import play.api.data.{ Form, Mapping }
 import play.api.data.Forms._
 import play.api.i18n.{ I18nSupport, MessagesApi }
 import play.api.mvc._
-import prism.RecipeUsage
+import prism.{ Prism, RecipeUsage }
 import schedule.BakeScheduler
 import services.PrismAgents
 
@@ -113,6 +113,21 @@ class RecipeController(
             }
         }
     })
+  }
+
+  def showUsages(id: RecipeId) = AuthAction { implicit request =>
+    Recipes.findById(id).fold[Result](NotFound) { recipe =>
+      val bakes = Bakes.list(recipe.id)
+      val recipeUsage: RecipeUsage = RecipeUsage(recipe, bakes)(prismAgents)
+      Ok(
+        views.html.showUsage(
+          recipe,
+          recipeUsage.bakeUsage,
+          prismAgents.accounts,
+          prismAgents.baseUrl
+        )
+      )
+    }
   }
 
 }

--- a/app/prism/RecipeUsage.scala
+++ b/app/prism/RecipeUsage.scala
@@ -1,22 +1,45 @@
 package prism
 
+import akka.stream.scaladsl.Source
 import models.{ Bake, Recipe, RecipeId }
-import prism.Prism.{ Instance, LaunchConfiguration }
+import prism.Prism.{ Image, Instance, LaunchConfiguration }
 import services.PrismAgents
 
-case class RecipeUsage(instances: Seq[Instance], launchConfigurations: Seq[LaunchConfiguration])
+case class BakeUsage(amiId: String, bake: Bake, viaCopy: Option[Image], instances: Seq[Instance], launchConfigurations: Seq[LaunchConfiguration])
+
+case class RecipeUsage(instances: Seq[Instance], launchConfigurations: Seq[LaunchConfiguration], bakeUsage: Seq[BakeUsage])
 
 object RecipeUsage {
 
-  def noUsage(): RecipeUsage = RecipeUsage(Seq.empty[Instance], Seq.empty[LaunchConfiguration])
+  def noUsage(): RecipeUsage = RecipeUsage(Seq.empty[Instance], Seq.empty[LaunchConfiguration], Seq.empty[BakeUsage])
 
   def apply(recipe: Recipe, bakes: Iterable[Bake])(implicit prismAgents: PrismAgents): RecipeUsage = {
-    val bakedAmiIds = bakes.flatMap(_.amiId.map(_.value)).toList
-    val copiedAmiIds = prismAgents.copiedImages(bakedAmiIds.toSet).values.flatten.map(_.imageId)
+    val bakedAmiLookupMap = bakes.flatMap(b => b.amiId.map(_.value -> b)).toMap
+    val bakedAmiIds = bakedAmiLookupMap.keys.toList
+    val copiedAmis = prismAgents.copiedImages(bakedAmiIds.toSet).values.flatten
+    val copiedAmiIds = copiedAmis.map(_.imageId)
+
     val amiIds = bakedAmiIds ++ copiedAmiIds
     val instances = prismAgents.allInstances.filter(instance => amiIds.contains(instance.imageId))
     val launchConfigurations = prismAgents.allLaunchConfigurations.filter(lc => amiIds.contains(lc.imageId))
-    RecipeUsage(instances, launchConfigurations)
+    val amis = (instances.map(_.imageId) ++ launchConfigurations.map(_.imageId)).distinct
+
+    val copiedAmiLookupMap = copiedAmis.map { image => image.imageId -> image }.toMap
+
+    val bakeUsage = amis.map { ami =>
+      val maybeDirectBake = bakedAmiLookupMap.get(ami)
+      val maybeCopy = copiedAmiLookupMap.get(ami)
+      val bake = (maybeDirectBake, maybeCopy) match {
+        case (Some(directBake), None) => directBake
+        case (None, Some(copy)) => bakedAmiLookupMap(copy.copiedFromAMI)
+        case _ => throw new IllegalArgumentException("AMI ID provided neither direct nor copied")
+      }
+      val amiInstances = instances.filter(_.imageId == ami)
+      val amiLc = launchConfigurations.filter(_.imageId == ami)
+      BakeUsage(ami, bake, maybeCopy, amiInstances, amiLc)
+    }
+
+    RecipeUsage(instances, launchConfigurations, bakeUsage)
   }
 
   def forAll(recipes: Iterable[Recipe], findBakes: RecipeId => Iterable[Bake])(implicit prismAgents: PrismAgents): Map[Recipe, RecipeUsage] = {

--- a/app/services/PrismAgents.scala
+++ b/app/services/PrismAgents.scala
@@ -22,6 +22,8 @@ class PrismAgents(prism: Prism,
   private val copiedImagesAgent: Agent[Map[String, Seq[Image]]] = Agent(Map.empty)
   private val accountsAgent: Agent[Seq[AWSAccount]] = Agent(Seq.empty)
 
+  val baseUrl: String = prism.baseUrl
+
   def allInstances: Seq[Instance] = instancesAgent.get
   def allLaunchConfigurations: Seq[LaunchConfiguration] = launchConfigurationsAgent.get
   def copiedImages(sourceAmiIds: Set[String]): Map[String, Seq[Image]] = copiedImagesAgent.get.filterKeys(sourceAmiIds.contains)

--- a/app/views/recipes.scala.html
+++ b/app/views/recipes.scala.html
@@ -28,10 +28,12 @@
         <td class="has-block-link"><a href="@routes.RecipeController.showRecipe(recipe.id)" class="block-link">@recipe.description</a></td>
         @defining(usages.getOrElse(recipe, prism.RecipeUsage.noUsage)) { usage =>
         <td class="recipe-usage" title="Used in @usage.instances.size instance@if(usage.instances.size != 1){s} and @usage.launchConfigurations.size launch configuration@if(usage.launchConfigurations.size != 1){s}">
-            <img src="@routes.Assets.versioned("images/computer.svg")" width="16" alt="Instances" />
-            <span>@usage.instances.size</span>
-            <img src="@routes.Assets.versioned("images/spanner.svg")" width="14" alt="Launch Configurations" />
-            <span>@usage.launchConfigurations.size</span>
+            <a href="@routes.RecipeController.showUsages(recipe.id)">
+              <img src="@routes.Assets.versioned("images/computer.svg")" width="16" alt="Instances" />
+              <span>@usage.instances.size</span>
+              <img src="@routes.Assets.versioned("images/spanner.svg")" width="14" alt="Launch Configurations" />
+              <span>@usage.launchConfigurations.size</span>
+            </a>
         </td>
         }
       </tr>

--- a/app/views/showRecipe.scala.html
+++ b/app/views/showRecipe.scala.html
@@ -9,7 +9,7 @@
         usage: prism.RecipeUsage,
         allRoles: Seq[RoleSummary],
         debugAvailable: Boolean
-)(implicit flash: Flash),
+)(implicit flash: Flash)
 @simpleLayout("AMIgo"){
 
   <h1>@recipe.id.value</h1>
@@ -32,7 +32,7 @@
       <p>Request encrypted copy: @if(recipe.encryptFor.nonEmpty){ @recipe.encryptFor.map(_.accountNumber).mkString(", ") }else{ None }</p>
       <p>@recipe.description</p>
       @if(usage.instances.size + usage.launchConfigurations.size > 0) {
-        <p>This recipe is used by @usage.instances.size instance@if(usage.instances.size != 1){s} and @usage.launchConfigurations.size launch configuration@if(usage.launchConfigurations.size != 1){s}</p>
+        <p>This recipe is used by <a href="@routes.RecipeController.showUsages(recipe.id)">@usage.instances.size instance@if(usage.instances.size != 1){s} and @usage.launchConfigurations.size launch configuration@if(usage.launchConfigurations.size != 1){s}</a></p>
       } else {
         <p><b>This recipe is not used</b></p>
       }
@@ -63,7 +63,7 @@
           <th>Started</th>
           <th>Build number</th>
           @if(recentCopies.nonEmpty) {
-            <th>Encrypted copy account</th>
+            <th>Encrypted copy</th>
           }
           <th>Status</th>
           <th>AMI</th>
@@ -89,10 +89,16 @@
           @for(copy <- bake.amiId.flatMap(id => recentCopies.get(id.value)).getOrElse(Nil)){
             <tr>
               <td></td>
-              <td></td>
-              <td>@defining(accounts.find(_.accountNumber == copy.ownerId)){ maybeOwnerAcc =>
-                @maybeOwnerAcc.map{ ownerAcc => @ownerAcc.accountName (@ownerAcc.accountNumber) }.getOrElse(copy.ownerId)
-              }</td>
+              <td>  </td>
+              <td><ul class="list-unstyled">
+                <li>Acc: @defining(accounts.find(_.accountNumber == copy.ownerId)){ maybeOwnerAcc =>
+                  @maybeOwnerAcc.map{ ownerAcc => @ownerAcc.accountName (@ownerAcc.accountNumber) }.getOrElse(copy.ownerId)
+                }</li>
+                @copy.encrypted.map{e =>
+                  <li>Encrypted tag: @e</li>
+                }
+              </ul>
+              </td>
               <td>@copy.state.capitalize</td>
               <td class="absolute-container">
                 <code>@copy.imageId</code>

--- a/app/views/showUsage.scala.html
+++ b/app/views/showUsage.scala.html
@@ -1,0 +1,95 @@
+@import data.Roles
+@import prism.BakeUsage
+@import prism.Prism.AWSAccount
+@(
+        recipe: Recipe,
+        bakeUsage: Seq[BakeUsage],
+        accounts: Seq[AWSAccount],
+        prismBaseUrl: String
+)(implicit flash: Flash)
+@simpleLayout("AMIgo"){
+
+    <h1>Usages of @recipe.id.value</h1>
+
+    @if(bakeUsage.isEmpty) {
+        <h4>No usages of this recipe found</h4>
+    } else {
+    <table class="table table-striped table-hover">
+        <thead>
+            <th>Build</th>
+            <th>Encrypted copy?</th>
+            <th>Usages</th>
+            <th>AMI</th>
+        </thead>
+        <tbody>
+            @bakeUsage.sortBy(bu => (bu.bake.startedAt.getMillis, bu.viaCopy.map(_.imageId))).map { usage =>
+                <tr>
+                    <td class="has-block-link">
+                        <a class="block-link" href="@routes.BakeController.showBake(usage.bake.recipe.id, usage.bake.buildNumber)">
+                            <ul class="list-unstyled">
+                                <li>@usage.bake.buildNumber</li>
+                                <li>@usage.bake.startedAt.toString("yyyy-MM-dd HH:mm:ss")</li>
+                            </ul>
+                        </a>
+                    </td>
+                    <td>
+                        @usage.viaCopy.map { viaCopy =>
+                            <ul class="list-unstyled">
+                                <li>Acc: @defining(accounts.find(_.accountNumber == viaCopy.ownerId)){ maybeOwnerAcc =>
+                                    @maybeOwnerAcc.map{ ownerAcc => @ownerAcc.accountName (@ownerAcc.accountNumber) }.getOrElse(viaCopy.ownerId)
+                                }</li>
+                                @viaCopy.encrypted.map{e =>
+                                    <li>Encrypted tag: @e</li>
+                                }
+                            </ul>
+                        }
+                    </td>
+                    <td>
+                        <ul>
+                           @usage.instances.map { instance =>
+                               <li class="list-unstyled">
+                                   <img src="@routes.Assets.versioned("images/computer.svg")" width="16" alt="Instance" />
+                                   <a href="@prismBaseUrl/instances?instanceName=@instance.name">@instance.name</a>
+                                   (in @instance.awsAccount.accountName)
+                               </li>
+                           }
+                           @usage.launchConfigurations.map { launchConfiguration =>
+                               <li class="list-unstyled">
+                                   <img src="@routes.Assets.versioned("images/spanner.svg")" width="14" alt="Launch Configurations" />
+                                   <a href="@prismBaseUrl/launch-configurations?name=@launchConfiguration.name">@launchConfiguration.name</a>
+                                   (in @launchConfiguration.awsAccount.accountName)
+                               </li>
+                           }
+                        </ul>
+                    </td>
+                    <td class="absolute-container">
+                    @if(usage.bake.amiId.isDefined) {
+                        <a href="@routes.BakeController.showBake(usage.bake.recipe.id, usage.bake.buildNumber)"><code>@usage.bake.amiId</code></a>
+                        <button class="btn btn-primary btn-xs copy-button" title="Copy to clipboard" data-clipboard-text="@usage.bake.amiId">
+                            <img src="@routes.Assets.versioned("images/clippy.svg")" width="13" alt="Copy to clipboard">
+                        </button>
+                    }
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+    }
+
+    <script src="@routes.Assets.versioned("javascripts/clipboard.min.js")"></script>
+    <script>
+            var clipboard = new Clipboard('.copy-button');
+
+            clipboard.on('success', function(e) {
+                console.log(e);
+                e.trigger.classList.add('btn--success');
+            });
+            clipboard.on('error', function(e) {
+                console.log(e);
+                //TODO: Add tooltip
+            });
+
+    </script>
+
+        <!-- TODO listen to bake events and update the bakes list accordingly -->
+}

--- a/conf/routes
+++ b/conf/routes
@@ -23,6 +23,8 @@ GET     /recipes/:id                controllers.RecipeController.showRecipe(id: 
 GET     /recipes/:id/edit           controllers.RecipeController.editRecipe(id: RecipeId)
 POST    /recipes/:id/edit           controllers.RecipeController.updateRecipe(id: RecipeId)
 
+GET     /recipes/:id/usages         controllers.RecipeController.showUsages(id: RecipeId)
+
 POST    /recipes/:id/bake                               controllers.BakeController.startBaking(id: RecipeId, debug: Boolean ?= false)
 GET     /recipes/:recipeId/bakes/:buildNumber           controllers.BakeController.showBake(recipeId: RecipeId, buildNumber: Int)
 GET     /recipes/:recipeId/bakes/:buildNumber/events    controllers.BakeController.bakeEvents(recipeId: models.RecipeId, buildNumber: Int)

--- a/test/prism/PrismSpec.scala
+++ b/test/prism/PrismSpec.scala
@@ -41,14 +41,20 @@ class PrismSpec extends FlatSpec with Matchers {
   it should "fetch all instances" in {
     withPrismClient { prism =>
       val instances = Await.result(prism.findAllInstances(), 10.seconds)
-      instances should be(Seq(Instance("ami-fa123456"), Instance("ami-abcd4321")))
+      instances should be(Seq(
+        Instance("i-123456", "ami-fa123456", AWSAccount("MyAccount", "1234567890")),
+        Instance("i-b123456", "ami-abcd4321", AWSAccount("MyAccount", "1234567890"))
+      ))
     }
   }
 
   it should "fetch all launch configurations" in {
     withPrismClient { prism =>
       val launchConfigurations = Await.result(prism.findAllLaunchConfigurations(), 10.seconds)
-      launchConfigurations should be(Seq(LaunchConfiguration("ami-abcdefg1"), LaunchConfiguration("ami-gfedcba2")))
+      launchConfigurations should be(Seq(
+        LaunchConfiguration("MyName", "ami-abcdefg1", AWSAccount("MyAccount", "1234567890")),
+        LaunchConfiguration("MyId", "ami-gfedcba2", AWSAccount("MyAccount", "1234567890"))
+      ))
     }
   }
 


### PR DESCRIPTION
The usage information in AMIgo is not surfaced in a particularly friendly way. As a first step towards automatically cleaning up AMIs, this adds pages that break down exactly where a particular recipe is used.

Main features:
 - Linked to from the recipe index / recipe page
 - Identifies copies to alternate accounts
 - Shows instances and launch configurations
 - Links from instances / launch configurations go to the prism API (not very friendly, but better than nothing)

![screen shot 2018-07-05 at 19 55 49](https://user-images.githubusercontent.com/1236466/42342371-c70d64d8-808d-11e8-8132-d050f6ab171d.png)
