### PR TITLE
Bump SBT riff-raff artifact plugin for Travis fix

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.7")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.8")
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts Artifact("jdeb", "jar", "jar")


### PR DESCRIPTION
When converting to DEB some snowflake logic for Travis got lost, this brings it back by adopting version 1.1.8 of the plugin which includes https://github.com/guardian/sbt-riffraff-artifact/pull/49