### PR TITLE
Fix bakes using `node_version`

### DIFF
--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Store node path
   set_fact:
     node_location: /usr/local/{{archive_contents.files[0]}}bin
-
+  when: node_full_version is defined
 
 - name: Add node symlink in /usr/bin
   file:


### PR DESCRIPTION
#225 missed a check that broke backwards compatibility with existing builds that simply specified `node_version`.