### PR TITLE
[WIP] Automatically update the lambdas across the estate when we deploy

### DIFF
--- a/imageCopier/imageCopier.yaml
+++ b/imageCopier/imageCopier.yaml
@@ -167,6 +167,10 @@ Resources:
             - !Ref KmsKeyArn
           ENCRYPTED_TAG_VALUE:
             !Ref EncryptedTagValue
+      Tags:
+        - Key: App
+          Value: image-copier-lambda
+
 
   # Permission for the housekeeping SNS topic to push events to the Lambda
   InvokeHousekeepingLambdaPermission:
@@ -194,7 +198,7 @@ Resources:
         S3Bucket: !Ref FunctionCodeBucket
         S3Key: !Sub ${Stack}/${Stage}/imagecopier/imagecopier.zip
       Runtime: java8
-      MemorySize: 512
+      MemorySize: 256
       Handler: com.gu.imageCopier.LambdaEntrypoint::housekeeping
       Role: !GetAtt HousekeepingLambdaRole.Arn
       Timeout: 30
@@ -202,3 +206,6 @@ Resources:
         Variables:
           ACCOUNT_ID:
             !Ref AWS::AccountId
+      Tags:
+        - Key: App
+          Value: housekeeping-lambda

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -2,6 +2,28 @@ stacks:
 - deploy
 regions:
 - eu-west-1
+templates:
+  lambda-upload:
+    type: aws-lambda
+    contentDirectory: imagecopier
+    actions:
+    - uploadLambda
+    parameters:
+      bucket: deploy-tools-dist
+      fileName: imagecopier.zip
+      lookupByTags: true
+
+  lambda-update:
+    template: lambda-upload
+    actions:
+    - updateLambda
+    # complete list of all stacks - should stay in sync with the imagecopier StackSet in the root account
+    stacks:
+    - deploy
+    - composer
+    - cms-fronts
+    - workflow
+
 deployments:
   amigo:
     type: autoscaling
@@ -9,18 +31,29 @@ deployments:
       bucket: deploy-tools-dist
     dependencies:
       - update-ami
+
   update-ami:
     type: ami-cloudformation-parameter
     app: amigo
     parameters:
       amiTags:
-        Recipe: xenial-java8-deploy-infrastructure
+        BuiltBy: amigo
         AmigoStage: PROD
+        Recipe: xenial-java8-deploy-infrastructure
       amiEncrypted: true
-  # upload lambda
-  imagecopier:
-    type: aws-s3
-    parameters:
-      bucket: deploy-tools-dist
-      cacheControl: public, max-age=600
-      publicReadAcl: false
+
+  # deploy lambdas
+  image-copier-lambda-upload:
+    template: lambda-upload
+    app: image-copier-lambda
+  housekeeping-lambda-upload:
+    template: lambda-upload
+    app: housekeeping-lambda
+  image-copier-lambda:
+    template: lambda-update
+    dependencies:
+    - image-copier-lambda-upload
+  housekeeping-lambda:
+    template: lambda-update
+    dependencies:
+    - housekeeping-lambda-upload


### PR DESCRIPTION
This is an attempt to update the lambdas automatically across the entire estate using a new Riff-Raff lambda update feature.

This relies on https://github.com/guardian/riff-raff/pull/499 and so cannot yet be merged.