### PR TITLE
Mt add service to install airflow python

### DIFF
--- a/roles/airflow/defaults/main.yml
+++ b/roles/airflow/defaults/main.yml
@@ -36,6 +36,10 @@ airflow_services:
     configure: yes
     enabled: no
     state: stopped
+  airflow-install-ophan-python:
+    configure: yes
+    enabled: no
+    state: stopped
   airflow-initdb:
     configure: yes
     enabled: no

--- a/roles/airflow/tasks/system.yml
+++ b/roles/airflow/tasks/system.yml
@@ -11,6 +11,7 @@
     - usr/local/bin/airflow-add-connection.sh.j2
     - usr/local/bin/airflow-update-dags.sh.j2
     - usr/local/bin/airflow-update-connections.sh.j2
+    - usr/local/bin/airflow-install-ophan-python.sh.j2
 
 - name: Support | Adding autoscaling group mutex scripts
   template:

--- a/roles/airflow/templates/lib/systemd/system/airflow-initdb.service.j2
+++ b/roles/airflow/templates/lib/systemd/system/airflow-initdb.service.j2
@@ -17,8 +17,9 @@
 Description=Airflow InitDB
 Requires=network.target
 After=network.target
-BindsTo=airflow-mutex.service
-After=airflow-mutex.service
+BindsTo=airflow-install-ophan-python.service
+After=airflow-install-ophan-python.service
+
 
 [Service]
 EnvironmentFile={{ airflow_environment_file_folder }}/airflow

--- a/roles/airflow/templates/lib/systemd/system/airflow-install-ophan-python.service.j2
+++ b/roles/airflow/templates/lib/systemd/system/airflow-install-ophan-python.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=Airflow connections update
+Requires=network.target
+After=network.target
+BindsTo=airflow-mutex.service
+After=airflow-mutex.service
+
+[Service]
+EnvironmentFile={{ airflow_environment_file_folder }}/airflow
+User={{ airflow_user }}
+Group={{ airflow_group }}
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/local/bin/airflow-install-ophan-python.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/airflow/templates/usr/local/bin/airflow-install-ophan-python.sh.j2
+++ b/roles/airflow/templates/usr/local/bin/airflow-install-ophan-python.sh.j2
@@ -1,0 +1,18 @@
+#!/bin/sh
+GUARDIAN_PYTHON_ZIP=guardian.zip
+PYTHON_FOLDER=python/
+S3_PATH="s3://${airflow_s3_dags_folder}/$PYTHON_FOLDER/$GUARDIAN_PYTHON_ZIP"
+LOCAL_PYTHON_FOLDER=
+
+echo "Downloading extra python libraries from $S3_PATH"
+rm -f {{ airflow_home }}/python
+mkdir {{ airflow_home }}/python
+aws s3 cp $S3_PATH {{ airflow_home }}/
+
+if [ -e {{ airflow_home }}/$GUARDIAN_PYTHON_ZIP ]; then
+    unzip -o {{ airflow_home }}/$GUARDIAN_PYTHON_ZIP -d {{ airflow_home }}
+    rm -f {{ airflow_home }}/$GUARDIAN_PYTHON_ZIP
+    {{ airflow_virtualenv_folder }}/bin/pip install -e {{ airflow_home }}/python/
+else
+    echo "WARNING: NO PYTHON MODULE FOUND IN {{ airflow_s3_dags_folder }}python/$GUARDIAN_PYTHON_ZIP"
+fi

--- a/roles/airflow/templates/usr/local/bin/airflow-install-ophan-python.sh.j2
+++ b/roles/airflow/templates/usr/local/bin/airflow-install-ophan-python.sh.j2
@@ -1,18 +1,38 @@
 #!/bin/sh
 GUARDIAN_PYTHON_ZIP=guardian.zip
-PYTHON_FOLDER=python/
-S3_PATH="s3://${airflow_s3_dags_folder}/$PYTHON_FOLDER/$GUARDIAN_PYTHON_ZIP"
-LOCAL_PYTHON_FOLDER=
+# Python subdir is replicated in the zip file contents also. So is used
+# for the local folder pointer for the pip command as well as build the
+# source s3 path.
+PYTHON_FOLDER=python
+# AIRFLOW_STAGE is exported from the live /etc/sysconfig/airflow which
+# is invoked as the EnvironmentFile for the airflow systemd services by
+# pattern. It is passed as the Stage variable in the cloudformation step
+# in ophan-data-lake.
+S3_PATH="s3://ophan-dist/ophan-data-lake/$AIRFLOW_STAGE/airflow-assets/$PYTHON_FOLDER/$GUARDIAN_PYTHON_ZIP"
 
+# Continue to use the Jinja invocation for the airflow_home variable which
+# is currently only set in the Airflow role's defaults yaml.
+
+# TODO: move airflow_home to an ENV variable on the image, and move it
+# to /home/airflow/ as convention dictates. Which will mean this file
+# can then be a static bash script.
 echo "Downloading extra python libraries from $S3_PATH"
-rm -f {{ airflow_home }}/python
-mkdir {{ airflow_home }}/python
+# Brute force a removal of the folder whether or not it exists already
+rm -f {{ airflow_home }}/$PYTHON_FOLDER
 aws s3 cp $S3_PATH {{ airflow_home }}/
 
 if [ -e {{ airflow_home }}/$GUARDIAN_PYTHON_ZIP ]; then
+	# Inflate / extract the python installable, note that files will now
+	# be in airflow_home/python/guardian/ etc.
     unzip -o {{ airflow_home }}/$GUARDIAN_PYTHON_ZIP -d {{ airflow_home }}
+    # Delete the downloaded artefact
     rm -f {{ airflow_home }}/$GUARDIAN_PYTHON_ZIP
-    {{ airflow_virtualenv_folder }}/bin/pip install -e {{ airflow_home }}/python/
+
+    # Install against the virtualenv pip binary, as the virtualenv binary
+    # is the one used by the instance's airflow systemd service
+
+    # -e is a flag to indicate its a local / editable directory
+    {{ airflow_virtualenv_folder }}/bin/pip install -e {{ airflow_home }}/$PYTHON_FOLDER/
 else
-    echo "WARNING: NO PYTHON MODULE FOUND IN {{ airflow_s3_dags_folder }}python/$GUARDIAN_PYTHON_ZIP"
+    echo "WARNING: NO PYTHON MODULE FOUND IN $S3_PATH"
 fi


### PR DESCRIPTION
Add a new service to Airflow to download and install the Python directory published by the new Riff Raff generated instance.