### PR TITLE
Add role for installing ruby gems

### DIFF
--- a/roles/ruby-gems/README.md
+++ b/roles/ruby-gems/README.md
@@ -1,0 +1,7 @@
+# ruby-gems
+
+Installs ruby gems with `gem`. The `gems` parameter specifies which gems(s) are installed, e.g.
+
+```
+gems: [gem-1, gem-2]
+```

--- a/roles/ruby-gems/meta/main.yml
+++ b/roles/ruby-gems/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - install-ruby
+

--- a/roles/ruby-gems/tasks/main.yml
+++ b/roles/ruby-gems/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Install ruby gems
+  gem:
+    name: "{{ item }}"
+    state: latest
+    user_install: no
+  with_items: "{{ gems }}"


### PR DESCRIPTION
A few teams (iOS, Android, Editions) are now using [`fastlane`](https://docs.fastlane.tools/) for app distribution, so we'd like to include it on the TeamCity build agents.

Fastlane is [installed as a gem](https://docs.fastlane.tools/getting-started/android/setup/#installing-fastlane), so this PR adds a new role for installing ruby gems (thanks to @philmcmahon for the suggestion to add a more generic role for this purpose).

I've tested this locally using the instructions here: https://github.com/guardian/amigo#testing-ansible-scripts-without-runing-amigopacker