### PR TITLE
Docker credentials and Amazon Linux 2 base image

### DIFF
--- a/app/models/BaseImage.scala
+++ b/app/models/BaseImage.scala
@@ -19,7 +19,7 @@ object LinuxDist {
 
   def create(name: String): Option[LinuxDist] = all.get(name)
 
-  val all = Map("ubuntu" -> Ubuntu, "redhat" -> RedHat)
+  val all = Map("ubuntu" -> Ubuntu, "redhat" -> RedHat, "amazon linux 2" -> AmazonLinux2)
 }
 case object Ubuntu extends LinuxDist {
   val name = "ubuntu"
@@ -49,6 +49,20 @@ case object RedHat extends LinuxDist {
       "yum -y update",
       "yum -y install ansible",
       "yum -y install libselinux-python-2.0.94-7.el6"
+    ))
+  )
+}
+
+case object AmazonLinux2 extends LinuxDist {
+  val name = "amazon linux 2"
+  val loginName = "ec2-user"
+  val provisioners = Seq(
+    PackerProvisionerConfig.executeRemoteCommands(Seq(
+      "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
+      "yum -y update",
+      "yum -y install amazon-linux-extras", // should be a no-op
+      "amazon-linux-extras enable ansible2",
+      "yum -y install ansible"
     ))
   )
 }

--- a/roles/docker-ecr/README.md
+++ b/roles/docker-ecr/README.md
@@ -1,0 +1,10 @@
+# Docker ECR
+
+**Use with an Amazon Linux 2 base image only.**
+
+Installs and starts Docker with the
+[ECR credentials helper](https://github.com/awslabs/amazon-ecr-credential-helper.).
+
+IAM credentials will be automatically used when interacting with any Docker
+registry. This only makes sense if you are pulling images/interacting with an
+ECR registry.

--- a/roles/docker-ecr/files/config.json
+++ b/roles/docker-ecr/files/config.json
@@ -1,0 +1,3 @@
+{
+  "credsStore": "ecr-login"
+}

--- a/roles/docker-ecr/tasks/main.yml
+++ b/roles/docker-ecr/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+- name: Enable Docker
+  command: amazon-linux-extras install docker
+
+- name: Install Docker
+  yum:
+    name: docker
+    state: present
+
+- name: Add ec2-user to docker group to avoid requiring 'sudo'
+  user:
+    name: ec2-user
+    groups: docker
+    append: yes
+
+- name: Install Amazon ECR Docker Credential Helper
+  yum:
+    name: amazon-ecr-credential-helper
+    state: present
+
+- name: Create Docker config directory (if doesn't exist)
+  file:
+    path: /home/ec2-user/.docker
+    state: directory
+    mode: ugo+rw
+    owner: ec2-user
+    group: ec2-user
+
+- name: Copy Docker config to register creds store
+  copy:
+    src: config.json
+    dest: /home/ec2-user/.docker/config.json
+    owner: ec2-user
+    group: ec2-user
+    mode: ugo+rw
+
+- name: Create Docker config directory (if doesn't exist) (for root user)
+  file:
+    path: /root/.docker
+    state: directory
+    mode: ugo+rw
+    owner: root
+    group: root
+
+- name: Copy Docker config to register creds store (for root user)
+  copy:
+    src: config.json
+    dest: /root/.docker/config.json
+    owner: root
+    group: root
+    mode: ugo+rw
+
+
+- name: Start Docker
+  service:
+    name: docker
+    state: started
+    enabled: yes

--- a/roles/docker/README.md
+++ b/roles/docker/README.md
@@ -1,3 +1,6 @@
 # Docker
 
-Installs Docker, takes a parameter `version` for the full docker version number. 
+Installs Docker, takes a parameter `version` for the full docker version number.
+
+NB: if you are using Amazon Linux, use the `docker-ecr` role instead, which also
+configures Docker to use AWS credentials if found.


### PR DESCRIPTION
*Note: have successfully built an Amazon Linux 2 AMI with the `docker-ecr` role on Amigo CODE and then tested that in the Frontend AWS account.*

## What does this change?

We use multiple languages and the surrounding tooling (cloudformation, AMIs, riffraff bundling, etc.) is language-specific. This means a lot of repetition. Docker provides a standard interface here.

Amazon Linux 2 has been used as the base image for a few reasons, but primarily because it has good out-of-the-box support for Docker (with the `amazon-linux-extras` package).

## How can we measure success?

Re-use of deployment code across languages/projects.

## Questions

`UserData` in cloudformation runs as `root`, but I've added the credentials helper config to the `ec2-user` home, which means it will only be found when launching a docker command with the ec2-user user.

What do people think on this? Should I assume people will only run docker as root?
