### PR TITLE
Improve "show bake" page

### DIFF
--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -29,7 +29,7 @@
   <div>
     <label>
       <input id="tail-log" type="checkbox" value="" checked>
-      tail -f
+      Auto scroll
     </label>
   </div>
 

--- a/public/javascripts/show-bake.js
+++ b/public/javascripts/show-bake.js
@@ -19,7 +19,8 @@ function scrollToBottom() {
     var div = $('#packer-output');
     var height = div.get(0).scrollHeight;
     div.animate({
-      scrollTop: height
+      scrollTop: height,
+      queue: false
     }, 500);
   }
 }


### PR DESCRIPTION
The auto-scroll logic queues the animations rather than scrolling to the bottom immediately. This makes the page 100% unusable because after many 10s of updates have come through you're waiting for
literally minutes, unable to scroll the output while the jQuery animation queue completes. Without the queue this actually follows the output and you'll never have to wait more than `$animationDuration` (currently 500ms) before you can regain control.

Labelling the checkbox `tail -f` makes it unclear whether this refers to scrolling the div, or actually obtaining the log contents. It makes it feel like unticking this would stop the log loading at all. Auto scroll makes it clear we're just talking about the interface.