### PR TITLE
Support adding keys from keyserver, extra docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ it possible to SSH onto the instance that is being used to build the AMI.
 
 ## How to run locally
 
+(For a faster but messier way of testing your ansible scripts - see 'Testing ansible scripts without runing amigo/packer' below.)
+
 AMIgo requires Packer to be [installed](https://www.packer.io/intro/getting-started/install.html)
 
 To run the Play app, you will need credentials in either the `deployTools` profile or the default profile.
@@ -120,3 +122,31 @@ $ sbt test
 }
 ```
 
+## Testing ansible scripts without runing amigo/packer
+
+Tired of waiting for amigo to build, deploy and bake only to discover you made a one character error in your ansible script?
+Then read on...
+
+You can use [Vagrant]() to test ansible scripts. Once set up, it allows you to try out your script with a feedback loop
+of 20 seconds or so. There are some docs [here](https://docs.ansible.com/ansible/2.5/scenario_guides/guide_vagrant.html) 
+covering this, but, roughly speaking you need to:
+ - Create a Vagrantfile (see docs for an example, update `config.vm.box` and `ansible.playbook` as required)
+ - Format your `tasks/main.yml` file as a playbook rather than a tasklist - see [here](https://stackoverflow.com/questions/38632170/error-file-is-not-a-valid-attribute-for-a-play)
+ for details
+ - Install [vagrant](https://www.vagrantup.com/downloads.html) and [ansible](https://hvops.com/articles/ansible-mac-osx/)
+ - Run `vagrant up` to download the image and run your ansible script
+ - Run `vagrant provision` to re-run the ansible script
+ 
+If you get an error about python not being set up properly, a hacky workaround is to install it as a pre task:
+
+```
+ - hosts: all
+   gather_facts: no
+   sudo: yes
+   pre_tasks:
+     - name: 'install python2'
+       raw: sudo apt-get -y install python
+       
+   tasks:
+     <<my ansible stuff>>
+```

--- a/roles/packages/README.md
+++ b/roles/packages/README.md
@@ -25,3 +25,7 @@ Likewise, if you need to add a signing key you can add that with:
 ```
 signing_keys: ['https://artifacts.elastic.co/GPG-KEY-elasticsearch']
 ```
+or
+```
+keyserver_keys: { 36A1D7869245C8950F966E92D8576A8BA88D21E9: 'keyserver.ubuntu.com' }
+```

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -1,7 +1,15 @@
 ---
-- name: Install signing keys
+- name: Install signing keys (url)
   apt_key: url={{ item }} state=present
   with_items: "{{ signing_keys|default([]) }}"
+  when:
+  - ansible_os_family == "Debian"
+
+- name: Install signing keys (keysever)
+  apt_key:
+    id: "{{ item.key }}"
+    keyserver: "{{ item.value }}"
+  with_dict: "{{ keyserver_keys|default({}) }}"
   when:
   - ansible_os_family == "Debian"
 

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -29,8 +29,7 @@
   - ansible_os_family == "Debian"
 
 - name: Install a package with apt-get
-  apt: name={{ item }} state=present
-  with_items: "{{ packages|default([]) }}"
+  apt: name={{ packages|default([]) }} state=present
   when:
   - ansible_os_family == "Debian"
 


### PR DESCRIPTION
Packages such as http://pm2.keymetrics.io/docs/usage/install-as-deb/ require the key to be installed from the ubuntu keyserver. This change adds the option of specifying a key in this way, rather than via a url.

It also adds some documentation for testing amigo roles with vagrant, something I found saved a lot of time recently. 