### PR TITLE
Add housekeeping task for orphaned bakes and a housekeeping UI

### DIFF
--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -188,6 +188,7 @@ class AppComponents(context: Context)
 
   val rootController = new RootController(googleAuthConfig)
   val baseImageController = new BaseImageController(googleAuthConfig, messagesApi)
+  val housekeepingController = new HousekeepingController(googleAuthConfig)
   val roleController = new RoleController(googleAuthConfig)
   val recipeController = new RecipeController(bakeScheduler, prismAgents, googleAuthConfig, messagesApi, debugAvailable)
   val bakeController = new BakeController(eventsSource, prismAgents, googleAuthConfig, messagesApi, ansibleVariables, debugAvailable)
@@ -197,6 +198,7 @@ class AppComponents(context: Context)
     httpErrorHandler,
     rootController,
     baseImageController,
+    housekeepingController,
     roleController,
     recipeController,
     bakeController,

--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -18,7 +18,7 @@ import com.gu.googleauth.GoogleAuthConfig
 import controllers._
 import data.{ Dynamo, Recipes }
 import event.{ ActorSystemWrapper, BakeEvent, Behaviours }
-import housekeeping.{ BakeDeletion, HousekeepingScheduler, MarkOldUnusedBakesForDeletion }
+import housekeeping.{ BakeDeletion, HousekeepingScheduler, MarkOldUnusedBakesForDeletion, MarkOrphanedBakesForDeletion }
 import notification.{ AmiCreatedNotifier, LambdaDistributionBucket, NotificationSender, SNS }
 import org.joda.time.Duration
 import org.quartz.Scheduler
@@ -179,8 +179,9 @@ class AppComponents(context: Context)
 
   val bakeDeletionHousekeeping = new BakeDeletion(dynamo, awsAccount, prismAgents, sender)
   val markOldUnusedBakesForDeletion = new MarkOldUnusedBakesForDeletion(prismAgents, dynamo)
+  val markOrphanedBakesForDeletion = new MarkOrphanedBakesForDeletion(prismAgents, dynamo)
 
-  val housekeepingScheduler = new HousekeepingScheduler(scheduler, List(bakeDeletionHousekeeping, markOldUnusedBakesForDeletion))
+  val housekeepingScheduler = new HousekeepingScheduler(scheduler, List(bakeDeletionHousekeeping, markOldUnusedBakesForDeletion, markOrphanedBakesForDeletion))
   housekeepingScheduler.initialise()
 
   val debugAvailable = identity.stage != "PROD"

