### PR TITLE
Bump SBT memory for teamcity agent role. Bump docker version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ covering this, but, roughly speaking you need to:
 ### Running Ansible roles
 
 1. `cd` into `roles/`
-1. Create a `Vagrantfile`:
+1. Create a `Vagrantfile` in this directory. Note location of .playbook and .extra_vars files (feel free to change):
  
     ```ruby
     Vagrant.configure(2) do |config|
@@ -160,8 +160,8 @@ covering this, but, roughly speaking you need to:
       config.vm.provision "ansible_local" do |ansible|
         ansible.install_mode = "pip" # Ubuntu is fine without that. Redhat prefers it.
         ansible.verbose = "v" # or "vv", "vvv", "vvvv"
-        ansible.playbook = "/vagrant/playbook.yaml"
-        ansible.extra_vars = "@/vagrant/extra-vars.yaml"
+        ansible.playbook = "vagrant/playbook.yaml"
+        ansible.extra_vars = "@vagrant/extra-vars.yaml"
       end
     end
     ```

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -39,7 +39,6 @@
     name: docker-ce={{ version }}~ubuntu
     update_cache: yes
     state: installed
-    force: yes
 
 - name: Create docker group
   group:

--- a/roles/pip/tasks/main.yml
+++ b/roles/pip/tasks/main.yml
@@ -3,3 +3,4 @@
   apt:
     name: ['python-pip']
     update_cache: yes
+    state: latest

--- a/roles/teamcity-agent/meta/main.yml
+++ b/roles/teamcity-agent/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 dependencies:
   - role: docker
-    version: 18.03.1~ce-0
+    version: 18.06.3~ce~3-0
   - role: packages
     packages: 
       - curl

--- a/roles/teamcity-agent/tasks/sbt.yml
+++ b/roles/teamcity-agent/tasks/sbt.yml
@@ -11,3 +11,5 @@
 - name: Populate SBT
   command: sbt sbtVersion
   become: teamcity
+  environment:
+    SBT_OPTS: -Xms256M -Xmx512M -Xss2M -XX:MaxMetaspaceSize=512M


### PR DESCRIPTION
Bakes are having memory problems when trying to run `sbt sbtVersion` because it's trying to allocate ~750mb memory

```
fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": ["sbt", "sbtVersion"], "delta": "0:00:00.401031", "end": "2019-06-12 15:53:48.685987", "msg": "non-zero return code", "rc": 1, "start": "2019-06-12 15:53:48.284956", "stderr": "OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00000000d5550000, 715849728, 0) failed; error='Cannot allocate memory' (errno=12)", "stderr_lines": ["OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00000000d5550000, 715849728, 0) failed; error='Cannot allocate memory' (errno=12)"], "stdout": "#
# There is insufficient memory for the Java Runtime Environment to continue.
# Native memory allocation (mmap) failed to map 715849728 bytes for committing reserved memory.
# An error report file with more information is saved as:
# /tmp/packer-provisioner-ansible-local/5d010df4-ac2b-db11-f771-c5ba6f315be8/hs_err_pid19307.log", "stdout_lines": ["#", "# There is insufficient memory for the Java Runtime Environment to continue.", "# Native memory allocation (mmap) failed to map 715849728 bytes for committing reserved memory.", "# An error report file with more information is saved as:", "# /tmp/packer-provisioner-ansible-local/5d010df4-ac2b-db11-f771-c5ba6f315be8/hs_err_pid19307.log"]}
```


This PR should fix that by allocating more memory to SBT. It also modifies the docker version number of the teamcity agent role to one that exists for ubuntu bionic, and removes force:yes as this isn't supported in bionic