### PR TITLE
Revert "Revert to t2.micro"

### DIFF
--- a/app/packer/PackerBuildConfigGenerator.scala
+++ b/app/packer/PackerBuildConfigGenerator.scala
@@ -31,7 +31,7 @@ object PackerBuildConfigGenerator {
       vpc_id = packerConfig.vpcId,
       subnet_id = packerConfig.subnetId,
       source_ami = "{{user `base_image_ami_id`}}",
-      instance_type = "t2.micro",
+      instance_type = "t3.micro",
 
       ssh_username = bake.recipe.baseImage.linuxDist.getOrElse(Ubuntu).loginName,
 


### PR DESCRIPTION
Reverts guardian/amigo#317

It still failed on t2.micro so very unlikely to be this. Let's leave it back on t3 for the cost / performance benefits.