### PR TITLE
workaround for latest version of flask breaking airflow

### DIFF
--- a/roles/airflow/tasks/install.yml
+++ b/roles/airflow/tasks/install.yml
@@ -25,7 +25,7 @@
 
 - name: Airflow | pip installs
   pip:
-    name: ['botocore', 'boto3', 'six', 'gunicorn', 'numpy','flask==1.0.3', 'flask_oauthlib']
+    name: ['botocore', 'boto3', 'six', 'gunicorn', 'numpy','flask==1.0.4', 'flask_oauthlib']
     state: latest
     virtualenv: "{{ airflow_virtualenv_folder }}/"
     virtualenv_python: "{{ airflow_python_path }}"

--- a/roles/airflow/tasks/install.yml
+++ b/roles/airflow/tasks/install.yml
@@ -25,7 +25,7 @@
 
 - name: Airflow | pip installs
   pip:
-    name: ['botocore', 'boto3', 'six', 'gunicorn', 'numpy', 'flask_oauthlib']
+    name: ['botocore', 'boto3', 'six', 'gunicorn', 'numpy','flask==1.0.3', 'flask_oauthlib']
     state: latest
     virtualenv: "{{ airflow_virtualenv_folder }}/"
     virtualenv_python: "{{ airflow_python_path }}"


### PR DESCRIPTION
Flask 1.1.0 released on Jul 5 doesn't seem to work with our airflow setup. It successfully bakes an image but it fails to start airflow. [release history](https://pypi.org/project/Flask/#history)
This PR fixes the flask version to 1.0.4 released a day earlier that is the latest one that works for us.
Hopefully we can fix this in a better way in the future