### PR TITLE
Enable Airflow paths to be set in the  launch configuration

### DIFF
--- a/roles/airflow/README.md
+++ b/roles/airflow/README.md
@@ -87,18 +87,20 @@ Pass the following values to your AMIgo recipe:
 
 ```yaml
 airflow_remote_logging: True
-airflow_remote_base_log_folder: "s3://some-bucket/"
 airflow_remote_log_conn_id: dummy #set to a dummy value if not relying on actual airflow connections but rather on ec2 permissions/role. Cannot be empty or null though.
 
 ```
-
+And set the following env variable in your `UserData` as previously explained
+```bash
+airflow_remote_base_log_folder=some-bucket-name/some-path
+```
 ## DAGs remote sources configuration
 
-```yaml
-# S3 assets
-airflow_s3_dags_folder: "ophan-dist/ophan-data-lake/PROD/airflow-assets/dags/"
-airflow_s3_connections_folder: "ophan-dist/ophan-data-lake/PROD/airflow-assets/connections/"
-airflow_s3_plugins_dir_folder: "ophan-dist/ophan-data-lake/PROD/airflow-assets/plugins/"
+Similarly set connections, plugins and dag locations env variables in `UserData`
+```bash
+airflow_s3_dags_folder=ophan-dist/ophan-data-lake/SOME-STAGE/airflow-assets/dags/
+airflow_s3_connections_folder=ophan-dist/ophan-data-lake/SOME-STAGE/airflow-assets/connections/
+airflow_s3_plugins_dir_folder=ophan-dist/ophan-data-lake/SOME-STAGE/airflow-assets/plugins/
 ```
 
 * [airflow-dags-update.service](templates/lib/systemd/system/airflow-dags-update.service.j2) drops DAGs in `{{ airflow_dags_folder }}` 

--- a/roles/airflow/templates/etc/airflow/airflow.cfg.j2
+++ b/roles/airflow/templates/etc/airflow/airflow.cfg.j2
@@ -22,7 +22,7 @@ base_log_folder = {{ airflow_logs_folder }}
 # configuration requirements.
 remote_logging = {{ airflow_remote_logging }}
 remote_log_conn_id = {{ airflow_remote_log_conn_id }}
-remote_base_log_folder = s3://{{ airflow_remote_base_log_folder }}
+remote_base_log_folder = s3://$airflow_remote_base_log_folder
 encrypt_s3_logs = {{ airflow_encrypt_s3_logs }}
 {% endif %}
 

--- a/roles/airflow/templates/usr/local/bin/airflow-update-connections.sh.j2
+++ b/roles/airflow/templates/usr/local/bin/airflow-update-connections.sh.j2
@@ -2,7 +2,7 @@
 
 ## MANAGED BY ANSIBLE ##
 
-S3_PATH="s3://{{ airflow_s3_connections_folder }}"
+S3_PATH="s3://$airflow_s3_connections_folder"
 
 echo "Downloading connections from $S3_PATH"
 aws s3 cp $S3_PATH {{ airflow_connections_folder }} --recursive

--- a/roles/airflow/templates/usr/local/bin/airflow-update-dags.sh.j2
+++ b/roles/airflow/templates/usr/local/bin/airflow-update-dags.sh.j2
@@ -4,8 +4,7 @@
 
 DAGS_ZIP=dags.zip
 PLUGINS_ZIP=plugins.zip
-
-S3_PATH="s3://{{ airflow_s3_dags_folder }}$DAGS_ZIP"
+S3_PATH="s3://$airflow_s3_dags_folder$DAGS_ZIP"
 
 echo "Downloading DAGs from $S3_PATH"
 aws s3 cp $S3_PATH {{ airflow_dags_folder }} \
@@ -20,7 +19,7 @@ else
 fi
 
 
-S3_PATH="s3://{{ airflow_s3_plugins_dir_folder }}$PLUGINS_ZIP"
+S3_PATH="s3://$airflow_s3_plugins_dir_folder$PLUGINS_ZIP"
 
 echo "Downloading extra python libraries from $S3_PATH"
 aws s3 cp $S3_PATH {{ airflow_plugins_dir }} \


### PR DESCRIPTION
Currently the paths to connections, logs, plugins and dags are set in role params in Amigo. Doing it this way forces us to hard code `PROD` parameters in the recipe.
By reading them from env variables we can set them in our launch configuration and set them to different paths depending on whether it is a `CODE` or `PROD` stack.

This PR should be merged after the [PR](https://github.com/guardian/amigo/pull/321) that fixes the Ubuntu Bionic base image 