### PR TITLE
Propagate prism errors and check for staleness of response

### DIFF
--- a/app/attempt/Attempt.scala
+++ b/app/attempt/Attempt.scala
@@ -1,0 +1,234 @@
+package attempt
+
+import cats.data.EitherT
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.control.NonFatal
+
+/**
+ * Represents a value that will need to be calculated using an asynchronous
+ * computation that may fail.
+ */
+case class Attempt[A] private (underlying: Future[Either[Failure, A]]) {
+  def map[B](f: A => B)(implicit ec: ExecutionContext): Attempt[B] =
+    flatMap(a => Attempt.Right(f(a)))
+
+  def flatMap[B](f: A => Attempt[B])(implicit ec: ExecutionContext): Attempt[B] = Attempt {
+    asFuture.flatMap {
+      case Right(a) => f(a).asFuture
+      case Left(e) => Future.successful(Left(e))
+    }
+  }
+
+  def fold[B](failure: Failure => B, success: A => B)(implicit ec: ExecutionContext): Future[B] = {
+    asFuture.map(_.fold(failure, success))
+  }
+
+  def map2[B, C](bAttempt: Attempt[B])(f: (A, B) => C)(implicit ec: ExecutionContext): Attempt[C] = {
+    for {
+      a <- this
+      b <- bAttempt
+    } yield f(a, b)
+  }
+
+  def recoverWith(pf: PartialFunction[Failure, Attempt[A]])(implicit ec: ExecutionContext) = Attempt {
+    asFuture.flatMap {
+      case Right(a) =>
+        Attempt.Right(a).asFuture
+
+      case Left(err) =>
+        val ret = pf.lift(err) match {
+          case Some(attempt) => attempt
+          case None => Attempt.Left[A](err)
+        }
+
+        ret.asFuture
+    }
+  }
+
+  def transform[B](sf: A => Attempt[B], ef: Failure => Attempt[B])(implicit ec: ExecutionContext) = Attempt {
+    asFuture.flatMap {
+      case Right(a) => sf(a).asFuture
+      case Left(err) => ef(err).asFuture
+    }
+  }
+
+  /**
+   * If there is an error in the Future itself (e.g. a timeout) we convert it to a
+   * Left so we have a consistent error representation. Unfortunately, this means
+   * the error isn't being handled properly so we're left with just the information
+   * provided by the exception.
+   *
+   * Try to avoid hitting this method's failure case by always handling Future errors
+   * and creating a suitable failure instance for the problem.
+   */
+  def asFuture(implicit ec: ExecutionContext): Future[Either[Failure, A]] = {
+    underlying recover {
+      case err =>
+        scala.Left(UnknownFailure(err))
+    }
+  }
+
+  def toEitherT: EitherT[Future, Failure, A] = EitherT(underlying)
+
+  def isSuccess(implicit ec: ExecutionContext): Future[Boolean] = fold(_ => false, _ => true)
+  def isFailure(implicit ec: ExecutionContext): Future[Boolean] = fold(_ => true, _ => false)
+}
+
+object Attempt {
+  /**
+   * Changes generated `List[Attempt[A]]` to `Attempt[List[A]]` via provided
+   * traversal function (like `Future.traverse`).
+   *
+   * This implementation returns the first failure in the resulting list,
+   * or the successful result.
+   */
+  def traverse[A, B](as: List[A])(f: A => Attempt[B])(implicit ec: ExecutionContext): Attempt[List[B]] = {
+    as.foldRight[Attempt[List[B]]](Right(Nil))(f(_).map2(_)(_ :: _))
+  }
+
+  /**
+   * Option doesn't implement TraversableOnce, so here is a helper to invert it
+   */
+  def traverseOption[A, B](a: Option[A])(f: A => Attempt[B])(implicit ec: ExecutionContext): Attempt[Option[B]] = {
+    a match {
+      case None => Attempt.Right(None)
+      case Some(a) => f(a).map(Some.apply)
+    }
+  }
+
+  /**
+   * Using the provided traversal function, sequence the resulting attempts
+   * into a list that preserves failures.
+   *
+   * This is useful if failure is acceptable in part of the application.
+   */
+  def traverseWithFailures[A, B](as: List[A])(f: A => Attempt[B])(implicit ec: ExecutionContext): Attempt[List[Either[Failure, B]]] = {
+    sequenceWithFailures(as.map(f))
+  }
+
+  /**
+   * As with `Future.sequence`, changes `List[Attempt[A]]` to `Attempt[List[A]]`.
+   *
+   * This implementation returns the first failure in the list, or the successful result.
+   */
+  def sequence[A](responses: List[Attempt[A]])(implicit ec: ExecutionContext): Attempt[List[A]] = {
+    traverse(responses)(identity)
+  }
+
+  /**
+   * Option doesn't implement TraversableOnce so this is a little helper to invert it.
+   */
+  def sequenceOption[A](option: Option[Attempt[A]])(implicit ec: ExecutionContext): Attempt[Option[A]] = {
+    traverseOption(option)(identity)
+  }
+
+  /**
+   * Sequence these attempts into a list that preserves failures.
+   *
+   * This is useful if failure is acceptable in part of the application.
+   */
+  def sequenceWithFailures[A](attempts: List[Attempt[A]])(implicit ec: ExecutionContext): Attempt[List[Either[Failure, A]]] = {
+    async.Right(Future.traverse(attempts)(_.asFuture))
+  }
+
+  def fromEither[A](e: Either[Failure, A]): Attempt[A] =
+    Attempt(Future.successful(e))
+
+  def fromOption[A](optA: Option[A], ifNone: => Failure): Attempt[A] =
+    fromEither(optA.toRight(ifNone))
+
+  /**
+   * Run f and catch any non-fatal exceptions from the execution. This is typically used to wrap IO SDK calls.
+   * @param f function to run
+   * @param recovery partial function to convert thrown exceptions to Failure types
+   */
+  def catchNonFatal[A](f: => A)(recovery: PartialFunction[Throwable, Failure]): Attempt[A] = {
+    try {
+      Attempt.Right(f)
+    } catch {
+      case NonFatal(t) => Attempt.Left(recovery.lift(t).getOrElse(UnknownFailure(t)))
+    }
+  }
+
+  /**
+   * Run f and convert all non fatal exceptions to UnknownFailures. Best practice is to use catchNonFatal
+   * instead but this can be used when you don't know what kind of exceptions will be thrown or you have a blasé attitude.
+   */
+  def catchNonFatalBlasé[A](f: => A): Attempt[A] = catchNonFatal(f)(Map.empty)
+
+  /**
+   * Convert a plain `Future` value to an attempt by providing a recovery handler.
+   */
+  def fromFuture[A](future: Future[A])(recovery: PartialFunction[Throwable, Failure])(implicit ec: ExecutionContext): Attempt[A] = {
+    Attempt {
+      future
+        .map(scala.Right(_))
+        .recover {
+          case t =>
+            scala.Left(recovery(t))
+        }
+    }
+  }
+
+  /**
+   * Discard failures from a list of attempts.
+   *
+   * **Use with caution**.
+   */
+  def successfulAttempts[A](attempts: List[Attempt[A]])(implicit ec: ExecutionContext): Attempt[List[A]] = {
+    Attempt.async.Right {
+      Future.traverse(attempts)(_.asFuture).map(_.collect { case Right(a) => a })
+    }
+  }
+
+  /**
+   * Create an Attempt instance from a "good" value.
+   */
+  def Right[A](a: A): Attempt[A] =
+    Attempt(Future.successful(scala.Right(a)))
+
+  /**
+   * Syntax sugar to create an Attempt failure if there's only a single error.
+   */
+  def Left[A](err: Failure): Attempt[A] =
+    Attempt(Future.successful(scala.Left(err)))
+
+  /**
+   * Asynchronous versions of the Attempt Right/Left helpers for when you have
+   * a Future that returns a good/bad value directly.
+   */
+  object async {
+    /**
+     * Run f asynchronously and catch any non-fatal exceptions from the execution. This is typically used to wrap IO
+     * SDK calls.
+     * @param f function to run asynchronously
+     * @param recovery partial function to convert thrown exceptions to Failure types
+     */
+    def catchNonFatal[A](f: => A)(recovery: PartialFunction[Throwable, Failure])(implicit ec: ExecutionContext): Attempt[A] =
+      Attempt(Future(scala.Right(f)).recover {
+        case NonFatal(t) => scala.Left(recovery.lift(t).getOrElse(UnknownFailure(t)))
+      })
+
+    /**
+     * Run f asynchronously and convert all non fatal exceptions to UnknownFailures. Best practice is to use
+     * catchNonFatal instead but this can be used when you don't know what kind of exceptions will be thrown or you
+     * have a blasé attitude to exceptions.
+     */
+    def catchNonFatalBlasé[A](f: => A)(implicit ec: ExecutionContext): Attempt[A] = catchNonFatal(f)(Map.empty)
+
+    /**
+     * Create an Attempt from a Future of a good value.
+     */
+    def Right[A](fa: Future[A])(implicit ec: ExecutionContext): Attempt[A] =
+      Attempt(fa.map(scala.Right(_)))
+
+    /**
+     * Create an Attempt from a known failure in the future. For example,
+     * if a piece of logic fails but you need to make a Database/API call to
+     * get the failure information.
+     */
+    def Left[A](ferr: Future[Failure])(implicit ec: ExecutionContext): Attempt[A] =
+      Attempt(ferr.map(scala.Left(_)))
+  }
+}

