### PR TITLE
Role: RDS Root CA Certificates

### DIFF
--- a/roles/aws-rds-root-cert-ca/defaults/main.yml
+++ b/roles/aws-rds-root-cert-ca/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+truststore_password: changeit
+castore_password: changeit

--- a/roles/aws-rds-root-cert-ca/defaults/main.yml
+++ b/roles/aws-rds-root-cert-ca/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-truststore_password: changeit
 castore_password: changeit

--- a/roles/aws-rds-root-cert-ca/meta/main.yml
+++ b/roles/aws-rds-root-cert-ca/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - java8

--- a/roles/aws-rds-root-cert-ca/readme.md
+++ b/roles/aws-rds-root-cert-ca/readme.md
@@ -1,0 +1,16 @@
+# aws-rds-root-ca-certs
+
+## Description
+Sets up an AWS RDS root CA certificate in a Java truststore if an app wants to use full SSL between an RDS database.
+
+## Variables
+| - | - |
+| `certificate_source` | url of the rds location |
+| `certificate_name` | name of the certificate (without the pem extension) |
+| `truststore_dir` | dir of the default Java truststores |
+| `truststore_name` | name of the new truststore |
+
+## Defaults
+| - | - |
+| `truststore_password` | password for the new truststore |
+| `castore_password` | password for the default truststore. It is unlikely this needs changing. |

--- a/roles/aws-rds-root-cert-ca/readme.md
+++ b/roles/aws-rds-root-cert-ca/readme.md
@@ -3,6 +3,11 @@
 ## Description
 Sets up an AWS RDS root CA certificate in a Java truststore if an app wants to use full SSL between an RDS database.
 
+## Mandatory Variables
+| Variable | Description |
+| - | - |
+| aws_rds_truststore_password | password for the new truststore |
+
 ## Variables
 | Variable | Description |
 | - | - |

--- a/roles/aws-rds-root-cert-ca/readme.md
+++ b/roles/aws-rds-root-cert-ca/readme.md
@@ -4,6 +4,7 @@
 Sets up an AWS RDS root CA certificate in a Java truststore if an app wants to use full SSL between an RDS database.
 
 ## Variables
+| Variable | Description |
 | - | - |
 | `certificate_source` | url of the rds location |
 | `certificate_name` | name of the certificate (without the pem extension) |
@@ -11,6 +12,7 @@ Sets up an AWS RDS root CA certificate in a Java truststore if an app wants to u
 | `truststore_name` | name of the new truststore |
 
 ## Defaults
+| Default | Description |
 | - | - |
 | `truststore_password` | password for the new truststore |
 | `castore_password` | password for the default truststore. It is unlikely this needs changing. |

--- a/roles/aws-rds-root-cert-ca/tasks/main.yml
+++ b/roles/aws-rds-root-cert-ca/tasks/main.yml
@@ -6,7 +6,7 @@
   command: openssl x509 -outform der -in /tmp/{{certificate_name}}.pem -out /tmp/{{certificate_name}}.der
 
 - name: create new truststore
-  command: keytool -import -alias rds-root -keystore "{{truststore_dir}}{{truststore_name}}" -file /tmp/{{certificate_name}}.der -storepass changeit -noprompt
+  command: keytool -import -alias rds-root -keystore "{{truststore_dir}}{{truststore_name}}" -file /tmp/{{certificate_name}}.der -storepass "{{truststore_password}}" -noprompt
 
 - name: import default truststore into new one
-  command: keytool -importkeystore -srckeystore "{{truststore_dir}}cacerts" -srcstorepass changeit -destkeystore "{{truststore_dir}}{{truststore_name}}" -deststorepass changeit
+  command: keytool -importkeystore -srckeystore "{{truststore_dir}}cacerts" -srcstorepass "{{castore_password}}" -destkeystore "{{truststore_dir}}{{truststore_name}}" -deststorepass "{{truststore_password}}"

