### PR TITLE
consistent formatting of bake id for tagging and searching of EC2 instances

### DIFF
--- a/app/housekeeping/TimeOutLongRunningBakes.scala
+++ b/app/housekeeping/TimeOutLongRunningBakes.scala
@@ -85,6 +85,7 @@ object TimeOutLongRunningBakes {
       instance.getTags.exists(tag => tag.getKey == key && tag.getValue == value)
 
     def getInstance(bakeId: BakeId): Option[Instance] = {
+      // Filters here are base on the instance tags that are set in PackerBuildConfigGenerator.
       val request = new DescribeInstancesRequest()
         .withFilters(
           new Filter("tag:Stage", List(PackerBuildConfigGenerator.stage)),

--- a/app/packer/PackerBuildConfigGenerator.scala
+++ b/app/packer/PackerBuildConfigGenerator.scala
@@ -39,7 +39,7 @@ object PackerBuildConfigGenerator {
         "Stage" -> stage,
         "Stack" -> stack,
         "App" -> "{{user `recipe`}}",
-        "BakeId" -> s"${bake.recipe.id.value}-${bake.buildNumber}"
+        "BakeId" -> s"${bake.bakeId.toString}"
       ),
       ami_name = imageDetails.name,
       ami_description = imageDetails.description,


### PR DESCRIPTION
An EC2 instance for a given bake couldn't be found, since different formats of a bake id were used for tagging and searching for an instance respectively. 

This PR fixes the issue by using the same bake id format for tagging and searching.

Agreed with @philmcmahon that centralising tagging logic for now is overkill. 