### PR TITLE
Add fastlane role for app distribution

### DIFF
--- a/roles/fastlane/meta/main.yml
+++ b/roles/fastlane/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - install-ruby

--- a/roles/fastlane/tasks/main.yml
+++ b/roles/fastlane/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: install fastlane ruby gem
+  gem: name=fastlane state=latest user_install=no


### PR DESCRIPTION
This PR adds a role which installs [`fastlane`](https://docs.fastlane.tools/). 

A few teams (iOS, Android, Editions) are now using `fastlane` for app distribution, so I'd like to include this role on the TeamCity build agents if possible.