### PR TITLE
remove hardcoded PROD in airflow mutex service

### DIFF
--- a/roles/airflow/templates/lib/systemd/system/airflow-mutex.service.j2
+++ b/roles/airflow/templates/lib/systemd/system/airflow-mutex.service.j2
@@ -24,7 +24,7 @@ User=airflow
 Group=airflow
 Type=oneshot
 RemainAfterExit=true
-ExecStart=/usr/local/sbin/airflow-scheduler-mutex.sh $REGION $LOGICAL_ID
+ExecStart=/usr/local/sbin/airflow-scheduler-mutex.sh $REGION $LOGICAL_ID $STAGE
 TimeoutSec=600
 
 [Install]

--- a/roles/airflow/templates/usr/local/sbin/airflow-scheduler-mutex.sh.j2
+++ b/roles/airflow/templates/usr/local/sbin/airflow-scheduler-mutex.sh.j2
@@ -15,7 +15,7 @@ if [ -z $ASG_NAME ]; then
 	exit 1
 fi
 
-ASG_COUNT="/usr/local/sbin/autoscaling-ensure-one-instance.sh $REGION $ASG_NAME"
+ASG_COUNT="/usr/local/sbin/autoscaling-ensure-one-instance.sh $REGION $ASG_NAME $STAGE"
 
 LOOP=0
 MAX=20

--- a/roles/airflow/templates/usr/local/sbin/airflow-scheduler-mutex.sh.j2
+++ b/roles/airflow/templates/usr/local/sbin/airflow-scheduler-mutex.sh.j2
@@ -2,9 +2,6 @@
 
 ## MANAGED BY ANSIBLE ##
 
-echo  "SCHEDULER MUTEX running"
-echo  -- "$@"
-
 REGION=$1
 ASG_NAME=$2
 STAGE=$3

--- a/roles/airflow/templates/usr/local/sbin/airflow-scheduler-mutex.sh.j2
+++ b/roles/airflow/templates/usr/local/sbin/airflow-scheduler-mutex.sh.j2
@@ -4,6 +4,7 @@
 
 REGION=$1
 ASG_NAME=$2
+STAGE=$3
 
 if [ -z $REGION ]; then
 	echo  "Please specify a region"
@@ -12,6 +13,11 @@ fi
 
 if [ -z $ASG_NAME ]; then
 	echo  "Please specify the name of the autoscaling group"
+	exit 1
+fi
+
+if [ -z "$STAGE" ]; then
+	echo  "Please specify the Stage "
 	exit 1
 fi
 

--- a/roles/airflow/templates/usr/local/sbin/airflow-scheduler-mutex.sh.j2
+++ b/roles/airflow/templates/usr/local/sbin/airflow-scheduler-mutex.sh.j2
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 ## MANAGED BY ANSIBLE ##
-
+echo "RUNNING SCHEDULER MUTEX"
+echo -- “$@”
 REGION=$1
 ASG_NAME=$2
 STAGE=$3

--- a/roles/airflow/templates/usr/local/sbin/airflow-scheduler-mutex.sh.j2
+++ b/roles/airflow/templates/usr/local/sbin/airflow-scheduler-mutex.sh.j2
@@ -1,8 +1,10 @@
 #!/bin/sh
 
 ## MANAGED BY ANSIBLE ##
-echo "RUNNING SCHEDULER MUTEX"
-echo -- “$@”
+
+echo  "SCHEDULER MUTEX running"
+echo  -- "$@"
+
 REGION=$1
 ASG_NAME=$2
 STAGE=$3
@@ -28,7 +30,7 @@ LOOP=0
 MAX=20
 
 while [ $LOOP -le $MAX ]; do
-	$($ASG_COUNT)
+	 sh $ASG_COUNT
 
 	if [ $? -eq 0 ]; then
 		echo "$ASG_NAME has 1 instance."

--- a/roles/airflow/templates/usr/local/sbin/autoscaling-ensure-one-instance.sh.j2
+++ b/roles/airflow/templates/usr/local/sbin/autoscaling-ensure-one-instance.sh.j2
@@ -2,9 +2,6 @@
 
 ## MANAGED BY ANSIBLE ##
 
-echo  "ensure one instance running..."
-echo  -- "$@"
-
 REGION=$1
 LOGICAL_ID=$2
 STAGE=$3
