### PR TITLE
Fix kong listen address

### DIFF
--- a/roles/kong/files/kong-0.14.0.conf
+++ b/roles/kong/files/kong-0.14.0.conf
@@ -59,7 +59,7 @@ anonymous_reports = off          # Send anonymous usage data such as error
 #proxy_listen_ssl = 0.0.0.0:8443 # Address and port on which Kong will accept
 # HTTPS requests if `ssl` is enabled.
 
-#admin_listen = 0.0.0.0:8001     # Address and port on which Kong will expose
+admin_listen = 0.0.0.0:8001     # Address and port on which Kong will expose
 # an entrypoint to the Admin API.
 # This API lets you configure and manage Kong,
 # and should be kept private and secured.


### PR DESCRIPTION
Subtly broken by this change https://github.com/Kong/kong/blob/master/UPGRADE.md#admin-api-1
It prevents outside access to kong's admin api, from kong v0.12.
The admin api needs to be accessed from bonobo, and we use security groups to keep this port secure.