--- a/app/attempt/Failure.scala
+++ b/app/attempt/Failure.scala
@@ -1,0 +1,52 @@
+package attempt
+
+import java.io.{ PrintWriter, StringWriter }
+
+sealed trait Failure {
+  def msg: String
+  def cause: Option[Throwable] = None
+
+  def toThrowable: Throwable = cause.getOrElse(new RuntimeException(msg))
+}
+
+/**
+ * This type of failure has a throwable which could potentially be logged
+ */
+sealed trait FailureWithThrowable extends Failure {
+  def throwable: Throwable
+  override def cause = Some(throwable)
+
+  // provide a default mechanism for showing the exception to a user
+  override def msg = {
+    val stringWriter = new StringWriter()
+    val writer = new PrintWriter(stringWriter)
+    throwable.printStackTrace(writer)
+
+    stringWriter.toString
+  }
+}
+
+case object PrismNotInitialisedFailure extends Failure {
+  val msg = "Prism is not yet initialised"
+}
+
+case class PrismStaleFailure(msg: String) extends Failure
+
+case class JsonParseFailure(msg: String) extends Failure
+
+case class HousekeepingFailure(msg: String) extends Failure
+
+case class ConfigurationFailure(msg: String) extends Failure
+
+case class UnknownFailure(throwable: Throwable) extends FailureWithThrowable
+
+case class AwsSdkFailure(throwable: Throwable) extends FailureWithThrowable
+
+object Failure {
+  def collect[A](eithers: List[Either[Failure, A]])(recurse: A => List[Failure]): List[Failure] = {
+    eithers.flatMap {
+      case Left(failure) => List(failure)
+      case Right(success) => recurse(success)
+    }
+  }
+}

