### PR TITLE
workaround for bug in ubuntu-bionic

### DIFF
--- a/app/models/BaseImage.scala
+++ b/app/models/BaseImage.scala
@@ -28,6 +28,7 @@ case object Ubuntu extends LinuxDist {
     // bootstrap Ansible
     PackerProvisionerConfig.executeRemoteCommands(Seq(
       // Wait for cloud-init to finish first: https://github.com/mitchellh/packer/issues/2639
+      "export DEBIAN_FRONTEND=noninteractive",
       "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
       "apt-get --yes install software-properties-common",
       "apt-add-repository --yes ppa:ansible/ansible",

--- a/app/models/BaseImage.scala
+++ b/app/models/BaseImage.scala
@@ -28,12 +28,11 @@ case object Ubuntu extends LinuxDist {
     // bootstrap Ansible
     PackerProvisionerConfig.executeRemoteCommands(Seq(
       // Wait for cloud-init to finish first: https://github.com/mitchellh/packer/issues/2639
-      "export DEBIAN_FRONTEND=noninteractive",
       "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
-      "apt-get --yes install software-properties-common",
+      "DEBIAN_FRONTEND=noninteractive  apt-get --yes install software-properties-common",
       "apt-add-repository --yes ppa:ansible/ansible",
       "apt-get --yes update",
-      "apt-get --yes install ansible"
+      "DEBIAN_FRONTEND=noninteractive apt-get --yes install ansible"
     ))
   )
 }


### PR DESCRIPTION
Right now all recipes that use [ubuntu-bionic (18.04)](https://amigo.gutools.co.uk/base-images/ubuntu-bionic%20(18.04%20LTS)) are failing. This seems to be caused by a bug somewhere in the os that causes the ansible installation to hang forever (presumably waiting for user input):
```
...
[2019-06-25 07:00:48] bionic-java8: + apt-get --yes install ansible
[2019-06-25 07:00:48] bionic-java8: Reading package lists...
[2019-06-25 07:00:48] bionic-java8: Building dependency tree...
[2019-06-25 07:00:48] bionic-java8: Reading state information...
[2019-06-25 07:00:48] bionic-java8: The following additional packages will be installed:
[2019-06-25 07:00:48] bionic-java8: libpython-stdlib libpython2.7-minimal libpython2.7-stdlib 
... [ some stuff removed here]
[2019-06-25 07:00:52] bionic-java8: Checking init scripts...
[2019-06-25 07:00:52] bionic-java8: Configuring libssl1.1:amd64
[2019-06-25 07:00:52] bionic-java8: ---------------------------
[2019-06-25 07:00:52] bionic-java8:
[2019-06-25 07:00:52] bionic-java8: There are services installed on your system which need to be restarted when
[2019-06-25 07:00:52] bionic-java8: certain libraries, such as libpam, libc, and libssl, are upgraded. Since these
[2019-06-25 07:00:52] bionic-java8: restarts may cause interruptions of service for the system, you will normally be
[2019-06-25 07:00:52] bionic-java8: prompted on each upgrade for the list of services you wish to restart. You can
[2019-06-25 07:00:52] bionic-java8: choose this option to avoid being prompted; instead, all necessary restarts will
[2019-06-25 07:00:52] bionic-java8: be done for you automatically so you can avoid being asked questions on each
[2019-06-25 07:00:52] bionic-java8: library upgrade.
[2019-06-25 07:00:52] bionic-java8:
[2019-06-25 08:17:06] bionic-java8: Restart services during package upgrades without asking? [yes/no]
[2019-06-25 08:17:06] ==> bionic-java8: Terminating the source AWS instance...
```
[example failed bake](https://amigo.gutools.co.uk/recipes/bionic-java8/bakes/13)

I found [this](https://github.com/hashicorp/vagrant/issues/10914) open issue in vagrant that suggests setting the environment variable ` DEBIAN_FRONTEND=noninteractive` as a work around and it seems to work in `CODE`

One thing to note is that the Source AMI used in Amigo `CODE` for ubuntu-bionic is a year newer than  the one used in `PROD`.  The newer source image doesn't have this problem for some reason so I could not reproduce this problem in `CODE` until I replicated the `PROD` configuration.

So another solution to this might be updating the source AMI in prod to the latest version but we have to make sure it doesn't bring other problems.  Also this issue might still be there in the new version but not manifest as fewer things need to the upgraded
