### PR TITLE
Include the AWS SAM cli tool in the teamcity recipe

### DIFF
--- a/roles/teamcity-agent/meta/main.yml
+++ b/roles/teamcity-agent/meta/main.yml
@@ -8,4 +8,4 @@ dependencies:
       - software-properties-common
       - zip
   - role: pip-packages 
-    packages: [boto3, botocore]
+    packages: [boto3, botocore, aws-sam-cli]


### PR DESCRIPTION
This is required for running the `sam` CLI tool during builds on teamcity. Don't think it will impact anything else so should be safe.