### PR TITLE
Deschedule recipes from automatic bakes when deleting

### DIFF
--- a/app/controllers/RecipeController.scala
+++ b/app/controllers/RecipeController.scala
@@ -145,6 +145,9 @@ class RecipeController(
       if (recipeUsage.bakeUsage.nonEmpty) {
         Conflict(s"Can't delete recipe $id as it is still used by ${recipeUsage.bakeUsage.size} resources.")
       } else {
+        // stop any scheduled build
+        bakeScheduler.reschedule(recipe.copy(bakeSchedule = None))
+
         // delete the AMIgo data
         bakes.foreach { bake =>
           Bakes.markToDelete(bake.bakeId)


### PR DESCRIPTION
Quick fix to deschedule a recipe that was scheduled to build automatically when it is deleted.