--- a/roles/aws-rds-root-cert-ca/tasks/main.yml
+++ b/roles/aws-rds-root-cert-ca/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: get aws RDS root CA certificate
+  get_url: url=https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem dest=/tmp/rds-ca-2019-root.pem
+
+- name: convert pem to der format
+  command: openssl x509 -outform der -in /tmp/rds-ca-2019-root.pem -out /tmp/rds-ca-2019-root.der
+
+- name: create new truststore
+  command: keytool -import -alias rds-root -keystore /usr/lib/ssl/certs/java/aws-rds-cacerts -file /tmp/rds-ca-2019-root.der -storepass changeit -noprompt
+
+- name: import default truststore into new one
+  command: keytool -importkeystore -srckeystore /usr/lib/ssl/certs/java/cacerts -srcstorepass changeit -destkeystore /usr/lib/ssl/certs/java/aws-rds-cacerts -deststorepass changeit

--- a/roles/aws-rds-root-cert-ca/tasks/main.yml
+++ b/roles/aws-rds-root-cert-ca/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: get aws RDS root CA certificate
-  get_url: url=https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem dest=/tmp/rds-ca-2019-root.pem
+  get_url: url={{certificate_source}}{{certificate_name}}.pem dest=/tmp/{{certificate_name}}.pem
 
 - name: convert pem to der format
-  command: openssl x509 -outform der -in /tmp/rds-ca-2019-root.pem -out /tmp/rds-ca-2019-root.der
+  command: openssl x509 -outform der -in /tmp/{{certificate_name}}.pem -out /tmp/{{certificate_name}}.der
 
 - name: create new truststore
-  command: keytool -import -alias rds-root -keystore /usr/lib/ssl/certs/java/aws-rds-cacerts -file /tmp/rds-ca-2019-root.der -storepass changeit -noprompt
+  command: keytool -import -alias rds-root -keystore "{{truststore_dir}}{{truststore_name}}" -file /tmp/{{certificate_name}}.der -storepass changeit -noprompt
 
 - name: import default truststore into new one
-  command: keytool -importkeystore -srckeystore /usr/lib/ssl/certs/java/cacerts -srcstorepass changeit -destkeystore /usr/lib/ssl/certs/java/aws-rds-cacerts -deststorepass changeit
+  command: keytool -importkeystore -srckeystore "{{truststore_dir}}cacerts" -srcstorepass changeit -destkeystore "{{truststore_dir}}{{truststore_name}}" -deststorepass changeit

--- a/roles/aws-rds-root-cert-ca/tasks/main.yml
+++ b/roles/aws-rds-root-cert-ca/tasks/main.yml
@@ -6,7 +6,7 @@
   command: openssl x509 -outform der -in /tmp/{{certificate_name}}.pem -out /tmp/{{certificate_name}}.der
 
 - name: create new truststore
-  command: keytool -import -alias rds-root -keystore "{{truststore_dir}}{{truststore_name}}" -file /tmp/{{certificate_name}}.der -storepass "{{truststore_password}}" -noprompt
+  command: keytool -import -alias rds-root -keystore "{{truststore_dir}}{{truststore_name}}" -file /tmp/{{certificate_name}}.der -storepass "{{aws_rds_truststore_password | mandatory}}" -noprompt
 
 - name: import default truststore into new one
-  command: keytool -importkeystore -srckeystore "{{truststore_dir}}cacerts" -srcstorepass "{{castore_password}}" -destkeystore "{{truststore_dir}}{{truststore_name}}" -deststorepass "{{truststore_password}}"
+  command: keytool -importkeystore -srckeystore "{{truststore_dir}}cacerts" -srcstorepass "{{castore_password}}" -destkeystore "{{truststore_dir}}{{truststore_name}}" -deststorepass "{{aws_rds_truststore_password | mandatory}}"

--- a/roles/aws-rds-root-cert-ca/vars/main.yml
+++ b/roles/aws-rds-root-cert-ca/vars/main.yml
@@ -1,0 +1,5 @@
+---
+certificate_source: https://s3.amazonaws.com/rds-downloads/
+certificate_name: rds-ca-2019-root
+truststore_dir: /usr/lib/ssl/certs/java/
+truststore_name: aws-rds-cacerts


### PR DESCRIPTION
For anyone interested in using full on SSL when connecting to an RDS service. This role gets the certificate, adds it to a new truststore & imports the default Java truststore certificates into that one.