### PR TITLE
Airflow: add shelljob to airflow pip installs

### DIFF
--- a/roles/airflow/tasks/install.yml
+++ b/roles/airflow/tasks/install.yml
@@ -25,7 +25,7 @@
 
 - name: Airflow | pip installs
   pip:
-    name: ['botocore', 'boto3', 'six', 'gunicorn', 'numpy','flask==1.0.4', 'flask_oauthlib']
+    name: ['botocore', 'boto3', 'six', 'gunicorn', 'numpy','flask==1.0.4', 'flask_oauthlib', 'shelljob']
     state: latest
     virtualenv: "{{ airflow_virtualenv_folder }}/"
     virtualenv_python: "{{ airflow_python_path }}"


### PR DESCRIPTION
Add shelljob to Airflow pip installs so that it is available for the new backfill plugin.