### PR TITLE
Change the name of the S3 key to force reload

### DIFF
--- a/app/notification/LambdaDistributionBucket.scala
+++ b/app/notification/LambdaDistributionBucket.scala
@@ -38,7 +38,10 @@ object LambdaDistributionBucket {
         "AWS" -> accounts
       )),
       Action = Some(JsString("s3:GetObject")),
-      Resource = Some(JsString(s"arn:aws:s3:::$bucketName/deploy/$stage/imagecopier/*"))
+      Resource = Some(JsArray(Seq(
+        JsString(s"arn:aws:s3:::$bucketName/deploy/$stage/imagecopier/*"),
+        JsString(s"arn:aws:s3:::$bucketName/deploy/$stage/housekeeping-lambda/*")
+      )))
     )
   }
 

--- a/imageCopier/imageCopier.yaml
+++ b/imageCopier/imageCopier.yaml
@@ -192,7 +192,7 @@ Resources:
       Description: Lambda for housekeeping AMIgo baked AMIs in other accounts
       Code:
         S3Bucket: !Ref FunctionCodeBucket
-        S3Key: !Sub ${Stack}/${Stage}/imagecopier/imagecopier.zip
+        S3Key: !Sub ${Stack}/${Stage}/housekeeping-lambda/imagecopier.zip
       Runtime: java8
       MemorySize: 512
       Handler: com.gu.imageCopier.LambdaEntrypoint::housekeeping


### PR DESCRIPTION
A bit of a hack that allowed us to force out a new version of the lambda to all the stacks in the stack set (by virtue of changing the s3 key).

There is another PR (https://github.com/guardian/amigo/pull/201) that should solve this properly but for the time being this let us fix a bug.

Note that the proposed riff-raff.yaml doesn't deal with dependencies quite as you expect as each stack/region combination does its own dependency resolution and Riff-Raff doesn't support dependencies across stacks.