### PR TITLE
Simplify Requires / Bind & After services configs

### DIFF
--- a/roles/airflow/templates/lib/systemd/system/airflow-connections-update.service.j2
+++ b/roles/airflow/templates/lib/systemd/system/airflow-connections-update.service.j2
@@ -18,6 +18,9 @@ Description=Airflow connections update
 Requires=network.target
 After=network.target
 
+Requires=airflow-initdb.service
+After=airflow-initdb.service
+
 
 [Service]
 EnvironmentFile={{ airflow_environment_file_folder }}/airflow

--- a/roles/airflow/templates/lib/systemd/system/airflow-initdb.service.j2
+++ b/roles/airflow/templates/lib/systemd/system/airflow-initdb.service.j2
@@ -17,7 +17,8 @@
 Description=Airflow InitDB
 Requires=network.target
 After=network.target
-BindsTo=airflow-install-ophan-python.service
+
+Requires=airflow-install-ophan-python.service
 After=airflow-install-ophan-python.service
 
 

--- a/roles/airflow/templates/lib/systemd/system/airflow-install-ophan-python.service.j2
+++ b/roles/airflow/templates/lib/systemd/system/airflow-install-ophan-python.service.j2
@@ -2,8 +2,6 @@
 Description=Airflow connections update
 Requires=network.target
 After=network.target
-BindsTo=airflow-mutex.service
-After=airflow-mutex.service
 
 [Service]
 EnvironmentFile={{ airflow_environment_file_folder }}/airflow

--- a/roles/airflow/templates/lib/systemd/system/airflow-scheduler.service.j2
+++ b/roles/airflow/templates/lib/systemd/system/airflow-scheduler.service.j2
@@ -18,11 +18,12 @@ Description=Airflow scheduler
 Requires=network.target
 After=network.target
 
-BindsTo=airflow-mutex.service
+
+Requires=airflow-mutex.service
 After=airflow-mutex.service
 
-BindsTo=airflow-initdb.service
-After=airflow-initdb.service
+Requires=airflow-dags-update.service
+After=airflow-dags-update.service
 
 BindsTo=airflow-connections-update.service
 After=airflow-connections-update.service

--- a/roles/airflow/templates/lib/systemd/system/airflow-webserver.service.j2
+++ b/roles/airflow/templates/lib/systemd/system/airflow-webserver.service.j2
@@ -18,8 +18,15 @@ Description=Airflow webserver
 Requires=network.target
 After=network.target
 
+Requires=airflow-mutex.service
+After=airflow-mutex.service
+
 Requires=airflow-dags-update.service
 After=airflow-dags-update.service
+
+BindsTo=airflow-connections-update.service
+After=airflow-connections-update.service
+
 {% if nfs_mount_enabled %}
 After=mnt-nfs.mount
 BindsTo=mnt-nfs.mount


### PR DESCRIPTION
The systemd services are wired strangely, without enforcing some required order.
After boot, the webserver.service keeps trying to start despite the design generally
requiring initdb and other things. This simpler mapping allows the design to inject the
ophan python installation as a requirement of initdb which will continue to be useful.