### PR TITLE
AWS config cleanup

### DIFF
--- a/roles/teamcity-agent/files/awsconfig_cleanup.sh
+++ b/roles/teamcity-agent/files/awsconfig_cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash -e
+
+if [ -d "/opt/teamcity/.aws" ]; then
+    ls -lhd /opt/teamcity/.aws
+    echo Existing .aws config directory present in /opt/teamcity, removing...
+    rm -rf /opt/teamcity/.aws
+    echo All gone!
+else
+    echo No existing .aws config directory present
+fi

--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -86,3 +86,13 @@
     enabled: yes
 - name: SBT
   include: sbt.yml
+- name: ".aws Cleanup Script"
+  copy:
+    src: awsconfig_cleanup.sh
+    dest: /usr/local/bin/awsconfig_cleanup.sh
+    mode: 0555
+- name: ".aws Cleanup Script sudoers"
+  shell: |
+    echo "teamcity  ALL=(root) NOPASSWD: /usr/local/bin/awsconfig_cleanup.sh" > /etc/sudoers.d/awscleanup
+  become: yes
+  become_user: root


### PR DESCRIPTION
adding cleanup script for phantom ".aws" directories left behind owned by root.

These have been present regularly on TC build agents and are breaking builds that rely on pulling a Docker image from ECR @philmcmahon @AWare 