### PR TITLE
Increase mmap limit for launching Elasticsearch docker containers

### DIFF
--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -2,6 +2,12 @@
 - name: set timezone to Europe/London
   timezone:
     name: Europe/London
+# Fixes launching Elasticseach in Docker
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
+- name: increase mmap limit
+  sysctl:
+    name: vm.max_map_count
+    value: 262144
 - name: create docker group
   group:
     name: docker


### PR DESCRIPTION
We tried to write integration tests that launch Elasticsearch in docker containers but hit the following error:

```
ERROR: [1] bootstrap checks failed
[1]: max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]
```

This update [follows the Elasticsearch guidance](https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html) and increases the limit on the hosts.

We have verified manually on a single agent that this fix works. Does anyone know how I can launch a CODE AMIgo agent to test it in reality?