### PR TITLE
bump instance type to t3.small

### DIFF
--- a/app/packer/PackerBuildConfigGenerator.scala
+++ b/app/packer/PackerBuildConfigGenerator.scala
@@ -31,7 +31,7 @@ object PackerBuildConfigGenerator {
       vpc_id = packerConfig.vpcId,
       subnet_id = packerConfig.subnetId,
       source_ami = "{{user `base_image_ami_id`}}",
-      instance_type = "t3.micro",
+      instance_type = "t3.small",
 
       ssh_username = bake.recipe.baseImage.linuxDist.getOrElse(Ubuntu).loginName,
 


### PR DESCRIPTION
Installing the `logstash-input-kinesis` plugin is failing on a `t3.micro` for... some reason...

Tested and proved this change on CODE.