### PR TITLE
Allow node role to install npm packages

### DIFF
--- a/roles/node/README.md
+++ b/roles/node/README.md
@@ -12,6 +12,8 @@ Using this approach the binary will be unpacked to `/usr/local/node` and a `node
 
 * `packages` - npm packages to install globally. e.g. `packages: [pm2, reqwest]`
 
+Using this approach, node binaries (node, npm, npx) will be accessible at `/usr/local/node/`. The `node` binary is linked to in `/usr/bin` so should be available via the `PATH` environment variable.
+
 #### DEPRECATED Approach
 
 * `node_version` which version of Node.js to install (from nodesource.com - unofficial). Default value is `4.x`. Consult https://github.com/nodesource/distributions for valid values.

--- a/roles/node/README.md
+++ b/roles/node/README.md
@@ -10,7 +10,7 @@ Using this approach the binary will be unpacked to `/usr/local/node` and a `node
 
 * `node_full_version` - which version of Node.js (major.minor.patch format) to be downloaded from nodejs.org. No default value. NOTE: this uses the `linux-x64` version from https://nodejs.org/dist/
 
-* `nodejs_dist_relative_path` - if the `node_full_version` param doesn't work or you need something other than the `linux-x64` version, with this parameter you can specify a path relative to https://nodejs.org/dist/
+* `packages` - npm packages to install globally. e.g. `packages: [pm2, reqwest]`
 
 #### DEPRECATED Approach
 

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -15,32 +15,26 @@
     list_files: yes
     mode: u=rwx,g=rx,o=rx
   when: node_full_version is defined
-  register: archive_contents_full_version
+  register: archive_contents
+
+- name: Add node directory to PATH
+  shell: echo "PATH=\"/usr/local/{{archive_contents.files[0]}}bin:$PATH\"" > /etc/environment
+  when: node_full_version is defined
 
 - name: Add node symlink in /usr/bin
   file:
-    src: /usr/local/{{archive_contents_full_version.files[0]}}bin/node
+    src: /usr/local/{{archive_contents.files[0]}}bin/node
     dest: /usr/bin/node
     state: link
     force: yes
     mode: u=rwx,g=rx,o=rx
   when: node_full_version is defined
 
-- name: Download & extract Node.js (from nodejs.org) alternate version
-  unarchive:
-    src: https://nodejs.org/dist/{{nodejs_dist_relative_path}}
-    dest: /usr/local
-    remote_src: yes
-    list_files: yes
-    mode: u=rwx,g=rx,o=rx
-  when: nodejs_dist_relative_path is defined
-  register: archive_contents_relative_path
-
-- name: Add node symlink in /usr/bin
-  file:
-    src: /usr/local/{{archive_contents_relative_path.files[0]}}bin/node
-    dest: /usr/bin/node
-    state: link
-    force: yes
-    mode: u=rwx,g=rx,o=rx
-  when: nodejs_dist_relative_path is defined
+- name: Install npm packages
+  npm:
+    name: "{{ item }}"
+    global: yes
+  with_items: "{{ packages|default([]) }}"
+  environment:
+    PATH: "/usr/local/{{archive_contents.files[0]}}bin:{{ lookup('env', 'PATH') }}"
+  when: packages is defined and node_full_version is defined

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -17,16 +17,24 @@
   when: node_full_version is defined
   register: archive_contents
 
-- name: Add node directory to PATH
-  shell: echo "PATH=\"/usr/local/{{archive_contents.files[0]}}bin:$PATH\"" > /etc/environment
-  when: node_full_version is defined
+- name: Store node path
+  set_fact:
+    node_location: /usr/local/{{archive_contents.files[0]}}bin
+
 
 - name: Add node symlink in /usr/bin
   file:
-    src: /usr/local/{{archive_contents.files[0]}}bin/node
+    src: "{{ node_location }}/node"
     dest: /usr/bin/node
     state: link
-    force: yes
+    mode: u=rwx,g=rx,o=rx
+  when: node_full_version is defined
+
+- name: Add consistent symlink to node binaries
+  file:
+    src: "{{ node_location }}"
+    dest: /usr/local/node
+    state: link
     mode: u=rwx,g=rx,o=rx
   when: node_full_version is defined
 
@@ -36,5 +44,5 @@
     global: yes
   with_items: "{{ packages|default([]) }}"
   environment:
-    PATH: "/usr/local/{{archive_contents.files[0]}}bin:{{ lookup('env', 'PATH') }}"
+    PATH: "/usr/local/node:{{ lookup('env', 'PATH') }}"
   when: packages is defined and node_full_version is defined


### PR DESCRIPTION
This adds a step to add a symlink to the node `bin` directory (containing node, npm etc.) in /usr/local so that it can be referenced easily (without knowing the node version).

It also adds the functionality to allow the role to install npm packages globally. Arguably this belongs in a separate role, but due to the dependency between the [npm ansible step](https://docs.ansible.com/ansible/devel/modules/npm_module.html) and `npm` it is bit of a pain to separate this out. This doesn't feel like a terrible place to put this step - as it is optional, and I suspect will be used fairly often to install node and [pm2](http://pm2.keymetrics.io/).

Finally, I've removed the 'alternative' option of specifying the nodejs.org relative path on the basis that it adds quite a bit of complexity, and will be easy to add back in should it be required. Since nobody is using it at the moment we might as well keep things simpler.

Testing done: I spun up an EC2 box with an AMI generated with this role. I ran `node --version` and got the expected version.