### PR TITLE
Amazon Kinesis Agent needs custom checkpoints file location

### DIFF
--- a/roles/aws-kinesis-agent/README.md
+++ b/roles/aws-kinesis-agent/README.md
@@ -3,10 +3,8 @@ This role will install the [Amazon Kinesis Agent](https://github.com/awslabs/ama
 It also provide a utility script to configure your logs in `/opt/aws-kinesis-agent/configure-aws-kinesis-agent`
 The arguments are:
  - the AWS region
- - the stack
- - the stage
- - the app
- - the full path to the log
+ - the AWS Kinesis Stream
+ - the AWS Kinesis pattern to match for the log file(s)
 
 
 Here's an example user data that makes use of it:
@@ -17,9 +15,7 @@ UserData:
   !Sub
     - |
       #!/bin/bash -ev
-      /opt/aws-kinesis-agent/configure-aws-kinesis-agent ${AWS::Region} ${Stack} ${Stage} ${App} /var/log/${App}/application.log
-    - App: !FindInMap [ Constants, App, Value ]
-      Stack: !FindInMap [ Constants, Stack, Value ]
+      /opt/aws-kinesis-agent/configure-aws-kinesis-agent ${AWS::Region} ${LogStream} ${LogFilePattern}
 ```
 
 You will need to give the following policies to your instance:
@@ -31,7 +27,7 @@ You will need to give the following policies to your instance:
   - kinesis:DescribeStream
   Resource:
    !Sub 
-     - arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${Stack}-${App}-${Stage}
+     - arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${LogStream}
      - App: !FindInMap [ Constants, App, Value ]
        Stack: !FindInMap [ Constants, Stack, Value ]
 ```

--- a/roles/aws-kinesis-agent/files/configure-aws-kinesis-agent
+++ b/roles/aws-kinesis-agent/files/configure-aws-kinesis-agent
@@ -9,6 +9,7 @@ file=$5
 cat > /etc/aws-kinesis/agent.json <<__END__
 {
   "kinesis.endpoint": "kinesis.$region.amazonaws.com",
+  "checkpointFile": "/opt/aws-kinesis-agent/run/checkpoints",
   "flows": [
     {
       "filePattern": "$file",

--- a/roles/aws-kinesis-agent/files/configure-aws-kinesis-agent
+++ b/roles/aws-kinesis-agent/files/configure-aws-kinesis-agent
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
 region=$1
-stack=$2
-stage=$3
-app=$4
-file=$5
+kinesis_stream=$2
+file=$3
 
 cat > /etc/aws-kinesis/agent.json <<__END__
 {
@@ -13,7 +11,7 @@ cat > /etc/aws-kinesis/agent.json <<__END__
   "flows": [
     {
       "filePattern": "$file",
-      "kinesisStream": "$stack-$app-$stage"
+      "kinesisStream": "$kinesis_stream"
     }
   ]
 }

--- a/roles/aws-kinesis-agent/tasks/main.yml
+++ b/roles/aws-kinesis-agent/tasks/main.yml
@@ -21,6 +21,13 @@
   args:
     executable: /bin/bash
 
+- name: aws-kinesis-agent-user owns aws-kinesis-agent run folder (where checkpoint is stored)
+  file:
+    dest: /opt/aws-kinesis-agent/run
+    owner: aws-kinesis-agent-user
+    recurse: yes
+    state: directory
+
 - name: Add Amazon Kinesis Config Script
   copy:
     src: configure-aws-kinesis-agent


### PR DESCRIPTION
Ubuntu reset /var/run permissions after restart (between ami build and run), so the agent fails to be able to use its checkpoint file.
If file is in /opt it should be fine, happy to change to another location if preferred, but this folder is already created as part of the installation.

Revised to take a stream parameter instead of app, stack, stage as the kinesis stream is unlikely to be per app.