--- a/app/controllers/HousekeepingController.scala
+++ b/app/controllers/HousekeepingController.scala
@@ -8,11 +8,11 @@ import play.api.Logger
 import play.api.mvc._
 
 class HousekeepingController(val authConfig: GoogleAuthConfig)(implicit dynamo: Dynamo) extends Controller with AuthActions {
-  private val (errors, recipes) = Recipes.recipesWithErrors
-  private val recipeIds = recipes.map(recipe => recipe.id).toSet
-  private val orphanedBakes = MarkOrphanedBakesForDeletion.findOrphanedBakeIds(recipeIds, Bakes.scanForAll())
 
   def showOrphans = AuthAction {
+    val (errors, recipes) = Recipes.recipesWithErrors
+    val recipeIds = recipes.map(recipe => recipe.id).toSet
+    val orphanedBakes = MarkOrphanedBakesForDeletion.findOrphanedBakeIds(recipeIds, Bakes.scanForAll())
     Ok(views.html.housekeeping(orphanedBakes, errors.length))
   }
 

--- a/app/controllers/HousekeepingController.scala
+++ b/app/controllers/HousekeepingController.scala
@@ -1,0 +1,30 @@
+package controllers
+
+import com.gu.googleauth.GoogleAuthConfig
+import data._
+import housekeeping.MarkOrphanedBakesForDeletion
+import models.BakeId
+import play.api.Logger
+import play.api.mvc._
+
+class HousekeepingController(val authConfig: GoogleAuthConfig)(implicit dynamo: Dynamo) extends Controller with AuthActions {
+  private val (errors, recipes) = Recipes.listWithErrors()
+  private val recipeIds = recipes.map(recipe => recipe.id).toSet
+  private val orphanedBakes = MarkOrphanedBakesForDeletion.findOrphanedBakeIds(recipeIds, Bakes.scanForAll())
+
+  def showOrphans = AuthAction {
+    Ok(views.html.housekeeping(orphanedBakes, errors.length))
+  }
+
+  def deleteOrphans(): Action[AnyContent] = AuthAction { implicit request =>
+    val formData = request.body.asFormUrlEncoded.get("orphaned-bake")
+
+    formData.foreach { bake =>
+      BakeId.fromString(bake) match {
+        case Right(bakeId) => Bakes.markToDelete(bakeId)
+        case Left(err) => Logger.warn(err.toString)
+      }
+    }
+    Redirect(routes.HousekeepingController.showOrphans())
+  }
+}

--- a/app/controllers/HousekeepingController.scala
+++ b/app/controllers/HousekeepingController.scala
@@ -8,7 +8,7 @@ import play.api.Logger
 import play.api.mvc._
 
 class HousekeepingController(val authConfig: GoogleAuthConfig)(implicit dynamo: Dynamo) extends Controller with AuthActions {
-  private val (errors, recipes) = Recipes.listWithErrors()
+  private val (errors, recipes) = Recipes.recipesWithErrors
   private val recipeIds = recipes.map(recipe => recipe.id).toSet
   private val orphanedBakes = MarkOrphanedBakesForDeletion.findOrphanedBakeIds(recipeIds, Bakes.scanForAll())
 

--- a/app/data/Bakes.scala
+++ b/app/data/Bakes.scala
@@ -61,6 +61,13 @@ object Bakes {
     }
   }
 
+  def scanForAll()(implicit dynamo: Dynamo): List[Bake.DbModel] = {
+    table
+      .scan()
+      .exec()
+      .flatMap(_.toOption)
+  }
+
   def markToDelete(bakeId: BakeId)(implicit dynamo: Dynamo): Unit = {
     table
       .given(attributeExists('recipeId) and attributeExists('buildNumber))

--- a/app/data/Recipes.scala
+++ b/app/data/Recipes.scala
@@ -30,17 +30,17 @@ object Recipes {
     }
   }
 
-  def listWithErrors()(implicit dynamo: Dynamo): (List[DynamoReadError], List[Recipe]) = {
+  def recipesWithErrors()(implicit dynamo: Dynamo): (List[DynamoReadError], List[Recipe]) = {
     val dbResponse: Traversable[Either[DynamoReadError, DbModel]] = table.scan().exec()
-    val results = dbResponse.toList.separate
+    val (errors, models) = dbResponse.toList.separate
 
     val recipes = for {
-      dbModel <- results._2
+      dbModel <- models
       baseImage <- BaseImages.findById(dbModel.baseImageId)
     } yield {
       Recipe.db2domain(dbModel, baseImage)
     }
-    (results._1, recipes)
+    (errors, recipes)
   }
 
   def create(id: RecipeId,

--- a/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
+++ b/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
@@ -13,7 +13,8 @@ object MarkOldUnusedBakesForDeletion {
   val BATCH_SIZE = 100
 
   def getOldUnusedBakes(
-    recipeIds: Set[RecipeId], now: DateTime,
+    recipeIds: Set[RecipeId],
+    now: DateTime,
     listBakes: RecipeId => Iterable[Bake],
     getRecipeUsage: Iterable[Bake] => RecipeUsage): Set[Bake] = {
     val allBakes = recipeIds.flatMap(listBakes)

--- a/app/housekeeping/MarkOrphanedBakesForDeletion.scala
+++ b/app/housekeeping/MarkOrphanedBakesForDeletion.scala
@@ -7,6 +7,8 @@ import play.api.Logger
 import services.PrismAgents
 
 object MarkOrphanedBakesForDeletion {
+  val FAULT_TOLERANCE = 0
+
   def findOrphanedBakeIds(recipeIds: Set[RecipeId], bakes: List[Bake.DbModel]): List[BakeId] = {
     val orphanedBakes = bakes.filterNot(bake => recipeIds.contains(bake.recipeId))
     orphanedBakes.map(bake => BakeId(bake.recipeId, bake.buildNumber))
@@ -19,16 +21,20 @@ class MarkOrphanedBakesForDeletion(prismAgents: PrismAgents, dynamo: Dynamo) ext
   override def housekeep(): Unit = {
     implicit val implicitPrismAgents: PrismAgents = prismAgents
     implicit val implicitDynamo: Dynamo = dynamo
-
-    Logger.info(s"Started marking orphaned bakes for deletion")
-    val recipeIds = Recipes.list().map(_.id).toSet
-    val bakes = Bakes.scanForAll()
-    val orphanedBakeIds = MarkOrphanedBakesForDeletion.findOrphanedBakeIds(recipeIds, bakes)
-
-    Logger.info(s"Marking ${orphanedBakeIds.size} orphaned bakes for deletion")
-    orphanedBakeIds.foreach { bakeId =>
-      Bakes.markToDelete(bakeId)
-      Logger.info(s"Marked ${bakeId.toString} for deletion")
+    val (errors, recipes) = Recipes.listWithErrors
+    errors match {
+      case _ if errors.length > MarkOrphanedBakesForDeletion.FAULT_TOLERANCE =>
+        Logger.info(s"Housekeeping found ${errors.length} database errors while searching for orphaned bakes")
+        Logger.warn(s"${errors.length} errors exceeds the limit so orphaned bake deletion will not continue")
+      case _ =>
+        val bakes = Bakes.scanForAll()
+        val orphanedBakeIds = MarkOrphanedBakesForDeletion.findOrphanedBakeIds(recipes.map(_.id).toSet, bakes)
+        // TODO: minimal safety check to avoid accidentally deleting all the bakes if there are db read errors
+        Logger.info(s"Marking ${orphanedBakeIds.size} orphaned bakes for deletion")
+        orphanedBakeIds.foreach { bakeId =>
+          Bakes.markToDelete(bakeId)
+          Logger.info(s"Marked ${bakeId.toString} for deletion")
+        }
     }
   }
 }

--- a/app/housekeeping/MarkOrphanedBakesForDeletion.scala
+++ b/app/housekeeping/MarkOrphanedBakesForDeletion.scala
@@ -6,6 +6,12 @@ import org.quartz.SimpleScheduleBuilder
 import play.api.Logger
 import services.PrismAgents
 
+
+/*
+If a recipe has been deleted from a table but not the associated bake, then these
+lonely bakes will linger on and never get picked up by the other housekeeping tasks
+*/
+
 object MarkOrphanedBakesForDeletion {
   val FAULT_TOLERANCE = 0
 
@@ -21,7 +27,7 @@ class MarkOrphanedBakesForDeletion(prismAgents: PrismAgents, dynamo: Dynamo) ext
   override def housekeep(): Unit = {
     implicit val implicitPrismAgents: PrismAgents = prismAgents
     implicit val implicitDynamo: Dynamo = dynamo
-    val (errors, recipes) = Recipes.listWithErrors
+    val (errors, recipes) = Recipes.recipesWithErrors
     errors match {
       case _ if errors.length > MarkOrphanedBakesForDeletion.FAULT_TOLERANCE =>
         Logger.info(s"Housekeeping found ${errors.length} database errors while searching for orphaned bakes")

--- a/app/housekeeping/MarkOrphanedBakesForDeletion.scala
+++ b/app/housekeeping/MarkOrphanedBakesForDeletion.scala
@@ -35,7 +35,6 @@ class MarkOrphanedBakesForDeletion(prismAgents: PrismAgents, dynamo: Dynamo) ext
       case _ =>
         val bakes = Bakes.scanForAll()
         val orphanedBakeIds = MarkOrphanedBakesForDeletion.findOrphanedBakeIds(recipes.map(_.id).toSet, bakes)
-        // TODO: minimal safety check to avoid accidentally deleting all the bakes if there are db read errors
         Logger.info(s"Marking ${orphanedBakeIds.size} orphaned bakes for deletion")
         orphanedBakeIds.foreach { bakeId =>
           Bakes.markToDelete(bakeId)

--- a/app/housekeeping/MarkOrphanedBakesForDeletion.scala
+++ b/app/housekeeping/MarkOrphanedBakesForDeletion.scala
@@ -1,0 +1,34 @@
+package housekeeping
+
+import data.{ Bakes, Dynamo, Recipes }
+import models.{ Bake, BakeId, RecipeId }
+import org.quartz.SimpleScheduleBuilder
+import play.api.Logger
+import services.PrismAgents
+
+object MarkOrphanedBakesForDeletion {
+  def findOrphanedBakeIds(recipeIds: Set[RecipeId], bakes: List[Bake.DbModel]): List[BakeId] = {
+    val orphanedBakes = bakes.filterNot(bake => recipeIds.contains(bake.recipeId))
+    orphanedBakes.map(bake => BakeId(bake.recipeId, bake.buildNumber))
+  }
+}
+
+class MarkOrphanedBakesForDeletion(prismAgents: PrismAgents, dynamo: Dynamo) extends HousekeepingJob {
+  override val schedule = SimpleScheduleBuilder.repeatHourlyForever(24)
+
+  override def housekeep(): Unit = {
+    implicit val implicitPrismAgents: PrismAgents = prismAgents
+    implicit val implicitDynamo: Dynamo = dynamo
+
+    Logger.info(s"Started marking orphaned bakes for deletion")
+    val recipeIds = Recipes.list().map(_.id).toSet
+    val bakes = Bakes.scanForAll()
+    val orphanedBakeIds = MarkOrphanedBakesForDeletion.findOrphanedBakeIds(recipeIds, bakes)
+
+    Logger.info(s"Marking ${orphanedBakeIds.size} orphaned bakes for deletion")
+    orphanedBakeIds.foreach { bakeId =>
+      Bakes.markToDelete(bakeId)
+      Logger.info(s"Marked ${bakeId.toString} for deletion")
+    }
+  }
+}

--- a/app/models/BakeId.scala
+++ b/app/models/BakeId.scala
@@ -12,11 +12,12 @@ object BakeId {
   // Bake ID is stored as a single string in Dynamo, e.g. "ubuntu-wily-java8 #123"
   private val DynamoFormatRegex = """(.+) #([0-9]+)""".r
 
+  def fromString(s: String): Either[DynamoReadError, BakeId] = s match {
+    case DynamoFormatRegex(recipeId, buildNumber) => Right(BakeId(RecipeId(recipeId), buildNumber.toInt))
+    case _ => Left(TypeCoercionError(new IllegalArgumentException(s"Invalid bake ID: $s")))
+  }
+
   implicit val dynamoFormat: DynamoFormat[BakeId] = {
-    def fromString(s: String): Either[DynamoReadError, BakeId] = s match {
-      case DynamoFormatRegex(recipeId, buildNumber) => Right(BakeId(RecipeId(recipeId), buildNumber.toInt))
-      case _ => Left(TypeCoercionError(new IllegalArgumentException(s"Invalid bake ID: $s")))
-    }
     DynamoFormat.xmap[BakeId, String](fromString)(bakeId => bakeId.toString)
   }
 

--- a/app/views/housekeeping.scala.html
+++ b/app/views/housekeeping.scala.html
@@ -1,0 +1,29 @@
+@(orphans: List[BakeId], errors: Int)
+    @layout("AMIgo") {
+        <h1>Housekeeping</h1>
+
+        <div class="panel panel-default">
+            <div class="panel-heading">Orphaned Bakes</div>
+            <div class="panel-body">
+                <form id="housekeeping" action="/housekeeping/deleteOrphans" method="POST">
+                    <div class="form-group col-md-6">
+                    @for(orphan <- orphans) {
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" name="orphaned-bake" value="@orphan.toString" id="@orphan.toString" checked>
+                            <label class="form-check-label" for="@orphan.toString">
+                                @orphan.toString
+                            </label>
+                        </div>
+                    }
+                    </div>
+                    <div class="form-group col-md-6">
+                        <h5>Housekeeping encountered @errors errors when searching the database, continue anyway?</h5>
+                        <button type="submit" class="btn btn-danger">Delete Orphaned Bakes</button>
+                    </div>
+
+                </form>
+            </div>
+        </div>
+    } {
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.4.3/showdown.min.js" type="text/javascript"></script>
+    }

--- a/app/views/layout.scala.html
+++ b/app/views/layout.scala.html
@@ -32,6 +32,7 @@
             <li><a href="@routes.BaseImageController.listBaseImages">Base images</a></li>
             <li><a href="@routes.RoleController.listRoles">Roles</a></li>
             <li><a href="@routes.RecipeController.listRecipes">Recipes</a></li>
+            <li><a href="@routes.HousekeepingController.showOrphans">Housekeeping</a></li>
           </ul>
         </div>
       </div>

--- a/conf/routes
+++ b/conf/routes
@@ -13,6 +13,9 @@ GET     /base-images/:id            controllers.BaseImageController.showBaseImag
 GET     /base-images/:id/edit       controllers.BaseImageController.editBaseImage(id: BaseImageId)
 POST    /base-images/:id/edit       controllers.BaseImageController.updateBaseImage(id: BaseImageId)
 
+GET     /housekeeping                      controllers.HousekeepingController.showOrphans
+POST    /housekeeping/deleteOrphans        controllers.HousekeepingController.deleteOrphans
+
 GET     /roles                      controllers.RoleController.listRoles
 
 GET     /recipes                    controllers.RecipeController.listRecipes

--- a/test/housekeeping/MarkOrphanedBakesForDeletionSpec.scala
+++ b/test/housekeeping/MarkOrphanedBakesForDeletionSpec.scala
@@ -1,0 +1,39 @@
+package housekeeping
+
+import models._
+import org.joda.time.{ DateTime, DateTimeZone }
+import org.scalatest.{ FlatSpec, Matchers }
+
+class MarkOrphanedBakesForDeletionSpec extends FlatSpec with Matchers {
+  val date = new DateTime(2018, 5, 28, 0, 0, 0, DateTimeZone.UTC)
+
+  def fixtureBakeDbModel(recipeId: String, amiId: Option[AmiId]): Bake.DbModel = {
+    Bake.DbModel(RecipeId(recipeId), 1, BakeStatus.Complete, amiId, "user", date, None)
+  }
+
+  val orphanBakes = List(fixtureBakeDbModel("recipe-x", None), fixtureBakeDbModel("recipe-y", None))
+  val otherBakes = List(fixtureBakeDbModel("recipe-1", None), fixtureBakeDbModel("recipe-2", None))
+
+  "findOrphanedBakeIds" should "return empty when there are no orphaned bakes" in {
+    val recipeIds = Set(RecipeId("recipe-1"), RecipeId("recipe-2"), RecipeId("recipe-3"), RecipeId("recipe-4"))
+    val markedBakes = MarkOrphanedBakesForDeletion.findOrphanedBakeIds(recipeIds, otherBakes)
+
+    markedBakes.size shouldEqual 0
+  }
+
+  it should "only find the orphaned bakes" in {
+    val recipeIds = Set(RecipeId("recipe-1"), RecipeId("recipe-2"), RecipeId("recipe-3"), RecipeId("recipe-4"))
+    val markedBakes = MarkOrphanedBakesForDeletion.findOrphanedBakeIds(recipeIds, otherBakes ++ orphanBakes)
+
+    markedBakes.size shouldEqual 2
+    markedBakes shouldEqual List(BakeId(RecipeId("recipe-x"), 1), BakeId(RecipeId("recipe-y"), 1))
+  }
+
+  it should "find all the orphaned bakes" in {
+    val recipeIds = Set(RecipeId("recipe-1"), RecipeId("recipe-3"), RecipeId("recipe-4"))
+    val markedBakes = MarkOrphanedBakesForDeletion.findOrphanedBakeIds(recipeIds, otherBakes ++ orphanBakes)
+
+    markedBakes.size shouldEqual 3
+    markedBakes.toSet shouldEqual Set(BakeId(RecipeId("recipe-x"), 1), BakeId(RecipeId("recipe-y"), 1), BakeId(RecipeId("recipe-2"), 1))
+  }
+}


### PR DESCRIPTION
Orphaned bakes may exist for a few reasons... 

If a recipe has been deleted from a table but not the associated bake, then these lonely bakes will linger on and never get picked up by the housekeeping... Until now

#### 👉 Adds a housekeeping task that hunts for orphaned bakes

Something interesting was happening with the DEV DynamoDB table and there were read errors so I have decided to surface these so the housekeeping task can decide what to do.

I have set the `FAULT_TOLERANCE` to `0` for now, which means that the housekeeping scheduler will abort in DEV mode:

<img width="689" alt="picture 155" src="https://user-images.githubusercontent.com/8607683/43145344-1513f3e0-8f57-11e8-942d-1f6799e4644f.png">

If the housekeeping task does not get stopped it should happily mark all the orphaned bakes for deletion. Once marked the deletion housekeeping should finish off doing the clean up.

#### 👉 New Housekeeping UI

This includes a form that manually allows you to mark the orphaned bakes for deletion. This is helpful if your database has read errors yet you want to delete things anyway!

<img width="1194" alt="picture 154" src="https://user-images.githubusercontent.com/8607683/43145330-0f5ca4b0-8f57-11e8-9242-b1552c505551.png">

The button works and will `POST` a request that should mark all the listed bakes for deletion, irrespective of the `FAULT_TOLERANCE`. The UI needs some work and the button just redirects you to the same page therefore currently it looks like nothing happens... The application is doing something secretly I promise!

#### 👉 Bringing some of the Death by Switches spirit to AMIgo

We should not let frontend have all the fun~

#### 🦄 TODO: 

- [x] Test on DEV
- [x] Test on CODE

- [ ] Improve the UI and UX

