### PR TITLE
fix bugs in cloudwatch-hardware-monitoring-cronjob role

### DIFF
--- a/roles/cloudwatch-hardware-monitoring-cronjob/README.md
+++ b/roles/cloudwatch-hardware-monitoring-cronjob/README.md
@@ -1,0 +1,11 @@
+# CloudWatch hardware monitoring cronjob
+
+Utilises [mon-put-instance-data.pl](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/mon-scripts.html) script to 
+collect and report to CloudWatch memory, swap and disk space utilization data. 
+
+## Gotchas
+
+- if `monitor_disk_space_available` or `monitor_disk_space_utilisation` are set to `true` then at least one 
+  path must be specified; else metrics won't be reported to CloudWatch
+- ensure that the EC2 instance on which the script is running has the correct permissions; as an example, see 
+  [this](https://github.com/guardian/deploy-tools-platform/pull/114) PR

--- a/roles/cloudwatch-hardware-monitoring-cronjob/defaults/main.yml
+++ b/roles/cloudwatch-hardware-monitoring-cronjob/defaults/main.yml
@@ -3,4 +3,4 @@ monitor_disk_space_available: false
 monitor_memory_available: false
 monitor_disk_space_utilisation: false
 monitor_memory_utilisation: false
-paths: [/]
+paths: []

--- a/roles/cloudwatch-hardware-monitoring-cronjob/tasks/main.yml
+++ b/roles/cloudwatch-hardware-monitoring-cronjob/tasks/main.yml
@@ -2,23 +2,23 @@
 - name: Create monitor memory available parameter
   set_fact:
       mem_avail_option: "--mem-avail"
-      when: monitor_memory_available
+  when: monitor_memory_available
 
 - name: Create monitor disk space available parameter
   set_fact:
       disk_space_avail_option: "--disk-space-avail"
-      when: monitor_disk_space_available
+  when: monitor_disk_space_available
 
 - name: Create monitor disk space utilisation parameter
   set_fact:
       disk_space_util_option: "--disk-space-util"
-      when: monitor_disk_space_utilisation
+  when: monitor_disk_space_utilisation
 
 - name: Create monitor memory utilisation parameter
   set_fact:
       mem_util_option: "--mem-util"
-      when: monitor_memory_utilisation
+  when: monitor_memory_utilisation
 
 - name: Add hardware data collection cronjob
   cron: name="send hardware data information to cloudwatch" minute="*/5" job="/usr/local/aws-scripts-mon/mon-put-instance-data.pl {{ mem_avail_option | default("") }} {{ disk_space_avail_option | default("") }} {{ disk_space_util_option | default("") }} {{ mem_util_option | default("") }} {{ item }} --auto-scaling --from-cron"
-  with_items: "{{ paths | join('--disk-path ') }}"
+  with_items: "{{ paths | map('regex_replace', '(.*)', '--disk-path \\1') | join(' ') }}"


### PR DESCRIPTION
Issues:
- `when` indentation meant that condition wasn't used and therefore facts were always set (therefore, all command line options always provided)
- logic to join paths meant that first path in array would not be prefixed with `--disk-path` (which is why providing `--disk-path` explicitly works [here](https://amigo.gutools.co.uk/recipes/centralised-elk-lk))

When this is merged I will update the roles which depend on this recipe accordingly.

