### PR TITLE
Automatically delete any bake that is older than a month and is not in use

### DIFF
--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -18,7 +18,7 @@ import com.gu.googleauth.GoogleAuthConfig
 import controllers._
 import data.{ Dynamo, Recipes }
 import event.{ ActorSystemWrapper, BakeEvent, Behaviours }
-import housekeeping.{ BakeDeletion, HousekeepingScheduler }
+import housekeeping.{ BakeDeletion, HousekeepingScheduler, MarkOldUnusedBakesForDeletion }
 import notification.{ AmiCreatedNotifier, LambdaDistributionBucket, NotificationSender, SNS }
 import org.joda.time.Duration
 import org.quartz.Scheduler
@@ -178,8 +178,9 @@ class AppComponents(context: Context)
   bakeScheduler.initialise(Recipes.list())
 
   val bakeDeletionHousekeeping = new BakeDeletion(dynamo, awsAccount, prismAgents, sender)
+  val markOldUnusedBakesForDeletion = new MarkOldUnusedBakesForDeletion(prismAgents, dynamo)
 
-  val housekeepingScheduler = new HousekeepingScheduler(scheduler, List(bakeDeletionHousekeeping))
+  val housekeepingScheduler = new HousekeepingScheduler(scheduler, List(bakeDeletionHousekeeping, markOldUnusedBakesForDeletion))
   housekeepingScheduler.initialise()
 
   val debugAvailable = identity.stage != "PROD"

--- a/app/controllers/RecipeController.scala
+++ b/app/controllers/RecipeController.scala
@@ -39,7 +39,7 @@ class RecipeController(
           recentBakes,
           recentCopies,
           prismAgents.accounts,
-          RecipeUsage(recipe, bakes)(prismAgents),
+          RecipeUsage(bakes)(prismAgents),
           Roles.list,
           debugAvailable
         )
