### PR TITLE
Fix Docker Compose install latest

### DIFF
--- a/roles/docker-compose/tasks/main.yml
+++ b/roles/docker-compose/tasks/main.yml
@@ -1,7 +1,16 @@
 ---
-- name: Install Docker Compose
+- name: Install the latest Docker Composer
+  when: version is undefined
   get_url:
     url: |
-      https://github.com/docker/compose/releases/{{ ("download/%s" % version) if version else "latest/download" }}/docker-compose-{{ansible_system}}-{{ansible_architecture}}
+      https://github.com/docker/compose/releases/latest/download/docker-compose-{{ansible_system}}-{{ansible_architecture}}
+    dest: /usr/local/bin/docker-compose
+    mode: '0755'
+
+- name: Install a given version of Docker Compose
+  when: version is defined
+  get_url:
+    url: |
+      https://github.com/docker/compose/releases/download/{{version}}/docker-compose-{{ansible_system}}-{{ansible_architecture}}
     dest: /usr/local/bin/docker-compose
     mode: '0755'


### PR DESCRIPTION
Follow up to #325 to use the correct syntax to differentiate between installing the latest and a given version.

NB: needs testing locally or in CODE before merging