### PR TITLE
Fix quoting on string in disk available

### DIFF
--- a/roles/disk-available-cronjob/tasks/main.yml
+++ b/roles/disk-available-cronjob/tasks/main.yml
@@ -4,4 +4,4 @@
     name: "disk space avaible"
     # Which minutes or how often (*/5)
     minute: "{{ minute | default(omit) }}"
-    job: "/usr/local/aws-scripts-mon/mon-put-instance-data.pl --disk-space-avail --mem-avail $(/bin/lsblk -pnl | /usr/bin/awk '{ if (NF==7 && $5==0) print "--disk-path " $1}' | xargs)  --auto-scaling --from-cron"
+    job: "/usr/local/aws-scripts-mon/mon-put-instance-data.pl --disk-space-avail --mem-avail $(/bin/lsblk -pnl | /usr/bin/awk '{ if (NF==7 && $5==0) print \"--disk-path \" $1}' | xargs)  --auto-scaling --from-cron"


### PR DESCRIPTION
This was causing `grid-imaging` and `grid-imaging-eoan` to fail.
@aug24 @philmcmahon 