### PR TITLE
Add extra permissions required for SSM-tunnel.

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -120,6 +120,10 @@ Resources:
           - ssm:ListInstanceAssociations
           - ssm:DescribeInstanceProperties
           - ssm:DescribeDocumentParameters
+          - ssmmessages:CreateControlChannel
+          - ssmmessages:CreateDataChannel
+          - ssmmessages:OpenControlChannel
+          - ssmmessages:OpenDataChannel
       Roles:
       - !Ref RootRole
 


### PR DESCRIPTION
This will allow us to close port 22 access entirely. This is already released on CODE and PROD.

See https://github.com/guardian/ssm-scala/pull/111 for details