### PR TITLE
Remove webserver dependency mutex

### DIFF
--- a/roles/airflow/templates/lib/systemd/system/airflow-webserver.service.j2
+++ b/roles/airflow/templates/lib/systemd/system/airflow-webserver.service.j2
@@ -18,9 +18,6 @@ Description=Airflow webserver
 Requires=network.target
 After=network.target
 
-Requires=airflow-mutex.service
-After=airflow-mutex.service
-
 Requires=airflow-dags-update.service
 After=airflow-dags-update.service
 


### PR DESCRIPTION
The webserver sevice is needed for RiffRaff to receive a 200 from the health check port. Making it dependent on the mutex means that there is nothing listening to that port on the new  instance during its deployment (because there will always be 2 services).

So RiffRaff thinks it isn't healthy and won't kill the old node.

In the future we will move the mutex into a subdirectory airflow-scheulder.requires or similar. But that is not a simple change in current architecture.