### PR TITLE
Override requests-oauthlib and oauthlib versions

### DIFF
--- a/roles/airflow/tasks/install.yml
+++ b/roles/airflow/tasks/install.yml
@@ -61,6 +61,13 @@
     virtualenv: "{{ airflow_virtualenv_folder }}/"
     virtualenv_python: "{{ airflow_python_path }}"
 
+- name: Airflow | overriding requests-oauthlib and oauthlib version to fix apache-airflow[gcp] compatibility
+  pip:
+    name: ['requests-oauthlib==0.8.0', 'oauthlib==2.0.6']
+    state: forcereinstall
+    virtualenv: "{{ airflow_virtualenv_folder }}/"
+    virtualenv_python: "{{ airflow_python_path }}"
+
 - name: "Airflow | ensuring {{ airflow_virtualenv_folder }}"
   file:
     path: "{{ item }}"


### PR DESCRIPTION
This is to fix compatibility issues between `pandas-gbq` installed by `apache-airflow[gcp]` and importing the latest `requests-oauthlib` and `oauthlib>=3.0.0` while airflow's `flask_appbuilder` requires `requests-oauthlib==0.8.0` and `oauthlib==2.0.6`.

Compatible version taken from: https://github.com/lepture/flask-oauthlib/blob/v0.9.5/requirements.txt