### PR TITLE
Fix Docker task, removing 'state: installed'

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -19,7 +19,7 @@
   apt: 
     name: "{{ item }}"
     update_cache: yes
-    state: installed
+    state: present
     force: yes
   with_items:
     - apt-transport-https
@@ -38,7 +38,7 @@
   apt:
     name: docker-ce={{ version }}~ubuntu
     update_cache: yes
-    state: installed
+    state: present
 
 - name: Create docker group
   group:


### PR DESCRIPTION
When Ansible 2.9 was [released](https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_9.html) on 31 October 2019, it [removed the option](https://github.com/ansible/ansible/issues/47869) to set the apt package state as `installed`.
The equivalent option is now called [`present`](https://docs.ansible.com/ansible/latest/modules/apt_module.html#parameter-state
).
 
This has caused [Amigo bakes to fail](https://amigo.gutools.co.uk/recipes/teamcity-agent) since November 2019, with the message:

```
[2020-02-17 01:07:02] teamcity-agent: failed: [127.0.0.1] (item=[u'apt-transport-https', u'ca-certificates', u'openssl']) => {"ansible_loop_var": "item", "changed": false, "item": ["apt-transport-https", "ca-certificates", "openssl"], "msg": "value of state must be one of: absent, build-dep, fixed, latest, present, got: installed"}
```

![image](https://user-images.githubusercontent.com/23078809/74745275-8c71ef00-525b-11ea-9c32-92c162469b89.png)
