### PR TITLE
Quick fix for Airflow recipe

### DIFF
--- a/roles/airflow/tasks/install.yml
+++ b/roles/airflow/tasks/install.yml
@@ -25,7 +25,7 @@
 
 - name: Airflow | pip installs
   pip:
-    name: ['botocore', 'boto3', 'six', 'gunicorn', 'numpy', 'flask_oauthlib']
+    name: ['botocore', 'boto3', 'six', 'gunicorn', 'numpy', 'Werkzeug==0.16.1', 'flask_oauthlib']
     state: latest
     virtualenv: "{{ airflow_virtualenv_folder }}/"
     virtualenv_python: "{{ airflow_python_path }}"


### PR DESCRIPTION
A very similar problem as in the one here https://github.com/guardian/amigo/pull/323
The Werkzeug library released a new version that broke our Airflow setup, bakes work but Airflow deployments fail.
This PR pins the library to the working version we had in the previous bakes to unblock Airflow deployments.
We can evaluate later if upgrading to the latest version of Airflow fixes this as a long term solution.
Deployed to Amigo `CODE` and deployed Airflow `CODE` successfully using that AMI.

