### PR TITLE
Add metricbeat role

### DIFF
--- a/roles/metricbeat/README.md
+++ b/roles/metricbeat/README.md
@@ -1,0 +1,11 @@
+# metricbeat
+
+Install [metricbeat](https://www.elastic.co/beats/metricbeat) to gather metrics from a [variety of sources](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-modules.html).
+
+Configuration to be supplied at launch time.
+
+Basic use allows the version of metricbeat to be specified:
+
+```
+version: 7.8.1
+```

--- a/roles/metricbeat/tasks/main.yml
+++ b/roles/metricbeat/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Add Elastic repository key
+  apt_key: url=https://artifacts.elastic.co/GPG-KEY-elasticsearch state=present
+
+- name: Ensure Metricbeat is installed
+  apt: deb=https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{ version }}-amd64.deb state=present


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Add role for [metricbeat](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-getting-started.html) to allow the collection of [elasticsearch metrics](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-elasticsearch.html).

Initially, this will be used to collect metrics about the Central ELK stack. We can look at expanding it for use by [Ophan](https://github.com/guardian/ophan/issues/3898).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Bake an image using this role? This has been done successfully on CODE.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
An AMI can be baked with metricbeat installed.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
n/a