### PR TITLE
Teamcity agent role: bump max_user_watchers

### DIFF
--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -8,6 +8,10 @@
   sysctl:
     name: vm.max_map_count
     value: 262144
+- name: set max_user_watchers to 8 times default ubuntu level
+  sysctl:
+    name: fs.inotify.max_user_watches
+    value: 65536
 - name: create docker group
   group:
     name: docker


### PR DESCRIPTION
I'm currently trying to get the editions android build to run on ubuntu agents in teamcity. The current error I'm facing is 'ENOSPC: System limit for number of file watchers reached'. This applies both to builds directly on the machine as well as to those run in a docker container.

This change bumps the limit for max_user_watchers, making use of the built in ansible sysctl command (we already do this for max_map_count). I've tested this change directly on an agent by sshing in to verify that it solved my build problems.