### PR TITLE
Ensure that Airflow has pg_config binary available for install.

### DIFF
--- a/roles/airflow/defaults/main.yml
+++ b/roles/airflow/defaults/main.yml
@@ -22,6 +22,7 @@ airflow_required_libs:
   - acl
   - gcc
   - jq
+  - libpq-dev
 
 # Owner
 airflow_user: airflow


### PR DESCRIPTION
This bake has been failing for a while, see [here](https://amigo.gutools.co.uk/recipes/datatech-airflow/bakes/62).

By adding this dependency, `pg_config` is available to execute the airflow installation.