--- a/app/attempt/package.scala
+++ b/app/attempt/package.scala
@@ -1,0 +1,16 @@
+import cats.syntax.either._
+
+package object attempt {
+
+  implicit class RichOption[A](option: Option[A]) {
+    def toAttempt(whenNone: => Failure): Attempt[A] = Attempt.fromOption(option, whenNone)
+  }
+
+  implicit class RichFailureEither[A](either: Either[Failure, A]) {
+    def toAttempt = Attempt.fromEither(either)
+  }
+
+  implicit class RichEither[Left, A](either: Either[Left, A]) {
+    def toAttempt(leftToFailure: Left => Failure) = Attempt.fromEither(either.leftMap(leftToFailure))
+  }
+}

--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -116,7 +116,7 @@ class AppComponents(context: Context)
   val prismAgents = new PrismAgents(prism, applicationLifecycle, actorSystem.scheduler, environment)
 
   // do this synchronously at startup so we can set permissions
-  val accountNumbers: Seq[String] = Await.result(prism.findAllAWSAccounts(), 30 seconds).map(_.accountNumber)
+  val accountNumbers: Seq[String] = Await.result(prism.findAllAWSAccounts().asFuture, 30 seconds).right.get.map(_.accountNumber)
 
   val sns: SNS = {
     val snsClient = AmazonSNSClientBuilder.standard

--- a/app/housekeeping/BakeDeletion.scala
+++ b/app/housekeeping/BakeDeletion.scala
@@ -1,5 +1,6 @@
 package housekeeping
 
+import attempt.Attempt
 import data.{ BakeLogs, Bakes, Dynamo }
 import models.BakeId
 import notification.NotificationSender
@@ -7,40 +8,49 @@ import org.quartz.SimpleScheduleBuilder
 import prism.RecipeUsage
 import services.{ Loggable, PrismAgents }
 
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
 /*
   This class deletes bakes that have been marked deleted
  */
 class BakeDeletion(dynamo: Dynamo,
     amigoAwsAccount: String,
     prismAgents: PrismAgents,
-    notificationSender: NotificationSender) extends HousekeepingJob with Loggable {
+    notificationSender: NotificationSender)(implicit ec: ExecutionContext) extends HousekeepingJob with Loggable {
 
   implicit private val implDynamo: Dynamo = dynamo
   implicit private val implPrismAgents: PrismAgents = prismAgents
 
   override val schedule = SimpleScheduleBuilder.repeatMinutelyForever(1)
+  override val timeout: Duration = 10 minutes
 
-  def housekeep(): Unit = {
+  def housekeep(executionContext: ExecutionContext): Attempt[Unit] = {
     log.info(s"Started bake deletion housekeeping")
 
     // get some bakes that have been deleted
     val deletedBakes = Bakes.findDeleted()
 
-    log.info(s"Found ${deletedBakes.size} bakes to delete")
+    if (deletedBakes.nonEmpty) { log.info(s"Found ${deletedBakes.size} bakes to delete") }
 
     // delete any AMIs
     val amis = deletedBakes.flatMap(_.amiId)
-    val allAmis = RecipeUsage.allAmis(amis, amigoAwsAccount)
-    notificationSender.sendHousekeepingTopicMessage(allAmis)
 
-    // delete the logs and bakes
-    deletedBakes.foreach { bake =>
-      val bakeId = BakeId(bake.recipeId, bake.buildNumber)
-      log.info(s"Deleting $bakeId")
-      BakeLogs.delete(bakeId)
-      Bakes.deleteById(bakeId)
-      // avoid overwhelming the DB by pausing briefly before the next one
-      Thread.sleep(2000)
+    for {
+      allAmis <- RecipeUsage.allAmis(amis, amigoAwsAccount)
+    } yield {
+      notificationSender.sendHousekeepingTopicMessage(allAmis)
+
+      // delete the logs and bakes
+      deletedBakes.foreach { bake =>
+        val bakeId = BakeId(bake.recipeId, bake.buildNumber)
+        log.info(s"Deleting $bakeId")
+        BakeLogs.delete(bakeId)
+        Bakes.deleteById(bakeId)
+        // avoid overwhelming the DB by pausing briefly before the next one
+        Thread.sleep(2000)
+      }
     }
   }
 }

--- a/app/housekeeping/HousekeepingJob.scala
+++ b/app/housekeeping/HousekeepingJob.scala
@@ -1,14 +1,19 @@
 package housekeeping
 
+import attempt.Attempt
 import org.quartz._
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.Duration
 
 trait HousekeepingJob {
   val schedule: ScheduleBuilder[_ <: Trigger]
+  val timeout: Duration
 
   val name: String = getClass.getName
 
   val jobKey = new JobKey(name)
   val triggerKey = new TriggerKey(name)
 
-  def housekeep(): Unit
+  def housekeep(executionContext: ExecutionContext): Attempt[Unit]
 }

--- a/app/housekeeping/HousekeepingJobWrapper.scala
+++ b/app/housekeeping/HousekeepingJobWrapper.scala
@@ -1,10 +1,13 @@
 package housekeeping
 
 import org.quartz.{ DisallowConcurrentExecution, Job, JobDataMap, JobExecutionContext }
+import services.Loggable
+
+import scala.concurrent.{ Await, ExecutionContext }
 
 /** Quartz job wrapper for [[schedule.ScheduledBakeRunner]] */
 @DisallowConcurrentExecution
-class HousekeepingJobWrapper extends Job {
+class HousekeepingJobWrapper extends Job with Loggable {
 
   private def getAs[T](key: String)(implicit jobDataMap: JobDataMap): T = jobDataMap.get(key).asInstanceOf[T]
 
@@ -12,8 +15,12 @@ class HousekeepingJobWrapper extends Job {
     implicit val jobDataMap: JobDataMap = context.getJobDetail.getJobDataMap
 
     val housekeepingJob = getAs[HousekeepingJob](HousekeepingScheduler.HousekeepingJobInstance)
+    implicit val ec = getAs[ExecutionContext](HousekeepingScheduler.HousekeepingJobInstance)
 
-    housekeepingJob.housekeep()
+    val result = housekeepingJob.housekeep(ec).fold({
+      failure => log.warn(s"${housekeepingJob.getClass.getSimpleName} failed with $failure")
+    }, identity)
+    Await.ready(result, housekeepingJob.timeout)
   }
 
 }

--- a/app/housekeeping/HousekeepingScheduler.scala
+++ b/app/housekeeping/HousekeepingScheduler.scala
@@ -4,7 +4,9 @@ import org.quartz.{ JobDataMap, Scheduler }
 import org.quartz.JobBuilder._
 import org.quartz.TriggerBuilder._
 
-class HousekeepingScheduler(scheduler: Scheduler, housekeepingJobs: List[HousekeepingJob]) {
+import scala.concurrent.ExecutionContext
+
+class HousekeepingScheduler(scheduler: Scheduler, housekeepingJobs: List[HousekeepingJob])(implicit ec: ExecutionContext) {
 
   def initialise(): Unit = {
     housekeepingJobs.foreach { housekeepingJob =>
@@ -23,10 +25,12 @@ class HousekeepingScheduler(scheduler: Scheduler, housekeepingJobs: List[Houseke
   private def buildJobDataMap(housekeepingJob: HousekeepingJob): JobDataMap = {
     val map = new JobDataMap()
     map.put(HousekeepingScheduler.HousekeepingJobInstance, housekeepingJob)
+    map.put(HousekeepingScheduler.HousekeepingExecutionContext, ec)
     map
   }
 }
 
 object HousekeepingScheduler {
   val HousekeepingJobInstance = "HousekeepingJobInstance"
+  val HousekeepingExecutionContext = "HousekeepingExecutionContext"
 }

--- a/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
+++ b/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
@@ -1,11 +1,16 @@
 package housekeeping
 
+import attempt.Attempt
 import data.{ Bakes, Dynamo, Recipes }
 import models.{ Bake, RecipeId }
 import org.joda.time.{ DateTime, Duration }
 import org.quartz.SimpleScheduleBuilder
 import prism.RecipeUsage
 import services.{ Loggable, PrismAgents }
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
 object MarkOldUnusedBakesForDeletion {
   val MAX_AGE = 30
@@ -15,38 +20,45 @@ object MarkOldUnusedBakesForDeletion {
     recipeIds: Set[RecipeId],
     now: DateTime,
     listBakes: RecipeId => Iterable[Bake],
-    getRecipeUsage: Iterable[Bake] => RecipeUsage): Set[Bake] = {
+    getRecipeUsage: Iterable[Bake] => Attempt[RecipeUsage])(implicit executionContext: ExecutionContext): Attempt[Set[Bake]] = {
     val allBakes = recipeIds.flatMap(listBakes)
 
     val oldBakes = allBakes.filter { bake =>
       val duration = new Duration(bake.startedAt, now)
       duration.getStandardDays > MAX_AGE
     }
-    val recipeUsage = getRecipeUsage(oldBakes)
-    val usedBakes = recipeUsage.bakeUsage.map(_.bake).distinct.toSet
-
-    oldBakes -- usedBakes
+    for {
+      recipeUsage <- getRecipeUsage(oldBakes)
+      usedBakes = recipeUsage.bakeUsage.map(_.bake).distinct.toSet
+    } yield {
+      oldBakes -- usedBakes
+    }
   }
 }
 
 class MarkOldUnusedBakesForDeletion(prismAgents: PrismAgents, dynamo: Dynamo) extends HousekeepingJob with Loggable {
   override val schedule = SimpleScheduleBuilder.repeatHourlyForever(1)
+  override val timeout = 10 minutes
 
-  override def housekeep(): Unit = {
+  override def housekeep(executionContext: ExecutionContext): Attempt[Unit] = {
     implicit val implicitPrismAgents: PrismAgents = prismAgents
     implicit val implicitDynamo: Dynamo = dynamo
+    implicit val implcitExecutionContext: ExecutionContext = executionContext
     log.info(s"Started marking old, unused bakes for deletion")
     val now = new DateTime()
     val recipeIds = Recipes.list().map(_.id).toSet
-    val oldUnusedBakes = MarkOldUnusedBakesForDeletion.getOldUnusedBakes(recipeIds, now, Bakes.list, RecipeUsage.apply)
-    log.info(s"Found ${oldUnusedBakes.size} unused bakes over ${MarkOldUnusedBakesForDeletion.MAX_AGE} days old")
+    for {
+      oldUnusedBakes <- MarkOldUnusedBakesForDeletion.getOldUnusedBakes(recipeIds, now, Bakes.list, RecipeUsage.apply)
+    } yield {
+      if (oldUnusedBakes.nonEmpty) log.info(s"Found ${oldUnusedBakes.size} unused bakes over ${MarkOldUnusedBakesForDeletion.MAX_AGE} days old")
 
-    val bakesToMark = oldUnusedBakes.take(MarkOldUnusedBakesForDeletion.BATCH_SIZE)
-    log.info(s"Marking ${bakesToMark.size} unused bakes for deletion")
+      val bakesToMark = oldUnusedBakes.take(MarkOldUnusedBakesForDeletion.BATCH_SIZE)
+      if (bakesToMark.nonEmpty) log.info(s"Marking ${bakesToMark.size} unused bakes for deletion")
 
-    bakesToMark.foreach { bake =>
-      Bakes.markToDelete(bake.bakeId)
-      log.info(s"Marked ${bake.bakeId} for deletion")
+      bakesToMark.foreach { bake =>
+        Bakes.markToDelete(bake.bakeId)
+        log.info(s"Marked ${bake.bakeId} for deletion")
+      }
     }
   }
 }

--- a/app/prism/RecipeUsage.scala
+++ b/app/prism/RecipeUsage.scala
@@ -1,8 +1,11 @@
 package prism
 
+import attempt._
 import models.{ AmiId, Bake, Recipe, RecipeId }
 import prism.Prism.{ Image, Instance, LaunchConfiguration }
 import services.PrismAgents
+
+import scala.concurrent.ExecutionContext
 
 case class Ami(account: String, id: AmiId)
 
@@ -14,46 +17,53 @@ object RecipeUsage {
 
   def noUsage(): RecipeUsage = RecipeUsage(Seq.empty[Instance], Seq.empty[LaunchConfiguration], Seq.empty[BakeUsage])
 
-  def allAmis(amiIds: Iterable[AmiId], amigoAccount: String)(implicit prismAgents: PrismAgents): List[Ami] = {
+  def allAmis(amiIds: Iterable[AmiId], amigoAccount: String)(implicit prismAgents: PrismAgents, ec: ExecutionContext): Attempt[List[Ami]] = {
     val amis = amiIds.map(Ami(amigoAccount, _))
 
-    val copiedAmiImages = prismAgents.copiedImages(amiIds.toSet).values.flatten
-    val copiedAmis = copiedAmiImages.map(image => Ami(image.ownerId, image.imageId))
-
-    amis.toList ++ copiedAmis
+    for {
+      copiedAmiImagesMap <- prismAgents.copiedImages(amiIds.toSet)
+      copiedAmiImages = copiedAmiImagesMap.values.flatten
+    } yield {
+      val copiedAmis = copiedAmiImages.map(image => Ami(image.ownerId, image.imageId))
+      amis.toList ++ copiedAmis
+    }
   }
 
-  def apply(bakes: Iterable[Bake])(implicit prismAgents: PrismAgents): RecipeUsage = {
+  def apply(bakes: Iterable[Bake])(implicit prismAgents: PrismAgents, ec: ExecutionContext): Attempt[RecipeUsage] = {
     val bakedAmiLookupMap = bakes.flatMap(b => b.amiId.map(_ -> b)).toMap
     val bakedAmiIds = bakedAmiLookupMap.keys.toList
-    val copiedAmis = prismAgents.copiedImages(bakedAmiIds.toSet).values.flatten
-    val copiedAmiIds = copiedAmis.map(_.imageId)
 
-    val amiIds = bakedAmiIds ++ copiedAmiIds
-    val instances = prismAgents.allInstances.filter(instance => amiIds.contains(instance.imageId))
-    val launchConfigurations = prismAgents.allLaunchConfigurations.filter(lc => amiIds.contains(lc.imageId))
-    val amis = (instances.map(_.imageId) ++ launchConfigurations.map(_.imageId)).distinct
-
-    val copiedAmiLookupMap = copiedAmis.map { image => image.imageId -> image }.toMap
-
-    val bakeUsage = amis.map { ami =>
-      val maybeDirectBake = bakedAmiLookupMap.get(ami)
-      val maybeCopy = copiedAmiLookupMap.get(ami)
-      val bake = (maybeDirectBake, maybeCopy) match {
-        case (Some(directBake), None) => directBake
-        case (None, Some(copy)) => bakedAmiLookupMap(copy.copiedFromAMI)
-        case _ => throw new IllegalArgumentException("AMI ID provided neither direct nor copied")
+    for {
+      copiedAmiImagesMap <- prismAgents.copiedImages(bakedAmiIds.toSet)
+      copiedAmis = copiedAmiImagesMap.values.flatten
+      copiedAmiIds = copiedAmis.map(_.imageId)
+      copiedAmiLookupMap = copiedAmis.map { image => image.imageId -> image }.toMap
+      amisThatExist = bakedAmiIds ++ copiedAmiIds
+      allInstances <- prismAgents.allInstances
+      instances = allInstances.filter(instance => amisThatExist.contains(instance.imageId))
+      allLaunchConfigurations <- prismAgents.allLaunchConfigurations
+      launchConfigurations = allLaunchConfigurations.filter(lc => amisThatExist.contains(lc.imageId))
+      amisInUse = (instances.map(_.imageId) ++ launchConfigurations.map(_.imageId)).distinct
+    } yield {
+      val bakeUsage = amisInUse.map { ami =>
+        val maybeDirectBake = bakedAmiLookupMap.get(ami)
+        val maybeCopy = copiedAmiLookupMap.get(ami)
+        val bake = (maybeDirectBake, maybeCopy) match {
+          case (Some(directBake), None) => directBake
+          case (None, Some(copy)) => bakedAmiLookupMap(copy.copiedFromAMI)
+          case _ => throw new IllegalArgumentException("AMI ID provided neither direct nor copied")
+        }
+        val amiInstances = instances.filter(_.imageId == ami)
+        val amiLc = launchConfigurations.filter(_.imageId == ami)
+        BakeUsage(ami, bake, maybeCopy, amiInstances, amiLc)
       }
-      val amiInstances = instances.filter(_.imageId == ami)
-      val amiLc = launchConfigurations.filter(_.imageId == ami)
-      BakeUsage(ami, bake, maybeCopy, amiInstances, amiLc)
-    }
 
-    RecipeUsage(instances, launchConfigurations, bakeUsage)
+      RecipeUsage(instances, launchConfigurations, bakeUsage)
+    }
   }
 
-  def forAll(recipes: Iterable[Recipe], findBakes: RecipeId => Iterable[Bake])(implicit prismAgents: PrismAgents): Map[Recipe, RecipeUsage] = {
-    recipes.map(r => r -> apply(findBakes(r.id))).toMap
+  def forAll(recipes: Iterable[Recipe], findBakes: RecipeId => Iterable[Bake])(implicit prismAgents: PrismAgents, ec: ExecutionContext): Attempt[Map[Recipe, RecipeUsage]] = {
+    Attempt.traverse(recipes.toList)(r => apply(findBakes(r.id)).map(r -> _)).map(_.toMap)
   }
 
 }

--- a/app/services/PrismAgents.scala
+++ b/app/services/PrismAgents.scala
@@ -2,36 +2,57 @@ package services
 
 import akka.agent.Agent
 import akka.actor.{Cancellable, Scheduler}
+import attempt._
 import models.AmiId
+import org.joda.time.DateTime
 import play.api.inject.ApplicationLifecycle
 import play.api.{Environment, Mode}
 import prism.Prism
 import prism.Prism.{AWSAccount, Image, Instance, LaunchConfiguration}
 
 import scala.collection.SeqLike
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
+
+import scala.language.postfixOps
+
+object PrismAgents {
+  val MAX_AGE: Long = 15 * 60 * 1000
+
+  type CacheData[T] = Attempt[(T, DateTime)]
+  def dataToResult[T](data: CacheData[T], now: DateTime)(implicit exec: ExecutionContext): Attempt[T] = {
+    data.flatMap { case (t, timestamp) =>
+      val age = now.getMillis - timestamp.getMillis
+      if (age > MAX_AGE) {
+        Attempt.Left(PrismStaleFailure(s"AMIgo internal data cache is stale - last update at $timestamp"))
+      } else {
+        Attempt.Right(t)
+      }
+    }
+  }
+}
 
 class PrismAgents(prism: Prism,
     lifecycle: ApplicationLifecycle,
     scheduler: Scheduler,
     environment: Environment)(implicit exec: ExecutionContext) extends Loggable {
 
-  private val instancesAgent: Agent[Seq[Instance]] = Agent(Seq.empty)
-  private val launchConfigurationsAgent: Agent[Seq[LaunchConfiguration]] = Agent(Seq.empty)
-  private val copiedImagesAgent: Agent[Map[AmiId, Seq[Image]]] = Agent(Map.empty)
-  private val accountsAgent: Agent[Seq[AWSAccount]] = Agent(Seq.empty)
+  import PrismAgents._
+
+  private val instancesAgent: Agent[CacheData[Seq[Instance]]] = Agent(Attempt.Left(PrismNotInitialisedFailure))
+  private val launchConfigurationsAgent: Agent[CacheData[Seq[LaunchConfiguration]]] = Agent(Attempt.Left(PrismNotInitialisedFailure))
+  private val copiedImagesAgent: Agent[CacheData[Map[AmiId, Seq[Image]]]] = Agent(Attempt.Left(PrismNotInitialisedFailure))
+  private val accountsAgent: Agent[CacheData[Seq[AWSAccount]]] = Agent(Attempt.Left(PrismNotInitialisedFailure))
 
   val baseUrl: String = prism.baseUrl
 
-  def allInstances: Seq[Instance] = instancesAgent.get
-  def allLaunchConfigurations: Seq[LaunchConfiguration] = launchConfigurationsAgent.get
-  def copiedImages(sourceAmiIds: Set[AmiId]): Map[AmiId, Seq[Image]] = copiedImagesAgent.get.filterKeys(sourceAmiIds.contains)
-  def accounts: Seq[AWSAccount] = accountsAgent.get
+  def allInstances: Attempt[Seq[Instance]] = dataToResult(instancesAgent.get, DateTime.now)
+  def allLaunchConfigurations: Attempt[Seq[LaunchConfiguration]] = dataToResult(launchConfigurationsAgent.get, DateTime.now)
+  def copiedImages(sourceAmiIds: Set[AmiId]): Attempt[Map[AmiId, Seq[Image]]] = dataToResult(copiedImagesAgent.get, DateTime.now).map(_.filterKeys(sourceAmiIds.contains))
+  def accounts: Attempt[Seq[AWSAccount]] = dataToResult(accountsAgent.get, DateTime.now)
 
   if (environment.mode != Mode.Test) {
-
-    val prismDataSchedule: Cancellable = scheduler.schedule(0.seconds, 1.minutes) {
+    val prismDataSchedule: Cancellable = scheduler.schedule(0 seconds, 1 minute) {
       log.debug(s"Refreshing Prism data")
       refresh
     }
@@ -42,22 +63,27 @@ class PrismAgents(prism: Prism,
     }
   }
 
-  private def refresh: Future[Unit] = {
-    refresh(prism.findAllInstances(), instancesAgent, "instances")(identity)
-    refresh(prism.findAllLaunchConfigurations(), launchConfigurationsAgent, "launch configuration")(identity)
-    refresh(prism.findCopiedImages(), copiedImagesAgent, "copied image")(_.groupBy(_.copiedFromAMI))
-    refresh(prism.findAllAWSAccounts(), accountsAgent, "aws accounts")(identity)
+  private def refresh: Unit = {
+    val results = Await.result(Attempt.sequenceWithFailures(List(
+      refresh(prism.findAllInstances(), instancesAgent, "instances")(identity),
+      refresh(prism.findAllLaunchConfigurations(), launchConfigurationsAgent, "launch configuration")(identity),
+      refresh(prism.findCopiedImages(), copiedImagesAgent, "copied image")(_.groupBy(_.copiedFromAMI)),
+      refresh(prism.findAllAWSAccounts(), accountsAgent, "aws accounts")(identity)
+    )).asFuture, 1 minute)
+    results match {
+      case Left(failure) => log.warn(s"Failure whilst refreshing Prism: $failure")
+      case Right(nestedResults) => nestedResults.foreach {
+        case Left(failure) => log.warn(s"Failure when refreshing Prism: $failure")
+        case _ => // don't log success
+      }
+    }
   }
 
-  private def refresh[T <: SeqLike[_, _], R](source: => Future[T], agent: Agent[R], name: String)(transform: T => R): Future[Unit] = {
+  private def refresh[T <: SeqLike[_, _], R](source: => Attempt[T], agent: Agent[CacheData[R]], name: String)(transform: T => R): Attempt[Unit] = {
     source
       .map { sourceData =>
         log.debug(s"Prism: Loaded ${sourceData.length} $name")
-        agent.send(transform(sourceData))
-      }
-      .recover {
-        case t =>
-          log.warn(s"Prism: Failed to update $name: ${t.getLocalizedMessage}")
+        agent.send(Attempt.Right(transform(sourceData) -> DateTime.now))
       }
   }
 

--- a/test/prism/PrismSpec.scala
+++ b/test/prism/PrismSpec.scala
@@ -3,16 +3,15 @@ package prism
 import models.AmiId
 import org.scalatest.{ FlatSpec, Matchers }
 import play.api.mvc.{ Action, Results }
+import play.api.routing.sird._
 import play.api.test.WsTestClient
 import play.core.server.Server
-import play.api.routing.sird._
 import prism.Prism.{ AWSAccount, Instance, LaunchConfiguration }
+import test.AttemptValues
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class PrismSpec extends FlatSpec with Matchers {
+class PrismSpec extends FlatSpec with Matchers with AttemptValues {
 
   def withPrismClient[T](block: Prism => T): T = {
     Server.withRouter() {
@@ -34,14 +33,14 @@ class PrismSpec extends FlatSpec with Matchers {
 
   it should "fetch all AWS account numbers" in {
     withPrismClient { prism =>
-      val accounts = Await.result(prism.findAllAWSAccounts(), 10.seconds)
+      val accounts = prism.findAllAWSAccounts().successValue
       accounts should be(Seq(AWSAccount("foo", "1234"), AWSAccount("bar", "5678")))
     }
   }
 
   it should "fetch all instances" in {
     withPrismClient { prism =>
-      val instances = Await.result(prism.findAllInstances(), 10.seconds)
+      val instances = prism.findAllInstances().successValue
       instances should be(Seq(
         Instance("i-123456", AmiId("ami-fa123456"), AWSAccount("MyAccount", "1234567890")),
         Instance("i-b123456", AmiId("ami-abcd4321"), AWSAccount("MyAccount", "1234567890"))
@@ -51,7 +50,7 @@ class PrismSpec extends FlatSpec with Matchers {
 
   it should "fetch all launch configurations" in {
     withPrismClient { prism =>
-      val launchConfigurations = Await.result(prism.findAllLaunchConfigurations(), 10.seconds)
+      val launchConfigurations = prism.findAllLaunchConfigurations().successValue
       launchConfigurations should be(Seq(
         LaunchConfiguration("MyName", AmiId("ami-abcdefg1"), AWSAccount("MyAccount", "1234567890")),
         LaunchConfiguration("MyId", AmiId("ami-gfedcba2"), AWSAccount("MyAccount", "1234567890"))

--- a/test/test/AttemptValues.scala
+++ b/test/test/AttemptValues.scala
@@ -1,0 +1,104 @@
+package test
+
+import org.scalatest.EitherValues
+import org.scalatest.concurrent.{ PatienceConfiguration, ScalaFutures }
+import org.scalatest.exceptions.{ StackDepthException, TestFailedException }
+import attempt.{ Attempt, Failure }
+import org.scalatest.time.{ Millis, Seconds, Span }
+
+import scala.concurrent.ExecutionContext
+
+trait SomePatience extends PatienceConfiguration {
+  implicit override val patienceConfig = PatienceConfig(scaled(Span(5, Seconds)), scaled(Span(10, Millis)))
+}
+
+trait AttemptValues extends EitherValues with ScalaFutures with SomePatience {
+  import StackDepthExceptionHelper.getStackDepthFun
+  /**
+   * Utility for dealing with attempts in tests
+   */
+  implicit class RichAttempt[A](attempt: Attempt[A]) {
+    def whenReady(implicit ec: ExecutionContext) = attempt.asFuture.futureValue
+
+    def throwableValue: Throwable = {
+      val result = try {
+        attempt.underlying.futureValue
+      } catch {
+        case testFailed: TestFailedException => throw testFailed
+        case expectedThrowable: Throwable => expectedThrowable
+      }
+      throw new TestFailedException((_: StackDepthException) => Some(s"Attempt did not result in a thrown exception, got $result instead"), None, getStackDepthFun("AttemptValues.scala", "result"))
+    }
+
+    def failureValue: Failure = {
+      val underlyingEither: Either[Failure, A] = eitherValue
+      try {
+        underlyingEither.left.get
+      } catch {
+        case cause: NoSuchElementException =>
+          throw new TestFailedException((_: StackDepthException) => Some(s"Expected Attempt to have failed, but was successful: $underlyingEither"), Some(cause), getStackDepthFun("AttemptValues.scala", "result"))
+      }
+    }
+
+    def successValue: A = {
+      val underlyingEither: Either[Failure, A] = eitherValue
+      try {
+        underlyingEither.right.get
+      } catch {
+        case cause: NoSuchElementException =>
+          throw new TestFailedException((_: StackDepthException) => Some(s"Expected Attempt to have succeeded, but failed: $underlyingEither"), Some(cause), getStackDepthFun("AttemptValues.scala", "result"))
+      }
+    }
+
+    def eitherValue = {
+      try {
+        attempt.underlying.futureValue
+      } catch {
+        case testFailed: TestFailedException => throw testFailed
+        case cause: Throwable =>
+          throw new TestFailedException((_: StackDepthException) => Some(s"Attempt resulted in a thrown exception in the underlying Future"), Some(cause), getStackDepthFun("AttemptValues.scala", "result"))
+      }
+    }
+  }
+}
+
+object StackDepthExceptionHelper {
+
+  def getStackDepth(stackTrace: Array[StackTraceElement], fileName: String, methodName: String, adjustment: Int = 0) = {
+    val stackTraceList = stackTrace.toList
+
+    val fileNameIsDesiredList: List[Boolean] =
+      for (element <- stackTraceList) yield element.getFileName == fileName // such as "Checkers.scala"
+
+    val methodNameIsDesiredList: List[Boolean] =
+      for (element <- stackTraceList) yield element.getMethodName == methodName // such as "check"
+
+    // For element 0, the previous file name was not desired, because there is no previous
+    // one, so you start with false. For element 1, it depends on whether element 0 of the stack trace
+    // had the desired file name, and so forth.
+    val previousFileNameIsDesiredList: List[Boolean] = false :: (fileNameIsDesiredList.dropRight(1))
+
+    // Zip these two related lists together. They now have two boolean values together, when both
+    // are true, that's a stack trace element that should be included in the stack depth.
+    val zipped1 = methodNameIsDesiredList zip previousFileNameIsDesiredList
+    val methodNameAndPreviousFileNameAreDesiredList: List[Boolean] =
+      for ((methodNameIsDesired, previousFileNameIsDesired) <- zipped1) yield methodNameIsDesired && previousFileNameIsDesired
+
+    // Zip the two lists together, that when one or the other is true is an include.
+    val zipped2 = fileNameIsDesiredList zip methodNameAndPreviousFileNameAreDesiredList
+    val includeInStackDepthList: List[Boolean] =
+      for ((fileNameIsDesired, methodNameAndPreviousFileNameAreDesired) <- zipped2) yield fileNameIsDesired || methodNameAndPreviousFileNameAreDesired
+
+    val includeDepth = includeInStackDepthList.takeWhile(include => include).length
+    val depth = if (includeDepth == 0 && stackTrace(0).getFileName != fileName && stackTrace(0).getMethodName != methodName)
+      stackTraceList.takeWhile(st => st.getFileName != fileName || st.getMethodName != methodName).length
+    else
+      includeDepth
+
+    depth + adjustment
+  }
+
+  def getStackDepthFun(fileName: String, methodName: String, adjustment: Int = 0): (StackDepthException => Int) = { sde =>
+    getStackDepth(sde.getStackTrace, fileName, methodName, adjustment)
+  }
+}


### PR DESCRIPTION
AMIgo has been deleting AMIs that were in use due to a race condition at startup. If AMIgo runs a housekeeping job before it has managed to populate data from Prism it will think that no AMIs are in use as the instance and launch config lists will be empty. This is *not good*™️.

This PR:
 - introduces `Attempt` into the codebase and uses it to propagate error conditions from the Prism API (this wasn't strictly necessary but the codebase is on Scala 2.11 and no cats so no right biased either)
 - changes the initial state of the prism caches from `[]` to `Attempt.Left(NotInitialised)`
 - never sets the data cache back to `[]` when it can't parse the prism response
 - will not use stale data from prism
 - internally flags prism data as stale when we've not successfully updated in 15 minutes
 - modifies housekeeping and controller routes to deal with the resulting attempts that are propagated to the edge

### How to review
I'd strongly recommend starting at `app/prism/Prism.scala` and `app/services/PrismAgents.scala` as everything cascades from there. You might well want to load it into a real editor.