### PR TITLE
Patch Airflow Logging Fix into VirtualEnv Installation

### DIFF
--- a/roles/airflow/files/patches/AIRFLOW-1916-dont-duplicate-logs.diff
+++ b/roles/airflow/files/patches/AIRFLOW-1916-dont-duplicate-logs.diff
@@ -1,0 +1,17 @@
+diff --git a/airflow/utils/log/s3_task_handler.py b/airflow/utils/log/s3_task_handler.py
+index da0d3bb11..50f7923e8 100644
+--- a/airflow/utils/log/s3_task_handler.py
++++ b/airflow/utils/log/s3_task_handler.py
+@@ -59,6 +59,12 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
+         self.log_relative_path = self._render_filename(ti, ti.try_number)
+         self.upload_on_close = not ti.raw
+ 
++        # Clear the file first so that duplicate data is not uploaded
++        # when re-using the same path (e.g. with rescheduled sensors)
++        if self.upload_on_close:
++            with open(self.handler.baseFilename, 'w'):
++                pass
++
+     def close(self):
+         """
+         Close and upload local log file to remote storage S3.

--- a/roles/airflow/tasks/install.yml
+++ b/roles/airflow/tasks/install.yml
@@ -47,6 +47,12 @@
     virtualenv: "{{ airflow_virtualenv_folder }}/"
     virtualenv_python: "{{ airflow_python_path }}"
 
+- name: Patch Airflow Logging -- Remove in 1.10.8+
+  patch:
+    basedir: "{{ airflow_virtualenv_folder }}/lib/python3.6/site-packages/"
+    src: patches/AIRFLOW-1916-dont-duplicate-logs.diff
+    strip: 1
+
 - name: Airflow | ensure psycopg2 is absent (deprecated, superseded with psycopg2-binary)
   pip:
     name: ['psycopg2']


### PR DESCRIPTION
Airflow logging to remote locations (such as S3) duplicates logs on each write where there is both a remote and a local copy of the logs at the point of opening. The compounding factor is that this hits UP_FOR_RESCHEDULE models the hardest, and we have lots of long running sensors with UP_FOR_RESCHEDULE.

This patch essentially clears the logging file, before writing to it. Thus no duplication!

While here add a `files/` dir to the module. This allows the
subdirectories to be called in the ansible patch module itself because
it will search relative to this path.

Actual patch:

  Taken from: https://github.com/apache/airflow/pull/7120
  Related to: https://issues.apache.org/jira/browse/AIRFLOW-6522