### PR TITLE
Pre-bake ngram data

### DIFF
--- a/roles/language-tool-ngrams/defaults/main.yml
+++ b/roles/language-tool-ngrams/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+source_tarball: s3://amigo-data/data/language-tool/ngrams.tar.gz
+target_dir: /opt/ngram-data

--- a/roles/language-tool-ngrams/tasks/main.yml
+++ b/roles/language-tool-ngrams/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Install ngrams
+  shell: |
+    set -e
+    mkdir -p {{ target_dir }}
+    cd {{ target_dir }}
+    aws --quiet s3 cp {{ source_tarball }} - | tar -xz
+    exit 0
+  args:
+    executable: /bin/bash


### PR DESCRIPTION
The ngram data for language tool is 8.5Gb and is impossible to download and extract within a reasonable timeframe at boot time. As such it is desirable to bake this into an AMI.

This is a hardcoded role just for doing this task. In order to shorten bake time we do a piped download and extract.