### PR TITLE
Increase max length of AMI ID

### DIFF
--- a/app/controllers/BaseImageController.scala
+++ b/app/controllers/BaseImageController.scala
@@ -85,7 +85,7 @@ object BaseImageController {
 
   object Forms {
 
-    val amiId = nonEmptyText(maxLength = 16).transform[AmiId](AmiId.apply, _.value)
+    val amiId = nonEmptyText(maxLength = 21).transform[AmiId](AmiId.apply, _.value)
 
     val linuxDist: Mapping[LinuxDist] =
       nonEmptyText(maxLength = 16)


### PR DESCRIPTION
AWS have increased the length of resource IDs. They are now a 17 char string prefixed by the resource ID (in this case `ami-`).

This adjusts the form validation accordingly.