### PR TITLE
Docker compose

### DIFF
--- a/roles/docker-compose/README.md
+++ b/roles/docker-compose/README.md
@@ -1,3 +1,3 @@
 # Docker Compose
 
-Installs Docker Compose. Requires `version` as a parameter. 
+Installs Docker Compose. Optional `version` as a parameter, otherwise it will install the latest. 

--- a/roles/docker-compose/README.md
+++ b/roles/docker-compose/README.md
@@ -1,0 +1,3 @@
+# Docker Compose
+
+Installs Docker Compose. Requires `version` as a parameter. 

--- a/roles/docker-compose/tasks/main.yml
+++ b/roles/docker-compose/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Docker Composer
+  get_url:
+    url: https://github.com/docker/compose/releases/download/{{version}}/docker-compose-{{ansible_system}}-{{ansible_architecture}}"
+    dest: /usr/local/bin/docker-compose
+    mode: '0755'

--- a/roles/docker-compose/tasks/main.yml
+++ b/roles/docker-compose/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Install Docker Composer
   get_url:
-    url: https://github.com/docker/compose/releases/download/{{version}}/docker-compose-{{ansible_system}}-{{ansible_architecture}}"
+    url: |
+      https://github.com/docker/compose/releases/{{ ("download/%s" % version) if version else "latest/download" }}/docker-compose-{{ansible_system}}-{{ansible_architecture}}
     dest: /usr/local/bin/docker-compose
     mode: '0755'

--- a/roles/docker-compose/tasks/main.yml
+++ b/roles/docker-compose/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install Docker Composer
+- name: Install Docker Compose
   get_url:
     url: |
       https://github.com/docker/compose/releases/{{ ("download/%s" % version) if version else "latest/download" }}/docker-compose-{{ansible_system}}-{{ansible_architecture}}


### PR DESCRIPTION
It's a role that installs Docker Compose. Very exciting.

You can specify `version`. If you don't you get the latest. Scintillating.

The Teamcity Agent role already does this, [pinned to a particular version](https://github.com/guardian/amigo/blob/7fef5db5851a3fa69eba0734e21c5c5a1f7f9db1/roles/teamcity-agent/tasks/main.yml#L25). Could be nice to modify it to use this in the recipe?