### PR TITLE
Fixed deprecated Airflow config keys for Elasticsearch

### DIFF
--- a/roles/airflow/templates/etc/airflow/airflow.cfg.j2
+++ b/roles/airflow/templates/etc/airflow/airflow.cfg.j2
@@ -549,9 +549,9 @@ api_rev = {{ airflow_github_enterprise_api_rev }}
 hide_sensitive_variable_fields = {{ airflow_admin_hide_sensitive_variable_fields }}
 
 [elasticsearch]
-elasticsearch_host = {{ airflow_elasticsearch_host }}
-elasticsearch_log_id_template = {dag_id}-{task_id}-{execution_date}-{try_number}
-elasticsearch_end_of_log_mark = end_of_log
+host = {{ airflow_elasticsearch_host }}
+log_id_template = {dag_id}-{task_id}-{execution_date}-{try_number}
+end_of_log_mark = end_of_log
 
 [kubernetes]
 # The repository, tag and imagePullPolicy of the Kubernetes Image for the Worker to Run


### PR DESCRIPTION
This fixes Airflow configuration deprecation warnings.

More info on Trello: https://trello.com/c/2ieGKdNF/260-fix-airflow-warnings