### PR TITLE
MSS-542: Kinesis Agent initialPosition: START_OF_FILE

### DIFF
--- a/roles/aws-kinesis-agent/files/configure-aws-kinesis-agent
+++ b/roles/aws-kinesis-agent/files/configure-aws-kinesis-agent
@@ -11,6 +11,7 @@ cat > /etc/aws-kinesis/agent.json <<__END__
   "flows": [
     {
       "filePattern": "$file",
+      "initialPosition", "START_OF_FILE",
       "kinesisStream": "$kinesis_stream"
     }
   ]


### PR DESCRIPTION
Current behaviour of cloud-watch-logs agent and no reason to change this.

See https://docs.aws.amazon.com/streams/latest/dev/writing-with-agents.html