### PR TITLE
bake timeout - handle case when EC2 instance not found

### DIFF
--- a/app/housekeeping/TimeOutLongRunningBakes.scala
+++ b/app/housekeeping/TimeOutLongRunningBakes.scala
@@ -42,10 +42,7 @@ class TimeOutLongRunningBakes private[housekeeping](stage: String, bakesRepo: Ba
 
       packerEC2Client.getInstance(bake.bakeId) match {
         case None =>
-          log.warn(
-            s"unable to find instance associated with long running bake ${bake.bakeId} - " +
-            "assuming instance was deleted manually"
-          )
+          log.warn(s"unable to find instance associated with long running bake ${bake.bakeId}")
 
         case Some(instance) =>
           val instanceId = instance.getInstanceId


### PR DESCRIPTION
Following up from the DevX chat...

If a bake has run for over an hour, but we can't find the associated EC2 instance, still update the status of the bake to TimedOut. This is to handle cases where e.g. the EC2 instance was deleted manually.