### PR TITLE
Fix initialisation race condition by dealing with empty prism cache

### DIFF
--- a/app/housekeeping/BakeDeletion.scala
+++ b/app/housekeeping/BakeDeletion.scala
@@ -26,7 +26,7 @@ class BakeDeletion(dynamo: Dynamo,
     // get some bakes that have been deleted
     val deletedBakes = Bakes.findDeleted()
 
-    log.info(s"Found ${deletedBakes.size} bakes to delete")
+    if (deletedBakes.nonEmpty) log.info(s"Found ${deletedBakes.size} bakes to delete")
 
     // delete any AMIs
     val amis = deletedBakes.flatMap(_.amiId)

--- a/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
+++ b/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
@@ -39,10 +39,10 @@ class MarkOldUnusedBakesForDeletion(prismAgents: PrismAgents, dynamo: Dynamo) ex
     val now = new DateTime()
     val recipeIds = Recipes.list().map(_.id).toSet
     val oldUnusedBakes = MarkOldUnusedBakesForDeletion.getOldUnusedBakes(recipeIds, now, Bakes.list, RecipeUsage.apply)
-    log.info(s"Found ${oldUnusedBakes.size} unused bakes over ${MarkOldUnusedBakesForDeletion.MAX_AGE} days old")
+    if (oldUnusedBakes.nonEmpty) log.info(s"Found ${oldUnusedBakes.size} unused bakes over ${MarkOldUnusedBakesForDeletion.MAX_AGE} days old")
 
     val bakesToMark = oldUnusedBakes.take(MarkOldUnusedBakesForDeletion.BATCH_SIZE)
-    log.info(s"Marking ${bakesToMark.size} unused bakes for deletion")
+    if (bakesToMark.nonEmpty) log.info(s"Marking ${bakesToMark.size} unused bakes for deletion")
 
     bakesToMark.foreach { bake =>
       Bakes.markToDelete(bake.bakeId)

--- a/app/housekeeping/MarkOrphanedBakesForDeletion.scala
+++ b/app/housekeeping/MarkOrphanedBakesForDeletion.scala
@@ -33,7 +33,7 @@ class MarkOrphanedBakesForDeletion(prismAgents: PrismAgents, dynamo: Dynamo) ext
       case _ =>
         val bakes = Bakes.scanForAll()
         val orphanedBakeIds = MarkOrphanedBakesForDeletion.findOrphanedBakeIds(recipes.map(_.id).toSet, bakes)
-        log.info(s"Marking ${orphanedBakeIds.size} orphaned bakes for deletion")
+        if (orphanedBakeIds.nonEmpty) log.info(s"Marking ${orphanedBakeIds.size} orphaned bakes for deletion")
         orphanedBakeIds.foreach { bakeId =>
           Bakes.markToDelete(bakeId)
           log.info(s"Marked ${bakeId.toString} for deletion")


### PR DESCRIPTION
A smaller more comprehensible alternative to #304 in response to @adamnfish fair criticism of the half-hearted adoption of `Attempt`.

AMIgo has been deleting AMIs that were in use due to a race condition at startup. If AMIgo runs a housekeeping job before it has managed to populate data from Prism it will think that no AMIs are in use as the instance and launch config lists will be empty. This is not good™️.

This PR:
- changes the initial state of the prism caches from `[]` to `Left(NotInitialised)`
- never sets the data cache back to `[]` when it can't parse the prism response
- will not use stale data from prism
- internally flags prism data as stale when we've not successfully updated in 15 minutes