### PR TITLE
Add recipe deletion capabilities to AMIgo

### DIFF
--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -12,10 +12,10 @@ class AppLoader extends ApplicationLoader {
     val components = new AppComponents(context)
 
     Logger.info("Starting the scheduler")
-    components.bakeScheduler.start()
+    components.scheduler.start()
     components.applicationLifecycle.addStopHook { () =>
       println("Shutting down scheduler")
-      Future.successful(components.bakeScheduler.shutdown())
+      Future.successful(components.scheduler.shutdown())
     }
 
     components.application

--- a/app/controllers/RecipeController.scala
+++ b/app/controllers/RecipeController.scala
@@ -152,7 +152,11 @@ class RecipeController(
         val amisToDelete = RecipeUsage.allAmis(bakes, amigoAccount)(prismAgents)
         // send messages to delete them
         notificationSender.sendHousekeepingTopicMessage(amisToDelete)
-        // delete the recipe
+        // delete the AMIgo data
+        bakes.foreach { bake =>
+          BakeLogs.delete(bake.bakeId)
+          Bakes.deleteById(bake.bakeId)
+        }
         Recipes.delete(recipe)
         // redirect back to the index page
         Redirect(routes.RecipeController.listRecipes())

--- a/app/data/BakeLogs.scala
+++ b/app/data/BakeLogs.scala
@@ -35,6 +35,8 @@ object BakeLogs {
     } yield unprocessedItem
     if (unprocessedItems.nonEmpty) {
       Logger.warn(s"${unprocessedItems.size} log entries not processed during deletion, trying again - attempt $attempt")
+      // avoid overwhelming the DB by pausing briefly before mopping up
+      Thread.sleep(2000)
       delete(bakeId, attempt + 1)
     } else {
       0

--- a/app/data/BakeLogs.scala
+++ b/app/data/BakeLogs.scala
@@ -2,6 +2,10 @@ package data
 
 import com.gu.scanamo.syntax._
 import models._
+import play.api.Logger
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
 
 object BakeLogs {
   import cats.syntax.either._
@@ -18,10 +22,23 @@ object BakeLogs {
     table.query('bakeId -> bakeId).exec().flatMap(_.toOption)
   }
 
-  def delete(bakeId: BakeId)(implicit dynamo: Dynamo): Unit = {
+  @tailrec
+  def delete(bakeId: BakeId, attempt: Int = 0)(implicit dynamo: Dynamo): Int = {
     val logNumbers: Seq[Int] = table.query('bakeId -> bakeId).exec().flatMap(_.toOption).map(_.logNumber)
     val uniqueKeyTuples: Set[(BakeId, Int)] = logNumbers.map((bakeId, _)).toSet
     val result = table.deleteAll((HashAndRangeKeyNames('bakeId, 'logNumber), uniqueKeyTuples)).exec()
+    val unprocessedItems = for {
+      batchResult <- result
+      unprocessedItemsMap = batchResult.getUnprocessedItems.asScala
+      unprocessedItems = unprocessedItemsMap.values.flatMap(_.asScala)
+      unprocessedItem <- unprocessedItems
+    } yield unprocessedItem
+    if (unprocessedItems.nonEmpty) {
+      Logger.warn(s"${unprocessedItems.size} log entries not processed during deletion, trying again - attempt $attempt")
+      delete(bakeId, attempt + 1)
+    } else {
+      0
+    }
   }
 
   private def table(implicit dynamo: Dynamo) = dynamo.Tables.bakeLogs.table

--- a/app/data/BakeLogs.scala
+++ b/app/data/BakeLogs.scala
@@ -1,11 +1,11 @@
 package data
 
-import models._
 import com.gu.scanamo.syntax._
+import models._
 
 object BakeLogs {
-  import Dynamo._
   import cats.syntax.either._
+  import Dynamo._
 
   def save(bakeLog: BakeLog)(implicit dynamo: Dynamo): Unit = {
     // Make sure we don't try to save an empty string to Dynamo
@@ -16,6 +16,12 @@ object BakeLogs {
 
   def list(bakeId: BakeId)(implicit dynamo: Dynamo): Iterable[BakeLog] = {
     table.query('bakeId -> bakeId).exec().flatMap(_.toOption)
+  }
+
+  def delete(bakeId: BakeId)(implicit dynamo: Dynamo): Unit = {
+    val logNumbers: Seq[Int] = table.query('bakeId -> bakeId).exec().flatMap(_.toOption).map(_.logNumber)
+    val uniqueKeyTuples: Set[(BakeId, Int)] = logNumbers.map((bakeId, _)).toSet
+    val result = table.deleteAll((HashAndRangeKeyNames('bakeId, 'logNumber), uniqueKeyTuples)).exec()
   }
 
   private def table(implicit dynamo: Dynamo) = dynamo.Tables.bakeLogs.table

--- a/app/data/Bakes.scala
+++ b/app/data/Bakes.scala
@@ -9,7 +9,7 @@ object Bakes {
   import cats.syntax.either._
 
   def create(recipe: Recipe, buildNumber: Int, startedBy: String)(implicit dynamo: Dynamo): Bake = {
-    val bake = Bake(recipe, buildNumber, status = BakeStatus.Running, amiId = None, startedBy = startedBy, startedAt = DateTime.now())
+    val bake = Bake(recipe, buildNumber, status = BakeStatus.Running, amiId = None, startedBy = startedBy, startedAt = DateTime.now(), deleted = false)
     val dbModel = Bake.domain2db(bake)
     table.put(dbModel).exec()
     bake
@@ -59,6 +59,25 @@ object Bakes {
     } yield {
       Bake.db2domain(model, r)
     }
+  }
+
+  def markToDelete(bakeId: BakeId)(implicit dynamo: Dynamo): Unit = {
+    table
+      .given(attributeExists('recipeId) and attributeExists('buildNumber))
+      .update(
+        ('recipeId -> bakeId.recipeId) and ('buildNumber -> bakeId.buildNumber),
+        set('deleted -> true)
+      )
+      .exec()
+  }
+
+  def findDeleted(limit: Int = 10)(implicit dynamo: Dynamo): List[Bake.DbModel] = {
+    table
+      .filter('deleted -> true)
+      .limit(limit)
+      .scan()
+      .exec()
+      .flatMap(_.toOption)
   }
 
   def deleteById(bakeId: BakeId)(implicit dynamo: Dynamo): Unit = {

--- a/app/data/Bakes.scala
+++ b/app/data/Bakes.scala
@@ -61,6 +61,10 @@ object Bakes {
     }
   }
 
+  def deleteById(bakeId: BakeId)(implicit dynamo: Dynamo): Unit = {
+    table.delete(('recipeId -> bakeId.recipeId) and ('buildNumber -> bakeId.buildNumber)).exec()
+  }
+
   private def table(implicit dynamo: Dynamo) = dynamo.Tables.bakes.table
 
 }

--- a/app/data/Recipes.scala
+++ b/app/data/Recipes.scala
@@ -6,6 +6,7 @@ import org.joda.time.DateTime
 import com.gu.scanamo.syntax._
 import cats.syntax.either._
 import com.gu.scanamo.error.DynamoReadError
+import com.gu.scanamo.query.UniqueKey
 import models.Recipe.DbModel
 
 import scala.collection.JavaConverters._
@@ -64,6 +65,10 @@ object Recipes {
 
     val update = table.update('id -> recipe.id, updateExpr)
     update.exec().map(Recipe.db2domain(_, baseImage))
+  }
+
+  def delete(recipe: Recipe)(implicit dynamo: Dynamo): DeleteItemResult = {
+    table.delete('id -> recipe.id.value).exec()
   }
 
   def findById(id: RecipeId)(implicit dynamo: Dynamo): Option[Recipe] = {

--- a/app/housekeeping/BakeDeletion.scala
+++ b/app/housekeeping/BakeDeletion.scala
@@ -1,0 +1,47 @@
+package housekeeping
+
+import data.{ BakeLogs, Bakes, Dynamo }
+import models.BakeId
+import notification.NotificationSender
+import org.quartz.SimpleScheduleBuilder
+import play.api.Logger
+import prism.RecipeUsage
+import services.PrismAgents
+
+/*
+  This class deletes bakes that have been marked deleted
+ */
+class BakeDeletion(dynamo: Dynamo,
+    amigoAwsAccount: String,
+    prismAgents: PrismAgents,
+    notificationSender: NotificationSender) extends HousekeepingJob {
+
+  implicit private val implDynamo: Dynamo = dynamo
+  implicit private val implPrismAgents: PrismAgents = prismAgents
+
+  override val schedule = SimpleScheduleBuilder.repeatMinutelyForever(1)
+
+  def housekeep(): Unit = {
+    Logger.info(s"Started bake deletion housekeeping")
+
+    // get some bakes that have been deleted
+    val deletedBakes = Bakes.findDeleted()
+
+    Logger.info(s"Found ${deletedBakes.size} bakes to delete")
+
+    // delete any AMIs
+    val amis = deletedBakes.flatMap(_.amiId)
+    val allAmis = RecipeUsage.allAmis(amis, amigoAwsAccount)
+    notificationSender.sendHousekeepingTopicMessage(allAmis)
+
+    // delete the logs and bakes
+    deletedBakes.foreach { bake =>
+      val bakeId = BakeId(bake.recipeId, bake.buildNumber)
+      Logger.info(s"Deleting $bakeId")
+      BakeLogs.delete(bakeId)
+      Bakes.deleteById(bakeId)
+      // avoid overwhelming the DB by pausing briefly before the next one
+      Thread.sleep(2000)
+    }
+  }
+}

--- a/app/housekeeping/HousekeepingJob.scala
+++ b/app/housekeeping/HousekeepingJob.scala
@@ -1,0 +1,14 @@
+package housekeeping
+
+import org.quartz._
+
+trait HousekeepingJob {
+  val schedule: ScheduleBuilder[_ <: Trigger]
+
+  val name: String = getClass.getName
+
+  val jobKey = new JobKey(name)
+  val triggerKey = new TriggerKey(name)
+
+  def housekeep(): Unit
+}

--- a/app/housekeeping/HousekeepingJobWrapper.scala
+++ b/app/housekeeping/HousekeepingJobWrapper.scala
@@ -1,0 +1,20 @@
+package housekeeping
+
+import org.quartz.{ DisallowConcurrentExecution, Job, JobDataMap, JobExecutionContext }
+
+/** Quartz job wrapper for [[schedule.ScheduledBakeRunner]] */
+@DisallowConcurrentExecution
+class HousekeepingJobWrapper extends Job {
+
+  private def getAs[T](key: String)(implicit jobDataMap: JobDataMap): T = jobDataMap.get(key).asInstanceOf[T]
+
+  override def execute(context: JobExecutionContext): Unit = {
+    implicit val jobDataMap: JobDataMap = context.getJobDetail.getJobDataMap
+
+    val housekeepingJob = getAs[HousekeepingJob](HousekeepingScheduler.HousekeepingJobInstance)
+
+    housekeepingJob.housekeep()
+  }
+
+}
+

--- a/app/housekeeping/HousekeepingScheduler.scala
+++ b/app/housekeeping/HousekeepingScheduler.scala
@@ -1,0 +1,32 @@
+package housekeeping
+
+import org.quartz.{ JobDataMap, Scheduler }
+import org.quartz.JobBuilder._
+import org.quartz.TriggerBuilder._
+
+class HousekeepingScheduler(scheduler: Scheduler, housekeepingJobs: List[HousekeepingJob]) {
+
+  def initialise(): Unit = {
+    housekeepingJobs.foreach { housekeepingJob =>
+      val jobDetail = newJob(classOf[HousekeepingJobWrapper])
+        .withIdentity(housekeepingJob.jobKey)
+        .usingJobData(buildJobDataMap(housekeepingJob))
+        .build()
+      val trigger = newTrigger()
+        .withIdentity(housekeepingJob.triggerKey)
+        .withSchedule(housekeepingJob.schedule)
+        .build()
+      scheduler.scheduleJob(jobDetail, trigger)
+    }
+  }
+
+  private def buildJobDataMap(housekeepingJob: HousekeepingJob): JobDataMap = {
+    val map = new JobDataMap()
+    map.put(HousekeepingScheduler.HousekeepingJobInstance, housekeepingJob)
+    map
+  }
+}
+
+object HousekeepingScheduler {
+  val HousekeepingJobInstance = "HousekeepingJobInstance"
+}

--- a/app/models/Bake.scala
+++ b/app/models/Bake.scala
@@ -7,7 +7,8 @@ case class Bake(recipe: Recipe,
     status: BakeStatus,
     amiId: Option[AmiId],
     startedBy: String,
-    startedAt: DateTime) {
+    startedAt: DateTime,
+    deleted: Boolean) {
   val bakeId = BakeId(recipe.id, buildNumber)
 }
 
@@ -19,14 +20,15 @@ object Bake {
     status: BakeStatus,
     amiId: Option[AmiId],
     startedBy: String,
-    startedAt: DateTime)
+    startedAt: DateTime,
+    deleted: Option[Boolean])
 
   import automagic._
 
   def domain2db(bake: Bake): DbModel =
-    transform[Bake, Bake.DbModel](bake, "recipeId" -> bake.recipe.id)
+    transform[Bake, Bake.DbModel](bake, "recipeId" -> bake.recipe.id, "deleted" -> Some(bake.deleted))
 
   def db2domain(dbModel: DbModel, recipe: Recipe): Bake =
-    transform[Bake.DbModel, Bake](dbModel, "recipe" -> recipe)
+    transform[Bake.DbModel, Bake](dbModel, "recipe" -> recipe, "deleted" -> dbModel.deleted.getOrElse(false))
 
 }

--- a/app/notification/NotificationSender.scala
+++ b/app/notification/NotificationSender.scala
@@ -1,11 +1,12 @@
 package notification
 
 import com.amazonaws.services.sns.model.PublishRequest
-import models.{ AmiId, Bake, Recipe }
+import models.{ AmiId, Bake }
 import models.packer.PackerVariablesConfig
 import _root_.packer.ImageDetails
 import play.api.Logger
 import play.api.libs.json.Json
+import prism.Ami
 
 class NotificationSender(sns: SNS, region: String, stage: String) {
   def sendTopicMessage(bake: Bake, amiId: AmiId): Unit = {
@@ -22,5 +23,16 @@ class NotificationSender(sns: SNS, region: String, stage: String) {
     val messageStr = Json.stringify(message)
     Logger.info(s"Sending message to topic ${sns.topicArn}: $messageStr")
     sns.client.publish(new PublishRequest().withTopicArn(sns.topicArn).withMessage(messageStr))
+  }
+
+  def sendHousekeepingTopicMessage(amisToDelete: List[Ami]): Unit = {
+    implicit val writes = Json.writes[Ami]
+    // don't overwhelm the receiver with more than 10 AMIs per message
+    amisToDelete.grouped(10).foreach { batchToDelete =>
+      val message = Json.obj("amis" -> batchToDelete)
+      val messageStr = Json.stringify(message)
+      Logger.info(s"Sending message to topic ${sns.housekeepingTopicArn}: $messageStr")
+      sns.client.publish(new PublishRequest().withTopicArn(sns.housekeepingTopicArn).withMessage(messageStr))
+    }
   }
 }

--- a/app/prism/RecipeUsage.scala
+++ b/app/prism/RecipeUsage.scala
@@ -1,12 +1,12 @@
 package prism
 
-import models.{ Bake, Recipe, RecipeId }
+import models.{ AmiId, Bake, Recipe, RecipeId }
 import prism.Prism.{ Image, Instance, LaunchConfiguration }
 import services.PrismAgents
 
-case class Ami(account: String, id: String)
+case class Ami(account: String, id: AmiId)
 
-case class BakeUsage(amiId: String, bake: Bake, viaCopy: Option[Image], instances: Seq[Instance], launchConfigurations: Seq[LaunchConfiguration])
+case class BakeUsage(amiId: AmiId, bake: Bake, viaCopy: Option[Image], instances: Seq[Instance], launchConfigurations: Seq[LaunchConfiguration])
 
 case class RecipeUsage(instances: Seq[Instance], launchConfigurations: Seq[LaunchConfiguration], bakeUsage: Seq[BakeUsage])
 
@@ -14,19 +14,17 @@ object RecipeUsage {
 
   def noUsage(): RecipeUsage = RecipeUsage(Seq.empty[Instance], Seq.empty[LaunchConfiguration], Seq.empty[BakeUsage])
 
-  def allAmis(bakes: Iterable[Bake], amigoAccount: String)(implicit prismAgents: PrismAgents): List[Ami] = {
-    val bakedAmiLookupMap = bakes.flatMap(b => b.amiId.map(_.value -> b)).toMap
-    val bakedAmiIds = bakedAmiLookupMap.keys.toList
-    val bakedAmis = bakedAmiIds.map(Ami(amigoAccount, _))
+  def allAmis(amiIds: Iterable[AmiId], amigoAccount: String)(implicit prismAgents: PrismAgents): List[Ami] = {
+    val amis = amiIds.map(Ami(amigoAccount, _))
 
-    val copiedAmiImages = prismAgents.copiedImages(bakedAmiIds.toSet).values.flatten
+    val copiedAmiImages = prismAgents.copiedImages(amiIds.toSet).values.flatten
     val copiedAmis = copiedAmiImages.map(image => Ami(image.ownerId, image.imageId))
 
-    bakedAmis ++ copiedAmis
+    amis.toList ++ copiedAmis
   }
 
   def apply(recipe: Recipe, bakes: Iterable[Bake])(implicit prismAgents: PrismAgents): RecipeUsage = {
-    val bakedAmiLookupMap = bakes.flatMap(b => b.amiId.map(_.value -> b)).toMap
+    val bakedAmiLookupMap = bakes.flatMap(b => b.amiId.map(_ -> b)).toMap
     val bakedAmiIds = bakedAmiLookupMap.keys.toList
     val copiedAmis = prismAgents.copiedImages(bakedAmiIds.toSet).values.flatten
     val copiedAmiIds = copiedAmis.map(_.imageId)

--- a/app/schedule/BakeScheduler.scala
+++ b/app/schedule/BakeScheduler.scala
@@ -1,16 +1,13 @@
 package schedule
 
 import models.{ BakeSchedule, Recipe, RecipeId }
+import org.quartz.{ JobDataMap, JobKey, Scheduler, TriggerKey }
 import org.quartz.CronScheduleBuilder._
 import org.quartz.JobBuilder._
 import org.quartz.TriggerBuilder._
-import org.quartz.impl.StdSchedulerFactory
-import org.quartz.{ TriggerKey, JobKey, JobDataMap }
 import play.api.Logger
 
-class BakeScheduler(scheduledBakeRunner: ScheduledBakeRunner) {
-
-  private val scheduler = StdSchedulerFactory.getDefaultScheduler()
+class BakeScheduler(scheduler: Scheduler, scheduledBakeRunner: ScheduledBakeRunner) {
 
   def initialise(recipes: Iterable[Recipe]): Unit = {
     recipes.flatMap(r => r.bakeSchedule.map(s => (r.id, s))).foreach {

--- a/app/services/PrismAgents.scala
+++ b/app/services/PrismAgents.scala
@@ -2,6 +2,7 @@ package services
 
 import akka.agent.Agent
 import akka.actor.{Cancellable, Scheduler}
+import models.AmiId
 import play.api.Logger
 import play.api.inject.ApplicationLifecycle
 import play.api.{Environment, Mode}
@@ -19,14 +20,14 @@ class PrismAgents(prism: Prism,
 
   private val instancesAgent: Agent[Seq[Instance]] = Agent(Seq.empty)
   private val launchConfigurationsAgent: Agent[Seq[LaunchConfiguration]] = Agent(Seq.empty)
-  private val copiedImagesAgent: Agent[Map[String, Seq[Image]]] = Agent(Map.empty)
+  private val copiedImagesAgent: Agent[Map[AmiId, Seq[Image]]] = Agent(Map.empty)
   private val accountsAgent: Agent[Seq[AWSAccount]] = Agent(Seq.empty)
 
   val baseUrl: String = prism.baseUrl
 
   def allInstances: Seq[Instance] = instancesAgent.get
   def allLaunchConfigurations: Seq[LaunchConfiguration] = launchConfigurationsAgent.get
-  def copiedImages(sourceAmiIds: Set[String]): Map[String, Seq[Image]] = copiedImagesAgent.get.filterKeys(sourceAmiIds.contains)
+  def copiedImages(sourceAmiIds: Set[AmiId]): Map[AmiId, Seq[Image]] = copiedImagesAgent.get.filterKeys(sourceAmiIds.contains)
   def accounts: Seq[AWSAccount] = accountsAgent.get
 
   if (environment.mode != Mode.Test) {

--- a/app/views/confirmDelete.scala.html
+++ b/app/views/confirmDelete.scala.html
@@ -1,0 +1,26 @@
+@import prism.BakeUsage
+@(recipeToDelete: Recipe, bakes: Seq[Bake], usages: Seq[BakeUsage])
+@simpleLayout("AMIgo"){
+
+    @if(usages.isEmpty) {
+        <h1>Really delete @recipeToDelete.id?</h1>
+
+        <div class="panel panel-default">
+            <div class="panel-heading">Confirm delete</div>
+            <div class="panel-body">
+                <p>Note that this will schedule the deletion of all associated AMIs and underlying EBS snapshots (@bakes.size).</p>
+                <p><a data-href="@routes.RecipeController.deleteRecipe(recipeToDelete.id)" class="post btn btn-danger">Delete</a></p>
+            </div>
+        </div>
+    } else {
+        <h1>Recipe @recipeToDelete.id still has usages</h1>
+
+        <div class="panel panel-default">
+            <div class="panel-heading">Can't be deleted</div>
+            <div class="panel-body">
+                This recipe still has usages and cannot be deleted. You can review the usages <a href="@routes.RecipeController.showUsages(recipeToDelete.id)">here</a>.
+            </div>
+        </div>
+    }
+
+}

--- a/app/views/showRecipe.scala.html
+++ b/app/views/showRecipe.scala.html
@@ -20,6 +20,7 @@
       <a data-href="@routes.BakeController.startBaking(recipe.id)" class="post btn btn-primary">Bake!</a>
       <a href="@routes.RecipeController.editRecipe(recipe.id)" class="btn btn-default">Edit</a>
       @if(debugAvailable){<a data-href="@routes.BakeController.startBaking(recipe.id, debug = true)" class="post btn btn-warning">Bake with debug enabled</a>}
+      <a href="@routes.RecipeController.deleteConfirm(recipe.id)" class="btn btn-danger">Delete...</a>
     </div>
   </div>
 

--- a/app/views/showRecipe.scala.html
+++ b/app/views/showRecipe.scala.html
@@ -4,7 +4,7 @@
 @(
         recipe: Recipe,
         recentBakes: Iterable[Bake],
-        recentCopies: Map[String, Seq[Image]],
+        recentCopies: Map[AmiId, Seq[Image]],
         accounts: Seq[AWSAccount],
         usage: prism.RecipeUsage,
         allRoles: Seq[RoleSummary],
@@ -87,7 +87,7 @@
             }
             </td>
           </tr>
-          @for(copy <- bake.amiId.flatMap(id => recentCopies.get(id.value)).getOrElse(Nil)){
+          @for(copy <- bake.amiId.flatMap(id => recentCopies.get(id)).getOrElse(Nil)){
             <tr>
               <td></td>
               <td>  </td>

--- a/app/views/showUsage.scala.html
+++ b/app/views/showUsage.scala.html
@@ -22,7 +22,7 @@
             <th>AMI</th>
         </thead>
         <tbody>
-            @bakeUsage.sortBy(bu => (bu.bake.startedAt.getMillis, bu.viaCopy.map(_.imageId))).map { usage =>
+            @bakeUsage.sortBy(bu => (bu.bake.startedAt.getMillis, bu.viaCopy.map(_.imageId.value))).map { usage =>
                 <tr>
                     <td class="has-block-link">
                         <a class="block-link" href="@routes.BakeController.showBake(usage.bake.recipe.id, usage.bake.buildNumber)">

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
-  "com.gu" %% "scanamo" % "0.9.2",
+  "com.gu" %% "scanamo" % "0.9.5",
   "com.github.cb372" %% "automagic" % "0.1",
   "com.beachape" %% "enumeratum" % "1.3.7",
   "com.typesafe.akka" %% "akka-typed-experimental" % "2.4.2",

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ libraryDependencies ++= Seq(
   "com.lihaoyi" %% "fastparse" % "0.4.1",
   "com.amazonaws" % "aws-java-sdk-sns" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
+  "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
   "org.scalatest" %% "scalatest" % "2.2.6" % Test,
   "org.mockito" % "mockito-core" % "2.7.19" % Test
 )

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -90,6 +90,10 @@ Resources:
           Resource: !Sub 'arn:aws:sns:*:*:amigo-${Stage}-notify'
         - Effect: Allow
           Action:
+          - sns:*
+          Resource: !Sub 'arn:aws:sns:*:*:amigo-${Stage}-housekeeping-notify'
+        - Effect: Allow
+          Action:
           - s3:GetBucketPolicy
           - s3:PutBucketPolicy
           Resource: arn:aws:s3::*:deploy-tools-dist

--- a/conf/routes
+++ b/conf/routes
@@ -22,6 +22,8 @@ POST    /recipes                    controllers.RecipeController.createRecipe
 GET     /recipes/:id                controllers.RecipeController.showRecipe(id: RecipeId)
 GET     /recipes/:id/edit           controllers.RecipeController.editRecipe(id: RecipeId)
 POST    /recipes/:id/edit           controllers.RecipeController.updateRecipe(id: RecipeId)
+GET     /recipes/:id/delete         controllers.RecipeController.deleteConfirm(id: RecipeId)
+POST    /recipes/:id/delete         controllers.RecipeController.deleteRecipe(id: RecipeId)
 
 GET     /recipes/:id/usages         controllers.RecipeController.showUsages(id: RecipeId)
 

--- a/imageCopier/imageCopier.yaml
+++ b/imageCopier/imageCopier.yaml
@@ -5,6 +5,9 @@ Parameters:
   AmigoTopicArn:
     Description: The SNS topic to subscribe to
     Type: String
+  AmigoHousekeepingTopicArn:
+    Description: The housekeeping SNS topic to subscribe to
+    Type: String
   KmsKeyArn:
     Description: Override the default KMS key if required
     Type: String
@@ -33,7 +36,20 @@ Conditions:
     !Equals [ !Ref KmsKeyArn, "" ]
 
 Resources:
-  LambdaRole:
+  CopierLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: /
+
+  HousekeepingLambdaRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -50,7 +66,8 @@ Resources:
     Type: AWS::IAM::Policy
     Properties:
       Roles:
-      - !Ref LambdaRole
+      - !Ref CopierLambdaRole
+      - !Ref HousekeepingLambdaRole
       PolicyName: LambdaLoggingPolicy
       PolicyDocument:
         Statement:
@@ -65,7 +82,7 @@ Resources:
     Type: AWS::IAM::Policy
     Properties:
       Roles:
-      - !Ref LambdaRole
+      - !Ref CopierLambdaRole
       PolicyName: KMSKeyPolicy
       PolicyDocument:
         Statement:
@@ -85,7 +102,7 @@ Resources:
     Type: AWS::IAM::Policy
     Properties:
       Roles:
-      - !Ref LambdaRole
+      - !Ref CopierLambdaRole
       PolicyName: ImageCopyPolicy
       PolicyDocument:
         Statement:
@@ -93,6 +110,21 @@ Resources:
           Action:
           - ec2:CopyImage
           - ec2:CreateTags
+          Resource: '*'
+
+  HousekeepingPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      Roles:
+      - !Ref HousekeepingLambdaRole
+      PolicyName: HousekeepingPolicy
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action:
+          - ec2:DescribeImages
+          - ec2:DeregisterImage
+          - ec2:DeleteSnapshot
           Resource: '*'
 
   # Permission for the SNS topic to push events to the Lambda
@@ -123,7 +155,7 @@ Resources:
       Runtime: java8
       MemorySize: 512
       Handler: com.gu.imageCopier.LambdaEntrypoint::run
-      Role: !GetAtt LambdaRole.Arn
+      Role: !GetAtt CopierLambdaRole.Arn
       Timeout: 30
       Environment:
         Variables:
@@ -135,3 +167,38 @@ Resources:
             - !Ref KmsKeyArn
           ENCRYPTED_TAG_VALUE:
             !Ref EncryptedTagValue
+
+  # Permission for the housekeeping SNS topic to push events to the Lambda
+  InvokeHousekeepingLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt HousekeepingLambda.Arn
+      Action: lambda:InvokeFunction
+      Principal: sns.amazonaws.com
+      SourceArn: !Ref AmigoHousekeepingTopicArn
+
+  # Actual subscription
+  SubscribeToHousekeepingAmigoTopic:
+    Type: AWS::SNS::Subscription
+    Properties:
+      TopicArn: !Ref AmigoHousekeepingTopicArn
+      Protocol: lambda
+      Endpoint: !GetAtt HousekeepingLambda.Arn
+
+  # Lambda that actions snapshot requests
+  HousekeepingLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Lambda for housekeeping AMIgo baked AMIs in other accounts
+      Code:
+        S3Bucket: !Ref FunctionCodeBucket
+        S3Key: !Sub ${Stack}/${Stage}/imagecopier/imagecopier.zip
+      Runtime: java8
+      MemorySize: 512
+      Handler: com.gu.imageCopier.LambdaEntrypoint::housekeeping
+      Role: !GetAtt HousekeepingLambdaRole.Arn
+      Timeout: 30
+      Environment:
+        Variables:
+          ACCOUNT_ID:
+            !Ref AWS::AccountId

--- a/imageCopier/src/main/scala/com/gu/imageCopier/AmiActions.scala
+++ b/imageCopier/src/main/scala/com/gu/imageCopier/AmiActions.scala
@@ -2,7 +2,7 @@ package com.gu.imageCopier
 
 import com.amazonaws.AmazonClientException
 import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.{CopyImageRequest, CreateTagsRequest, CreateTagsResult, Tag}
+import com.amazonaws.services.ec2.model._
 import com.gu.imageCopier.attempt.{Attempt, AwsSdkFailure}
 
 import scala.collection.JavaConverters._
@@ -39,6 +39,49 @@ object AmiActions {
       val result = ec2Client.createTags(request)
       println(s"Succeeded")
       result
+    } {
+      case ace:AmazonClientException => AwsSdkFailure(ace)
+    }
+  }
+
+  def getImagesAndEbsSnapshots(amis: List[Ami])(implicit ec2Client: AmazonEC2): Attempt[List[(String, List[String])]] = {
+    Attempt.catchNonFatal {
+      val request = new DescribeImagesRequest()
+        .withImageIds(amis.map(_.id).asJava)
+      println(s"Getting list of images and EBS snapshots with request $request")
+      val result = ec2Client.describeImages(request)
+      println(s"Raw result: $result")
+      val ids = result.getImages.asScala.map { image =>
+        image.getImageId -> image.getBlockDeviceMappings.asScala.toList.flatMap(mapping => Option(mapping.getEbs).map(_.getSnapshotId))
+      }
+      println(s"List of AMIs and snapshots: $ids")
+      ids.toList
+    } {
+      case ace:AmazonClientException => AwsSdkFailure(ace)
+    }
+  }
+
+  def deregisterAmi(amiId: String)(implicit ec2Client: AmazonEC2): Attempt[String] = {
+    Attempt.catchNonFatal {
+      val request = new DeregisterImageRequest()
+        .withImageId(amiId)
+      println(s"Deregistering AMI with request $request")
+      val result = ec2Client.deregisterImage(request)
+      println(s"Deregistered")
+      amiId
+    } {
+      case ace:AmazonClientException => AwsSdkFailure(ace)
+    }
+  }
+
+  def deleteSnapshot(snapshotId: String)(implicit ec2Client: AmazonEC2): Attempt[String] = {
+    Attempt.catchNonFatal {
+      val request = new DeleteSnapshotRequest()
+        .withSnapshotId(snapshotId)
+      println(s"Deleting snapshot with request $request")
+      val result = ec2Client.deleteSnapshot(request)
+      println(s"Deleted snapshot")
+      snapshotId
     } {
       case ace:AmazonClientException => AwsSdkFailure(ace)
     }

--- a/imageCopier/src/main/scala/com/gu/imageCopier/Configuration.scala
+++ b/imageCopier/src/main/scala/com/gu/imageCopier/Configuration.scala
@@ -1,12 +1,12 @@
 package com.gu.imageCopier
 
-case class Configuration(ownAccountNumber: String, kmsKeyArn: String, encryptedTagValue: String)
+case class Configuration(ownAccountNumber: String, kmsKeyArn: Option[String], encryptedTagValue: Option[String])
 
 object Configuration {
   def fromEnvironment: Configuration = {
     val accountId = System.getenv("ACCOUNT_ID")
-    val kmsKeyArn = System.getenv("KMS_KEY_ARN")
-    val encryptedTagValue = System.getenv("ENCRYPTED_TAG_VALUE")
+    val kmsKeyArn = Option(System.getenv("KMS_KEY_ARN"))
+    val encryptedTagValue = Option(System.getenv("ENCRYPTED_TAG_VALUE"))
     Configuration(accountId, kmsKeyArn, encryptedTagValue)
   }
 }

--- a/imageCopier/src/main/scala/com/gu/imageCopier/DeleteEvent.scala
+++ b/imageCopier/src/main/scala/com/gu/imageCopier/DeleteEvent.scala
@@ -1,0 +1,42 @@
+package com.gu.imageCopier
+
+import io.circe._
+import io.circe.parser.decode
+import com.gu.imageCopier.attempt._
+import io.circe.{Decoder, HCursor}
+
+import cats.syntax.either._
+
+case class Ami(account: String, id: String)
+
+object Ami {
+  implicit val amiDecoder: Decoder[Ami] = new Decoder[Ami] {
+    final def apply(c: HCursor): Decoder.Result[Ami] = {
+      for {
+        account <- c.downField("account").as[String]
+        id <- c.downField("id").as[String]
+      } yield {
+        new Ami(account, id)
+      }
+    }
+  }
+}
+
+case class DeleteEvent(amis: List[Ami])
+
+object DeleteEvent {
+  implicit val deleteEventDecoder: Decoder[DeleteEvent] = new Decoder[DeleteEvent] {
+    final def apply(c: HCursor): Decoder.Result[DeleteEvent] = {
+      for {
+        amis <- c.downField("amis").as[List[Ami]]
+      } yield {
+        new DeleteEvent(amis)
+      }
+    }
+  }
+
+  def fromJsonString(json: String): Attempt[DeleteEvent] = decode[DeleteEvent](json).toAttempt(JsonParseFailure)
+}
+
+
+

--- a/imageCopier/src/main/scala/com/gu/imageCopier/LambdaEntrypoint.scala
+++ b/imageCopier/src/main/scala/com/gu/imageCopier/LambdaEntrypoint.scala
@@ -3,7 +3,7 @@ package com.gu.imageCopier
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SNSEvent
 import com.amazonaws.services.ec2.{AmazonEC2, AmazonEC2ClientBuilder}
-import com.gu.imageCopier.attempt.{Attempt, MessageNotForUsFailure}
+import com.gu.imageCopier.attempt.{Attempt, ConfigurationFailure, Failure, MessageNotForUsFailure}
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -23,13 +23,47 @@ class LambdaEntrypoint {
     println(s"Got messages: $messages")
     val amisAttempt = Attempt.traverseWithFailures(messages){ message =>
       for {
+        kmsKeyArn <- Attempt.fromOption(configuration.kmsKeyArn, ConfigurationFailure("KMS key ARN not configured"))
+        encryptedTagValue <- Attempt.fromOption(configuration.encryptedTagValue, ConfigurationFailure("Encrypted tag value not configured"))
         amiEvent <- AmiEvent.fromJsonString(message.content)
         _ <- if (amiEvent.targetAccounts.contains(configuration.ownAccountNumber)) Attempt.Right(()) else Attempt.Left(MessageNotForUsFailure)
-        copiedAmi <- AmiActions.copyAmi(amiEvent, configuration.kmsKeyArn)
-        _ <- AmiActions.tagAmi(amiEvent, configuration.encryptedTagValue, copiedAmi)
+        copiedAmi <- AmiActions.copyAmi(amiEvent, kmsKeyArn)
+        _ <- AmiActions.tagAmi(amiEvent, encryptedTagValue, copiedAmi)
       } yield copiedAmi
     }
     val amis = Await.result(amisAttempt.asFuture, Duration.Inf)
+    println(s"Completed: $amis")
+  }
+
+  def housekeeping(input: SNSEvent, context: Context): Unit = {
+    println("Running AMIgo housekeeper")
+    val messages = SNSMessage.fromLambdaEvent(input)
+    println(s"Got messages: $messages")
+    val deleteAttempt = Attempt.traverseWithFailures(messages){ message =>
+      for {
+        deleteEvent <- DeleteEvent.fromJsonString(message.content)
+        localAmis = deleteEvent.amis.filter(_.account == configuration.ownAccountNumber)
+        actualAmisAndSnapshots <- AmiActions.getImagesAndEbsSnapshots(localAmis)
+        deletedAmis <- Attempt.traverseWithFailures(actualAmisAndSnapshots){ case(ami, _) => AmiActions.deregisterAmi(ami) }
+        actualSnapshots = actualAmisAndSnapshots.flatMap{ case(_, snapshots) => snapshots }
+        deletedSnapshots <- Attempt.traverseWithFailures(actualSnapshots){ snapshot => AmiActions.deleteSnapshot(snapshot) }
+      } yield (deletedAmis, deletedSnapshots)
+    }
+    val amis = Await.result(deleteAttempt.asFuture, Duration.Inf)
+
+    val allFailures = Failure.collect(List(amis)) { successfulAmis =>
+      Failure.collect(successfulAmis) { case (deletedAmis, deletedSnapshots) =>
+        Failure.collect(deletedAmis)(_ => Nil) ::: Failure.collect(deletedSnapshots)(_ => Nil)
+      }
+    }
+
+    if (allFailures.nonEmpty) {
+      println(s"Failures")
+      allFailures.foreach { failure =>
+        println(s"${failure.msg} ${failure.cause.map(_.getStackTraceString)}")
+      }
+    }
+
     println(s"Completed: $amis")
   }
 }

--- a/imageCopier/src/main/scala/com/gu/imageCopier/attempt/Failure.scala
+++ b/imageCopier/src/main/scala/com/gu/imageCopier/attempt/Failure.scala
@@ -34,6 +34,17 @@ case object MessageNotForUsFailure extends Failure {
   override def msg: String = "Message was not for this account"
 }
 
+case class ConfigurationFailure(msg: String) extends Failure
+
 case class UnknownFailure(throwable: Throwable) extends FailureWithThrowable
 
 case class AwsSdkFailure(throwable: Throwable) extends FailureWithThrowable
+
+object Failure {
+  def collect[A](eithers: List[Either[Failure, A]])(recurse: A => List[Failure]): List[Failure] = {
+    eithers.flatMap {
+      case Left(failure) => List(failure)
+      case Right(success) => recurse(success)
+    }
+  }
+}

--- a/test/prism/PrismSpec.scala
+++ b/test/prism/PrismSpec.scala
@@ -1,5 +1,6 @@
 package prism
 
+import models.AmiId
 import org.scalatest.{ FlatSpec, Matchers }
 import play.api.mvc.{ Action, Results }
 import play.api.test.WsTestClient
@@ -42,8 +43,8 @@ class PrismSpec extends FlatSpec with Matchers {
     withPrismClient { prism =>
       val instances = Await.result(prism.findAllInstances(), 10.seconds)
       instances should be(Seq(
-        Instance("i-123456", "ami-fa123456", AWSAccount("MyAccount", "1234567890")),
-        Instance("i-b123456", "ami-abcd4321", AWSAccount("MyAccount", "1234567890"))
+        Instance("i-123456", AmiId("ami-fa123456"), AWSAccount("MyAccount", "1234567890")),
+        Instance("i-b123456", AmiId("ami-abcd4321"), AWSAccount("MyAccount", "1234567890"))
       ))
     }
   }
@@ -52,8 +53,8 @@ class PrismSpec extends FlatSpec with Matchers {
     withPrismClient { prism =>
       val launchConfigurations = Await.result(prism.findAllLaunchConfigurations(), 10.seconds)
       launchConfigurations should be(Seq(
-        LaunchConfiguration("MyName", "ami-abcdefg1", AWSAccount("MyAccount", "1234567890")),
-        LaunchConfiguration("MyId", "ami-gfedcba2", AWSAccount("MyAccount", "1234567890"))
+        LaunchConfiguration("MyName", AmiId("ami-abcdefg1"), AWSAccount("MyAccount", "1234567890")),
+        LaunchConfiguration("MyId", AmiId("ami-gfedcba2"), AWSAccount("MyAccount", "1234567890"))
       ))
     }
   }

--- a/test/prism/RecipeUsageSpec.scala
+++ b/test/prism/RecipeUsageSpec.scala
@@ -13,7 +13,7 @@ class RecipeUsageSpec extends FlatSpec with Matchers with MockitoSugar {
 
   def fixtureBaseImage(baseImageId: String): BaseImage = BaseImage(BaseImageId(baseImageId), "MyDescription", AmiId("ami-1"), List(), "Test", DateTime.now, "Test", DateTime.now)
   def fixtureRecipe(id: String): Recipe = Recipe(RecipeId(id), None, fixtureBaseImage(s"base-image-$id"), List(), "Test", DateTime.now, "Test", DateTime.now, None, Nil)
-  def fixtureBake(recipe: Recipe, amiId: Option[AmiId]): Bake = Bake(recipe, 1, amiId.map(_ => BakeStatus.Complete).getOrElse(BakeStatus.Failed), amiId, "Test", DateTime.now)
+  def fixtureBake(recipe: Recipe, amiId: Option[AmiId]): Bake = Bake(recipe, 1, amiId.map(_ => BakeStatus.Complete).getOrElse(BakeStatus.Failed), amiId, "Test", DateTime.now, false)
 
   "RecipeUsage" should "find for each recipes where they are being used" in {
     val amiId1 = AmiId("1")
@@ -43,18 +43,18 @@ class RecipeUsageSpec extends FlatSpec with Matchers with MockitoSugar {
 
     val account = AWSAccount("accountName", "1234567890")
 
-    val instance1 = Instance("i-1", amiId1.value, account)
-    val instance2 = Instance("i-2", amiId2.value, account)
-    val instance5 = Instance("i-5", amiId5.value, account)
+    val instance1 = Instance("i-1", amiId1, account)
+    val instance2 = Instance("i-2", amiId2, account)
+    val instance5 = Instance("i-5", amiId5, account)
 
-    val lc1 = LaunchConfiguration("lc-1", amiId1.value, account)
-    val lc2 = LaunchConfiguration("lc-2", amiId3.value, account)
+    val lc1 = LaunchConfiguration("lc-1", amiId1, account)
+    val lc2 = LaunchConfiguration("lc-2", amiId3, account)
 
     val mockPrismAgents = mock[PrismAgents]
     when(mockPrismAgents.allInstances) thenReturn Seq(instance1, instance2, instance5)
     when(mockPrismAgents.allLaunchConfigurations) thenReturn Seq(lc1, lc2)
-    when(mockPrismAgents.copiedImages(any())) thenReturn Map[String, Seq[Image]]()
-    when(mockPrismAgents.copiedImages(Set("3"))) thenReturn Map("3" -> Seq(Image("5", "1234", "3", None, "available")))
+    when(mockPrismAgents.copiedImages(any())) thenReturn Map[AmiId, Seq[Image]]()
+    when(mockPrismAgents.copiedImages(Set(AmiId("3")))) thenReturn Map(AmiId("3") -> Seq(Image(AmiId("5"), "1234", AmiId("3"), None, "available")))
 
     val usages: Map[Recipe, RecipeUsage] = RecipeUsage.forAll(recipes, bakes)(mockPrismAgents)
 
@@ -64,17 +64,17 @@ class RecipeUsageSpec extends FlatSpec with Matchers with MockitoSugar {
     val recipe1Usages = usages(recipe1)
     recipe1Usages.instances shouldBe Seq(instance1, instance2)
     recipe1Usages.launchConfigurations shouldBe Seq(lc1)
-    recipe1Usages.bakeUsage.sortBy(_.amiId) shouldBe Seq(
-      BakeUsage("1", bakeR1A1, None, Seq(instance1), Seq(lc1)),
-      BakeUsage("2", bakeR1A2, None, Seq(instance2), Seq.empty)
+    recipe1Usages.bakeUsage.sortBy(_.amiId.value) shouldBe Seq(
+      BakeUsage(AmiId("1"), bakeR1A1, None, Seq(instance1), Seq(lc1)),
+      BakeUsage(AmiId("2"), bakeR1A2, None, Seq(instance2), Seq.empty)
     )
 
     val recipe2Usages = usages(recipe2)
     recipe2Usages.instances shouldBe Seq(instance5)
     recipe2Usages.launchConfigurations shouldBe Seq(lc2)
-    recipe2Usages.bakeUsage.sortBy(_.amiId) shouldBe Seq(
-      BakeUsage("3", bakeR2A3, None, Seq.empty, Seq(lc2)),
-      BakeUsage("5", bakeR2A3, Some(Image("5", "1234", "3", None, "available")), Seq(instance5), Seq.empty)
+    recipe2Usages.bakeUsage.sortBy(_.amiId.value) shouldBe Seq(
+      BakeUsage(AmiId("3"), bakeR2A3, None, Seq.empty, Seq(lc2)),
+      BakeUsage(AmiId("5"), bakeR2A3, Some(Image(AmiId("5"), "1234", AmiId("3"), None, "available")), Seq(instance5), Seq.empty)
     )
 
     val recipe3Usages = usages(recipe3)


### PR DESCRIPTION
It's now possible to delete recipes from AMIgo!!!

When a recipe is deleted we also delete all of the AMIs and the related snapshots asynchronously. This needs to be done across all accounts so a new Lambda has been created to handle this.

Messages are fired out to a new housekeeping topic that is distributed to lambdas in all accounts much like they are when a copy is required. This is a fire and forget, we don't check they complete.

We also introduce housekeeping jobs. When a recipe is deleted we mark all of the bakes as deleted and delete the recipe and the deletion housekeeping job actually does the work of sending the AMI delete messages and cleaning up bake log and bake entries in Dynamo.

It is not possible to delete a recipe if any of the bakes are still being used by an instance or launch configuration.

This is another step towards deleting old and unused bakes as a regular housekeeping job.

Todo
-----

 - [x] Figure out how to also delete the bake logs (this is non-trivial, apparently we need to know the range key, sad times)
 - [ ] Roll out the new imageCopier CFN that includes the housekeeping Lambda via the Stackset
 - [x] Merge and deploy to PROD