### PR TITLE
new parameters for the 'node' role to allow downloading from nodejs.org

### DIFF
--- a/roles/node/README.md
+++ b/roles/node/README.md
@@ -4,4 +4,14 @@ Installs Node.js.
 
 ## Variables
 
-* `node_version` - which version of Node.js to install. Default value is `4.x`. Valid values include `4.x` and `6.x`.
+#### Preferred Approach
+
+Using this approach the binary will be unpacked to `/usr/local/node` and a `node` symlink added to `/usr/bin`
+
+* `node_full_version` - which version of Node.js (major.minor.patch format) to be downloaded from nodejs.org. No default value. NOTE: this uses the `linux-x64` version from https://nodejs.org/dist/
+
+* `nodejs_dist_relative_path` - if the `node_full_version` param doesn't work or you need something other than the `linux-x64` version, with this parameter you can specify a path relative to https://nodejs.org/dist/
+
+#### DEPRECATED Approach
+
+* `node_version` which version of Node.js to install (from nodesource.com - unofficial). Default value is `4.x`. Consult https://github.com/nodesource/distributions for valid values.

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -1,6 +1,35 @@
 ---
 - name: Add node source repository
   shell: curl -sL https://deb.nodesource.com/setup_{{node_version}} | bash -
+  when: node_full_version is undefined and nodejs_dist_relative_path is undefined
 
-- name: Install Node.js
+- name: Install Node.js (from nodesource.com)
   apt: name=nodejs state=latest
+  when: node_full_version is undefined and nodejs_dist_relative_path is undefined
+
+- name: Create /usr/local/node
+  file:
+    path: /usr/local/node
+    state: directory
+  when: node_full_version is defined or nodejs_dist_relative_path is defined
+
+- name: Download & extract Node.js (from nodejs.org)
+  unarchive:
+    src: https://nodejs.org/dist/v{{node_full_version}}/node-v{{node_full_version}}-linux-x64.tar.gz
+    dest: /usr/local/node
+    remote_src: yes
+  when: node_full_version is defined
+
+- name: Download & extract Node.js (from nodejs.org) alternate version
+  unarchive:
+    src: https://nodejs.org/dist/{{nodejs_dist_relative_path}}
+    dest: /usr/local/node
+    remote_src: yes
+  when: nodejs_dist_relative_path is defined
+
+- name: Add node symlink in /usr/bin
+  file:
+    src: /usr/local/node/bin/node
+    dest: /usr/bin/node
+    state: link
+  when: node_full_version is defined or nodejs_dist_relative_path is defined

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -7,29 +7,27 @@
   apt: name=nodejs state=latest
   when: node_full_version is undefined and nodejs_dist_relative_path is undefined
 
-- name: Create /usr/local/node
-  file:
-    path: /usr/local/node
-    state: directory
-  when: node_full_version is defined or nodejs_dist_relative_path is defined
-
 - name: Download & extract Node.js (from nodejs.org)
   unarchive:
     src: https://nodejs.org/dist/v{{node_full_version}}/node-v{{node_full_version}}-linux-x64.tar.gz
-    dest: /usr/local/node
+    dest: /usr/local
     remote_src: yes
+    list_files: yes
   when: node_full_version is defined
+  register: archive_contents
 
 - name: Download & extract Node.js (from nodejs.org) alternate version
   unarchive:
     src: https://nodejs.org/dist/{{nodejs_dist_relative_path}}
     dest: /usr/local/node
     remote_src: yes
+    list_files: yes
   when: nodejs_dist_relative_path is defined
+  register: archive_contents
 
 - name: Add node symlink in /usr/bin
   file:
-    src: /usr/local/node/bin/node
+    src: /usr/local/{{archive_contents.files[0]}}/bin/node
     dest: /usr/bin/node
     state: link
     force: yes

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Add node symlink in /usr/bin
   file:
-    src: /usr/local/{{archive_contents_full_version.files[0]}}/bin/node
+    src: /usr/local/{{archive_contents_full_version.files[0]}}bin/node
     dest: /usr/bin/node
     state: link
     force: yes

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -32,4 +32,5 @@
     src: /usr/local/node/bin/node
     dest: /usr/bin/node
     state: link
+    force: yes
   when: node_full_version is defined or nodejs_dist_relative_path is defined

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -13,6 +13,7 @@
     dest: /usr/local
     remote_src: yes
     list_files: yes
+    mode: u=rwx,g=rx,o=rx
   when: node_full_version is defined
   register: archive_contents_full_version
 
@@ -22,6 +23,7 @@
     dest: /usr/bin/node
     state: link
     force: yes
+    mode: u=rwx,g=rx,o=rx
   when: node_full_version is defined
 
 - name: Download & extract Node.js (from nodejs.org) alternate version
@@ -30,6 +32,7 @@
     dest: /usr/local
     remote_src: yes
     list_files: yes
+    mode: u=rwx,g=rx,o=rx
   when: nodejs_dist_relative_path is defined
   register: archive_contents_relative_path
 
@@ -39,4 +42,5 @@
     dest: /usr/bin/node
     state: link
     force: yes
+    mode: u=rwx,g=rx,o=rx
   when: nodejs_dist_relative_path is defined

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -14,7 +14,15 @@
     remote_src: yes
     list_files: yes
   when: node_full_version is defined
-  register: archive_contents
+  register: archive_contents_full_version
+
+- name: Add node symlink in /usr/bin
+  file:
+    src: /usr/local/{{archive_contents_full_version.files[0]}}/bin/node
+    dest: /usr/bin/node
+    state: link
+    force: yes
+  when: node_full_version is defined
 
 - name: Download & extract Node.js (from nodejs.org) alternate version
   unarchive:
@@ -23,12 +31,12 @@
     remote_src: yes
     list_files: yes
   when: nodejs_dist_relative_path is defined
-  register: archive_contents
+  register: archive_contents_relative_path
 
 - name: Add node symlink in /usr/bin
   file:
-    src: /usr/local/{{archive_contents.files[0]}}/bin/node
+    src: /usr/local/{{archive_contents_relative_path.files[0]}}bin/node
     dest: /usr/bin/node
     state: link
     force: yes
-  when: node_full_version is defined or nodejs_dist_relative_path is defined
+  when: nodejs_dist_relative_path is defined

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: Download & extract Node.js (from nodejs.org) alternate version
   unarchive:
     src: https://nodejs.org/dist/{{nodejs_dist_relative_path}}
-    dest: /usr/local/node
+    dest: /usr/local
     remote_src: yes
     list_files: yes
   when: nodejs_dist_relative_path is defined


### PR DESCRIPTION
added additional parameters for the 'node' role to allow downloading from nodejs.org (rather than the current unofficial nodesource.com)

paired with @philmcmahon 