### PR TITLE
Disable scheduler to prevent accidental AMI deletion

### DIFF
--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -187,7 +187,7 @@ class AppComponents(context: Context)
   val markOrphanedBakesForDeletion = new MarkOrphanedBakesForDeletion(prismAgents, dynamo)
 
   val housekeepingScheduler = new HousekeepingScheduler(scheduler, List(bakeDeletionHousekeeping, markOldUnusedBakesForDeletion, markOrphanedBakesForDeletion))
-  housekeepingScheduler.initialise()
+  //housekeepingScheduler.initialise()
 
   val debugAvailable = identity.stage != "PROD"
 


### PR DESCRIPTION
There is some evidence that the AMI deletion stuff has gone rogue. We're disabling it for now.