### PR TITLE
Add role for new cloud watch agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@ target
 /RUNNING_PID
 amigo.iml
 
+Brewfile.lock.json
+
 roles/*.log
 roles/.vagrant

--- a/roles/aws-cloud-watch-agent/README.md
+++ b/roles/aws-cloud-watch-agent/README.md
@@ -1,0 +1,17 @@
+This role installs the [AWS Cloud Watch agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html).
+
+Currently the role does not assume anything about how the agent should be configured, nor does the role run the agent.
+Typically both of these actions would be performed in the [User Data](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-userdata)
+made available to EC2 instances.
+
+At the moment, the role is only available for Ubuntu Linux running on AMD64 architecture, though this can be expanded
+as and when needed; for example by following the pattern in the `aws-tools` role.
+
+The AWS documentation on Cloud Watch agent is fairly comprehensive, but scattered; for convenience, some relevant
+resources are listed below:
+
+- creating the Cloud Watch configuration file:
+    - [manually](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html)
+    - [using the wizard](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/create-cloudwatch-agent-configuration-file-wizard.html)
+- [running the Cloud Watch agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-common-scenarios.html)
+ 

--- a/roles/aws-cloud-watch-agent/tasks/main.yml
+++ b/roles/aws-cloud-watch-agent/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Download cloudwatch agent for Ubuntu amd64
+  get_url:
+    url: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+    dest: /tmp/amazon-cloudwatch-agent.deb
+
+- name: Install cloudwatch agent
+  apt:
+    deb: /tmp/amazon-cloudwatch-agent.deb
+
+# When the agent is started, it'll return an error if the file /usr/share/collectd/types.db doesn't exist
+# https://github.com/awsdocs/amazon-cloudwatch-user-guide/issues/1
+
+- name: Create collectd directory
+  file:
+    path: /usr/share/collectd
+    state: directory
+
+- name: Create types.db file
+  copy:
+    content: ""
+    dest: /usr/share/collectd/types.db

--- a/roles/aws-cloud-watch-agent/tasks/main.yml
+++ b/roles/aws-cloud-watch-agent/tasks/main.yml
@@ -16,6 +16,8 @@
     path: /usr/share/collectd
     state: directory
 
+# How to create an empty file with Ansible.
+# https://stackoverflow.com/questions/28347717/how-to-create-an-empty-file-with-ansible
 - name: Create types.db file
   copy:
     content: ""


### PR DESCRIPTION
Some of the functionality this brings is already provided by other Amigo roles, however, this is the canonical approach suggested by AWS for EC2 instance metric collection; allows for more configuration; and enables the collection of SDK metrics (c.f. the work I'm about to do - will report back when I've learnt more).

Tested, locally and on CODE.