### PR TITLE
Bump the version of airflow to the latest stable version 1.10.5.

### DIFF
--- a/roles/airflow/defaults/main.yml
+++ b/roles/airflow/defaults/main.yml
@@ -6,7 +6,7 @@ nfs_mount_id:
 nfs_mount_point: /mnt/nfs
 
 ## General
-airflow_version: 1.10.3
+airflow_version: 1.10.5
 airflow_extra_packages: ['crypto,postgres,google_auth,s3']
 airflow_python_path: /usr/bin/python3
 

--- a/roles/airflow/tasks/install.yml
+++ b/roles/airflow/tasks/install.yml
@@ -25,7 +25,7 @@
 
 - name: Airflow | pip installs
   pip:
-    name: ['botocore', 'boto3', 'six', 'gunicorn', 'numpy','flask==1.0.4', 'flask_oauthlib']
+    name: ['botocore', 'boto3', 'six', 'gunicorn', 'numpy', 'flask_oauthlib']
     state: latest
     virtualenv: "{{ airflow_virtualenv_folder }}/"
     virtualenv_python: "{{ airflow_python_path }}"


### PR DESCRIPTION
We are also removing the explicit flask dependency when installing airflow as we don't believe that this is necessary anymore.

There are a number of other dependencies that are included in the bake, which I'd question - e.g. `numpy` - but I'm not planning on doing a full audit of airflow's requirements today.