### PR TITLE
Prepend AIRFLOW_HOME to PYTHONPATH

### DIFF
--- a/roles/airflow/templates/etc/sysconfig/airflow-environment-file.j2
+++ b/roles/airflow/templates/etc/sysconfig/airflow-environment-file.j2
@@ -27,6 +27,6 @@ AIRFLOW_HOME={{ airflow_home }}
 
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:{{ airflow_virtualenv_folder }}/bin
 
-PYTHONPATH="{{ airflow_plugins_dir }}"
+PYTHONPATH={{ airflow_home }}:{{ airflow_plugins_dir }}
 
 GUNICORN_CMD_ARGS="--log-level WARNING"


### PR DESCRIPTION
Allow `from dags.<dagfile> import dag` on deployments. This is the value used as the PYTHONPATH when the daemons for the airflow components. Prepending it just makes airflow home available which is just a useful convention.

This file is created at BAKE... values from deployment and secrets are appended on deployment by cloudformation step. It is the EnvironmentFile. All good.

This PYTHONPATH setting means that AIRFLOW_HOME isn't known to the
PYTHON executable when it is invoked by the systemd services that manage
the webserver, executor and scheduler. That is because in the BAKE this
file is  unpacked into /etc/sysconfig/ which is then used for the
Environment File.

Just adding a second value means that we can use conventions in Airflow
development that import from the path. Such as imports from DAG files
without relative imports.