@@ -37,6 +34,6 @@ if [ -z "$COUNT" ]; then
         exit 1
 fi
 
-echo  "count for $STAGE was $COUNT"
+echo  "instance count for $STAGE was $COUNT"
 
 exit `expr $COUNT - 1`

--- a/roles/airflow/templates/usr/local/sbin/autoscaling-ensure-one-instance.sh.j2
+++ b/roles/airflow/templates/usr/local/sbin/autoscaling-ensure-one-instance.sh.j2
@@ -15,10 +15,15 @@ if [ -z "$LOGICAL_ID" ]; then
 	exit 1
 fi
 
+if [ -z "$STAGE" ]; then
+	echo  "Please specify the Stage "
+	exit 1
+fi
+
 COUNT=$(aws ec2 describe-instances --region $REGION \
     --filters Name=instance-state-code,Values=16,32 \
     Name=tag:Stack,Values=ophan-data-lake \
-    Name=tag:Stage,Values=PROD \
+    Name=tag:Stage,Values=$STAGE \
     Name=tag:aws:cloudformation:logical-id,Values=$LOGICAL_ID \
     | jq '.Reservations | length')
 

--- a/roles/airflow/templates/usr/local/sbin/autoscaling-ensure-one-instance.sh.j2
+++ b/roles/airflow/templates/usr/local/sbin/autoscaling-ensure-one-instance.sh.j2
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 ## MANAGED BY ANSIBLE ##
-
+echo "RUNNING ENSURE ONE INSTANCE"
+echo -- “$@”
 REGION=$1
 LOGICAL_ID=$2
 STAGE=$3

--- a/roles/airflow/templates/usr/local/sbin/autoscaling-ensure-one-instance.sh.j2
+++ b/roles/airflow/templates/usr/local/sbin/autoscaling-ensure-one-instance.sh.j2
@@ -20,6 +20,7 @@ if [ -z "$STAGE" ]; then
 	exit 1
 fi
 
+
 COUNT=$(aws ec2 describe-instances --region $REGION \
     --filters Name=instance-state-code,Values=16,32 \
     Name=tag:Stack,Values=ophan-data-lake \
@@ -27,4 +28,5 @@ COUNT=$(aws ec2 describe-instances --region $REGION \
     Name=tag:aws:cloudformation:logical-id,Values=$LOGICAL_ID \
     | jq '.Reservations | length')
 
+echo "count for $STAGE was $COUNT"
 exit `expr $COUNT - 1`

--- a/roles/airflow/templates/usr/local/sbin/autoscaling-ensure-one-instance.sh.j2
+++ b/roles/airflow/templates/usr/local/sbin/autoscaling-ensure-one-instance.sh.j2
@@ -4,6 +4,7 @@
 
 REGION=$1
 LOGICAL_ID=$2
+STAGE=$3
 
 if [ -z "$REGION" ]; then
 	echo  "Please specify a region"
@@ -29,4 +30,5 @@ COUNT=$(aws ec2 describe-instances --region $REGION \
     | jq '.Reservations | length')
 
 echo "count for $STAGE was $COUNT"
+
 exit `expr $COUNT - 1`

--- a/roles/airflow/templates/usr/local/sbin/autoscaling-ensure-one-instance.sh.j2
+++ b/roles/airflow/templates/usr/local/sbin/autoscaling-ensure-one-instance.sh.j2
@@ -1,8 +1,10 @@
 #!/bin/sh
 
 ## MANAGED BY ANSIBLE ##
-echo "RUNNING ENSURE ONE INSTANCE"
-echo -- “$@”
+
+echo  "ensure one instance running..."
+echo  -- "$@"
+
 REGION=$1
 LOGICAL_ID=$2
 STAGE=$3
@@ -30,6 +32,11 @@ COUNT=$(aws ec2 describe-instances --region $REGION \
     Name=tag:aws:cloudformation:logical-id,Values=$LOGICAL_ID \
     | jq '.Reservations | length')
 
-echo "count for $STAGE was $COUNT"
+if [ -z "$COUNT" ]; then
+        echo "could not get instance count!"
+        exit 1
+fi
+
+echo  "count for $STAGE was $COUNT"
 
 exit `expr $COUNT - 1`


### PR DESCRIPTION
the service that prevents more than one airflow to run within the same asg always checks prod instead of the proper stage.
Tested in `CODE` 