@@ -118,7 +118,7 @@ class RecipeController(
   def showUsages(id: RecipeId) = AuthAction { implicit request =>
     Recipes.findById(id).fold[Result](NotFound) { recipe =>
       val bakes = Bakes.list(recipe.id)
-      val recipeUsage: RecipeUsage = RecipeUsage(recipe, bakes)(prismAgents)
+      val recipeUsage: RecipeUsage = RecipeUsage(bakes)(prismAgents)
       Ok(
         views.html.showUsage(
           recipe,
@@ -133,7 +133,7 @@ class RecipeController(
   def deleteConfirm(id: RecipeId) = AuthAction { implicit request =>
     Recipes.findById(id).fold[Result](NotFound) { recipe =>
       val bakes = Bakes.list(recipe.id).toSeq
-      val recipeUsage: RecipeUsage = RecipeUsage(recipe, bakes)(prismAgents)
+      val recipeUsage: RecipeUsage = RecipeUsage(bakes)(prismAgents)
       Ok(views.html.confirmDelete(recipe, bakes, recipeUsage.bakeUsage))
     }
   }
@@ -141,7 +141,7 @@ class RecipeController(
   def deleteRecipe(id: RecipeId) = AuthAction { implicit request =>
     Recipes.findById(id).fold[Result](NotFound) { recipe =>
       val bakes = Bakes.list(recipe.id)
-      val recipeUsage: RecipeUsage = RecipeUsage(recipe, bakes)(prismAgents)
+      val recipeUsage: RecipeUsage = RecipeUsage(bakes)(prismAgents)
       if (recipeUsage.bakeUsage.nonEmpty) {
         Conflict(s"Can't delete recipe $id as it is still used by ${recipeUsage.bakeUsage.size} resources.")
       } else {

--- a/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
+++ b/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
@@ -1,0 +1,49 @@
+package housekeeping
+
+import data.{ Bakes, Dynamo, Recipes }
+import models.{ Bake, RecipeId }
+import org.joda.time.{ DateTime, Duration }
+import org.quartz.SimpleScheduleBuilder
+import play.api.Logger
+import prism.RecipeUsage
+import services.PrismAgents
+
+object MarkOldUnusedBakesForDeletion {
+  def getOldUnusedBakes(
+    recipeIds: Set[RecipeId], now: DateTime,
+    listBakes: RecipeId => Iterable[Bake],
+    getRecipeUsage: Iterable[Bake] => RecipeUsage): Set[Bake] = {
+    val allBakes = recipeIds.flatMap(listBakes)
+
+    val oldBakes = allBakes.filter { bake =>
+      val duration = new Duration(bake.startedAt, now)
+      duration.getStandardDays > 30
+    }
+    val recipeUsage = getRecipeUsage(oldBakes)
+    val usedBakes = recipeUsage.bakeUsage.map(_.bake).distinct.toSet
+
+    oldBakes -- usedBakes
+  }
+}
+
+class MarkOldUnusedBakesForDeletion(prismAgents: PrismAgents, dynamo: Dynamo) extends HousekeepingJob {
+  override val schedule = SimpleScheduleBuilder.repeatHourlyForever(1)
+
+  override def housekeep(): Unit = {
+    implicit val implicitPrismAgents: PrismAgents = prismAgents
+    implicit val implicitDynamo: Dynamo = dynamo
+    Logger.info(s"Started marking old, unused bakes for deletion")
+    val now = new DateTime()
+    val recipeIds = Recipes.list().map(_.id).toSet
+    val oldUnusedBakes = MarkOldUnusedBakesForDeletion.getOldUnusedBakes(recipeIds, now, Bakes.list, RecipeUsage.apply)
+    Logger.info(s"Found ${oldUnusedBakes.size} unused bakes over 30 days old")
+
+    val bakesToMark = oldUnusedBakes.take(100)
+    Logger.info(s"Marking ${bakesToMark.size} unused bakes for deletion")
+
+    bakesToMark.foreach { bake =>
+      Bakes.markToDelete(bake.bakeId)
+      Logger.info(s"Marked ${bake.bakeId} for deletion")
+    }
+  }
+}

--- a/app/prism/RecipeUsage.scala
+++ b/app/prism/RecipeUsage.scala
@@ -23,7 +23,7 @@ object RecipeUsage {
     amis.toList ++ copiedAmis
   }
 
-  def apply(recipe: Recipe, bakes: Iterable[Bake])(implicit prismAgents: PrismAgents): RecipeUsage = {
+  def apply(bakes: Iterable[Bake])(implicit prismAgents: PrismAgents): RecipeUsage = {
     val bakedAmiLookupMap = bakes.flatMap(b => b.amiId.map(_ -> b)).toMap
     val bakedAmiIds = bakedAmiLookupMap.keys.toList
     val copiedAmis = prismAgents.copiedImages(bakedAmiIds.toSet).values.flatten
@@ -53,7 +53,7 @@ object RecipeUsage {
   }
 
   def forAll(recipes: Iterable[Recipe], findBakes: RecipeId => Iterable[Bake])(implicit prismAgents: PrismAgents): Map[Recipe, RecipeUsage] = {
-    recipes.map(r => r -> apply(r, findBakes(r.id))).toMap
+    recipes.map(r => r -> apply(findBakes(r.id))).toMap
   }
 
 }

--- a/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
+++ b/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
@@ -2,11 +2,10 @@ package housekeeping
 
 import models._
 import org.joda.time.{ DateTime, DateTimeZone }
-import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ FlatSpec, Matchers }
 import prism.{ BakeUsage, RecipeUsage }
 
-class MarkOldUnusedBakesForDeletionSpec extends FlatSpec with Matchers with MockitoSugar {
+class MarkOldUnusedBakesForDeletionSpec extends FlatSpec with Matchers {
   val oldDate = new DateTime(2018, 5, 28, 0, 0, 0, DateTimeZone.UTC)
   val newDate = new DateTime(2018, 6, 20, 0, 0, 0, DateTimeZone.UTC)
   val oldBake1: Bake = fixtureBake(fixtureRecipe("recipe-1", oldDate), Some(AmiId("ami-1")), oldDate)

--- a/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
+++ b/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
@@ -1,0 +1,61 @@
+package housekeeping
+
+import models._
+import org.joda.time.{ DateTime, DateTimeZone }
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{ FlatSpec, Matchers }
+import prism.{ BakeUsage, RecipeUsage }
+
+class MarkOldUnusedBakesForDeletionSpec extends FlatSpec with Matchers with MockitoSugar {
+  val oldDate = new DateTime(2018, 5, 28, 0, 0, 0, DateTimeZone.UTC)
+  val newDate = new DateTime(2018, 6, 20, 0, 0, 0, DateTimeZone.UTC)
+  val oldBake1: Bake = fixtureBake(fixtureRecipe("recipe-1", oldDate), Some(AmiId("ami-1")), oldDate)
+  val oldBake2: Bake = fixtureBake(fixtureRecipe("recipe-2", oldDate), Some(AmiId("ami-2")), oldDate)
+  val newBake1: Bake = fixtureBake(fixtureRecipe("recipe-3", newDate), Some(AmiId("ami-3")), newDate)
+  val newBake2: Bake = fixtureBake(fixtureRecipe("recipe-4", newDate), Some(AmiId("ami-4")), newDate)
+
+  def fixtureBaseImage(baseImageId: String, createdDate: DateTime): BaseImage = {
+    BaseImage(BaseImageId(baseImageId), "MyDescription", AmiId("ami-1"), List(), "Test", createdDate, "Test", createdDate)
+  }
+  def fixtureRecipe(id: String, createdDate: DateTime): Recipe = {
+    Recipe(RecipeId(id), None, fixtureBaseImage(s"base-image-$id", createdDate), List(), "Test", createdDate, "Test", createdDate, None, Nil)
+  }
+  def fixtureBake(recipe: Recipe, amiId: Option[AmiId], startedAt: DateTime): Bake = {
+    Bake(recipe, 1, amiId.map(_ => BakeStatus.Complete).getOrElse(BakeStatus.Failed), amiId, "Test", startedAt, deleted = false)
+  }
+
+  def getBakes(recipeId: RecipeId): Iterable[Bake] = Iterable(oldBake1, oldBake2, newBake1, newBake2)
+  def getEmptyRecipeUsage(bakes: Iterable[Bake]): RecipeUsage = RecipeUsage(Seq.empty, Seq.empty, Seq.empty)
+
+  def getRecipeUsage(bakes: Iterable[Bake]): RecipeUsage = {
+    val bakeUsageA = BakeUsage(AmiId("ami-2"), oldBake2, None, Seq.empty, Seq.empty)
+    val bakeUsageB = BakeUsage(AmiId("ami-4"), newBake2, None, Seq.empty, Seq.empty)
+    RecipeUsage(Seq.empty, Seq.empty, Seq(bakeUsageA, bakeUsageB))
+  }
+
+  "getOldUnusedBakes" should "return empty when all bakes are recent" in {
+    val housekeepingDate = new DateTime(2018, 6, 24, 0, 0, 0, DateTimeZone.UTC)
+    val recipeIds = Set(RecipeId("recipe-1"), RecipeId("recipe-2"), RecipeId("recipe-3"), RecipeId("recipe-4"))
+    val markedBakes = MarkOldUnusedBakesForDeletion.getOldUnusedBakes(recipeIds, housekeepingDate, getBakes, getEmptyRecipeUsage)
+
+    markedBakes.size shouldEqual 0
+  }
+
+  it should "find all unused bakes older than 30 days" in {
+    val housekeepingDate = new DateTime(2018, 7, 12, 0, 0, 0, DateTimeZone.UTC)
+    val recipeIds = Set(RecipeId("recipe-1"), RecipeId("recipe-2"), RecipeId("recipe-3"), RecipeId("recipe-4"))
+    val markedBakes = MarkOldUnusedBakesForDeletion.getOldUnusedBakes(recipeIds, housekeepingDate, getBakes, getEmptyRecipeUsage)
+
+    markedBakes.size shouldEqual 2
+    markedBakes.map(_.bakeId) shouldEqual Set(BakeId(RecipeId("recipe-1"), 1), BakeId(RecipeId("recipe-2"), 1))
+  }
+
+  it should "not include old bakes that are still in use" in {
+    val housekeepingDate = new DateTime(2018, 7, 12, 0, 0, 0, DateTimeZone.UTC)
+    val recipeIds = Set(RecipeId("recipe-1"), RecipeId("recipe-2"), RecipeId("recipe-3"), RecipeId("recipe-4"))
+    val markedBakes = MarkOldUnusedBakesForDeletion.getOldUnusedBakes(recipeIds, housekeepingDate, getBakes, getRecipeUsage)
+
+    markedBakes.size shouldEqual 1
+    markedBakes.map(_.bakeId) shouldEqual Set(BakeId(RecipeId("recipe-1"), 1))
+  }
+}

--- a/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
+++ b/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
@@ -41,7 +41,7 @@ class MarkOldUnusedBakesForDeletionSpec extends FlatSpec with Matchers with Mock
     markedBakes.size shouldEqual 0
   }
 
-  it should "find all unused bakes older than 30 days" in {
+  it should "find all the unused bakes that are older than the max age" in {
     val housekeepingDate = new DateTime(2018, 7, 12, 0, 0, 0, DateTimeZone.UTC)
     val recipeIds = Set(RecipeId("recipe-1"), RecipeId("recipe-2"), RecipeId("recipe-3"), RecipeId("recipe-4"))
     val markedBakes = MarkOldUnusedBakesForDeletion.getOldUnusedBakes(recipeIds, housekeepingDate, getBakes, getEmptyRecipeUsage)


### PR DESCRIPTION
### 👉Remove unused recipe argument from RecipeUsage apply

This was not being used anyway so is a bit of a code clean up

### 👉Mark old unused bakes for deletion with a housekeeping job

This adds a new housekeeping task that runs each hour and will find bakes over **30 days old** that are **not in use**. To prevent hitting DynamoDB too hard and running into throughput exceptions, only the first 100 of the old unused bakes will be marked for deletion upon each run.

We have never deleted bakes before, so it may take us a while to get under 100! Once we do, it is unlikely we will get over 100 again, so scheduling this task for once an hour and taking 100 seemed like a reasonable approach that allows us to avoid scaling up the DynamoDB throughput, or adding in a `Thread.sleep(...)` that probably wont matter after the first run...

This change means that any bakes marked as deleted will be deleted by the other housekeeping tasks added in #193. Actually deleting the bakes will be rate-limited by the BakeDeletion housekeeping task.

### TODO:

- [x] add tests for getOldUnusedBakes
- [x] test on CODE
- [ ] Remember to check the PROD logs so we can see how many bakes we end up deleting 😁 
