### PR TITLE
Pin WTForms to 2.2.0 in Airflow Role

### DIFF
--- a/roles/airflow/tasks/install.yml
+++ b/roles/airflow/tasks/install.yml
@@ -25,7 +25,7 @@
 
 - name: Airflow | pip installs
   pip:
-    name: ['attrs', 'botocore', 'boto3', 'six', 'gunicorn', 'numpy', 'Werkzeug==0.16.1', 'flask_oauthlib']
+    name: ['attrs', 'botocore', 'boto3', 'six', 'gunicorn', 'numpy', 'Werkzeug==0.16.1', 'WTForms==2.2.1', 'flask_oauthlib']
     state: latest
     virtualenv: "{{ airflow_virtualenv_folder }}/"
     virtualenv_python: "{{ airflow_python_path }}"


### PR DESCRIPTION
Overnight WTForms release 2.3.0 which introduces a breaking  change for Airflow. Pin the version until resolved in the dependencies.