### PR TITLE
Fix #238 by stopping the JVM caching DNS lookups forever.

### DIFF
--- a/roles/java8/tasks/main.yml
+++ b/roles/java8/tasks/main.yml
@@ -22,3 +22,9 @@
 - name: Install Java certificates
   command: /var/lib/dpkg/info/ca-certificates-java.postinst configure
   when: ansible_os_family == "Debian"
+
+## This modifies the JVM's DNS cache TTL, changing it from the default of INFINITY to 60
+## seconds. See this issue for full details: https://github.com/guardian/amigo/issues/238
+- name: Change JVM DNS cache TTL
+  command: sed -i'.backup' 's/#networkaddress.cache.ttl=.*/networkaddress.cache.ttl=60/g' $(dirname $(dirname $(readlink -f $(which javac))))/jre/lib/security/java.security
+


### PR DESCRIPTION
Co-authored-by: Roberto Tyley <roberto.tyley@gmail.com>