### PR TITLE
Airflow: change default user registration role

### DIFF
--- a/roles/airflow/defaults/main.yml
+++ b/roles/airflow/defaults/main.yml
@@ -334,7 +334,7 @@ airflow_rbac_security_manager: AUTH_OAUTH # AUTH_DB | AUTH_LDAP | AUTH_OAUTH | A
 airflow_rbac_auth_role_admin: Admin
 airflow_rbac_auth_role_public: Viewer
 airflow_rbac_auth_user_registration: True
-airflow_rbac_auth_user_registration_role: Admin
+airflow_rbac_auth_user_registration_role: User
 
 # RBAC OAUTH
 airflow_rbac_auth_oauth_name: google


### PR DESCRIPTION
Previously, when a new user signs in to Airflow via Oauth, they are automatically given Admin access. We want to restrict permissions for users outside of datatech so this will ensure that new users have the more restricted User role.

I have also been through and changed users from other teams to have the User role. Unfortunately, Thomas and I were unable to find a way to overwrite the default permissions for different roles. Rather than creating new roles, we are just using the default ones for now.