### PR TITLE
Ensure all connections are updated before starting airflow scheduler

### DIFF
--- a/roles/airflow/templates/lib/systemd/system/airflow-connections-update.service.j2
+++ b/roles/airflow/templates/lib/systemd/system/airflow-connections-update.service.j2
@@ -17,8 +17,7 @@
 Description=Airflow connections update
 Requires=network.target
 After=network.target
-BindsTo=airflow-scheduler.service
-After=airflow-scheduler.service
+
 
 [Service]
 EnvironmentFile={{ airflow_environment_file_folder }}/airflow

--- a/roles/airflow/templates/lib/systemd/system/airflow-scheduler.service.j2
+++ b/roles/airflow/templates/lib/systemd/system/airflow-scheduler.service.j2
@@ -24,6 +24,9 @@ After=airflow-mutex.service
 BindsTo=airflow-initdb.service
 After=airflow-initdb.service
 
+BindsTo=airflow-connections-update.service
+After=airflow-connections-update.service
+
 {% if nfs_mount_enabled %}
 After=mnt-nfs.mount
 BindsTo=mnt-nfs.mount


### PR DESCRIPTION
The update connections service was configured to start after the airflow scheduler. This meant that sometimes airflow tasks failed as they were scheduled to run before the required connections were available.
This PR reverses the dependency so that the scheduler will only start once all the connections are added
I tested it baking a `CODE` image and deployed it to `CODE` Airflow

According to the logs it seems to work well :
```
Jul 24 15:09:34 ip-10-248-183-223 systemd[1]: Starting Airflow connections update...
-- [A bunch of lines adding the connections here ] ----------------
Jul 24 15:12:20 ip-10-248-183-223 airflow[3786]: [2019-07-24 15:12:20,292] {jobs.py:1500} INFO - Starting the scheduler
```
I have not actually run any real EMR jobs though,  not sure if we need to do some more in depth testing before merging