### PR TITLE
mscorefonts - Microsoft TrueType core fonts

### DIFF
--- a/roles/mscorefonts/README.md
+++ b/roles/mscorefonts/README.md
@@ -1,0 +1,12 @@
+mscorefonts - Microsoft TrueType core fonts
+===========
+
+https://en.wikipedia.org/wiki/Core_fonts_for_the_Web
+
+From 1996 to 2002 Microsoft made freely available a set of fonts
+that were designed for the web, including Arial, Comic Sans MS,
+Courier New, Times New Roman, Verdana, etc.
+
+In 2002 Microsoft cancelled the project, but because of the license
+terms, the distributed files are still legally available from some
+third-party websites.

--- a/roles/mscorefonts/tasks/main.yml
+++ b/roles/mscorefonts/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- apt_repository:
+    repo: "{{item}}"
+  register: multiverse_installed
+  update_cache: false  # Rather than doing this several times, we just do this once afterwares
+  when: ansible_distribution == 'Ubuntu'
+  with_items:
+  - 'deb http://archive.ubuntu.com/ubuntu {{ansible_distribution_release}} multiverse'
+  - 'deb-src http://archive.ubuntu.com/ubuntu {{ansible_distribution_release}} multiverse'
+  - 'deb http://archive.ubuntu.com/ubuntu {{ansible_distribution_release}}-updates multiverse'
+  - 'deb-src http://archive.ubuntu.com/ubuntu {{ansible_distribution_release}}-updates multiverse'
+
+- apt:
+    update_cache: true
+  when: multiverse_installed | changed
+
+- apt:
+    pgk: '{{item}}'
+  with_items:
+  - libfreetype6
+  - libfreetype6-dev
+  - libfontconfig
+
+- name: 'Accept License'
+  shell: 'echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections'
+
+- apt: pkg=ttf-mscorefonts-installer


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Core_fonts_for_the_Web

From 1996 to 2002 Microsoft made freely available a set of fonts that were designed for the web, before cancelling the project - but because of the license terms, the distributed files are still legally available.

This ansible script is copied from https://www.stefanwienert.de/blog/2014/08/29/ansible-enable-ubuntu-multiverse-and-install-mscorefonts/ ...I have no idea if it's valid!