### PR TITLE
Puppeteer - Headless Chrome Node API

### DIFF
--- a/roles/puppeteer/README.md
+++ b/roles/puppeteer/README.md
@@ -1,0 +1,8 @@
+Puppeteer - Headless Chrome Node API for taking web page screenshots
+===========
+
+https://github.com/GoogleChrome/puppeteer - https://pptr.dev/
+
+If you're interested in taking screenshots of web pages, you may also
+want to install `mscorefonts` to make sure realistic fonts are available
+for rendering. 

--- a/roles/puppeteer/tasks/main.yml
+++ b/roles/puppeteer/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Install dependencies required by "puppeteer"
+  apt:
+    state: present
+    name: [
+      'npm', # we need this to *install* Puppeteer
+      'nodejs', # we need this to *run* Puppeteer
+      'chromium-browser' # easiest way to get all the X11 libraries required by Puppeteer's bundled copy of Chrome
+    ]
+
+- name: Install "puppeteer" node.js package so that it is available to any program on the system
+  npm:
+    name: puppeteer
+    version: '1.9.0'
+    path: / # Hack based on https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders - blame Alex


### PR DESCRIPTION
Ophan's Time Machine (https://dashboard.ophan.co.uk/time-machine) needs `Puppeteer` in order to be able to take full-page web screenshots - it used to use `phantomjs` but that is a dead project...

https://github.com/guardian/ophan/issues/2952