### PR TITLE
Add a link to view the AMI in AMIable.

### DIFF
--- a/app/views/showRecipe.scala.html
+++ b/app/views/showRecipe.scala.html
@@ -87,6 +87,7 @@
               <button class="btn btn-primary btn-xs absolute-right copy-button" title="Copy to clipboard" data-clipboard-text="@bake.amiId">
                 <img src="@routes.Assets.versioned("images/clippy.svg")" width="13" alt="Copy to clipboard">
               </button>
+              <a href="https://amiable.gutools.co.uk/ami?imageId=@bake.amiId" target="_blank" rel="noopener noreferrer">View in AMIable</a>
             }
             </td>
           </tr>
@@ -109,6 +110,7 @@
                 <button class="btn btn-primary btn-xs absolute-right copy-button" title="Copy to clipboard" data-clipboard-text="@copy.imageId">
                   <img src="@routes.Assets.versioned("images/clippy.svg")" width="13" alt="Copy to clipboard">
                 </button>
+                <a href="https://amiable.gutools.co.uk/ami?imageId=@bake.amiId" target="_blank" rel="noopener noreferrer">View in AMIable</a>
               </td>
             </tr>
           }

--- a/app/views/showRecipe.scala.html
+++ b/app/views/showRecipe.scala.html
@@ -71,45 +71,78 @@
           }
           <th>Status</th>
           <th>AMI</th>
+          @* Column for copy button *@
+          <th></th>
+          @* Column for open in AMIable link *@
+          <th></th>
         </thead>
         <tbody>
         @for(bake <- recentBakes) {
           <tr>
-          <td class="has-block-link"><a class="block-link" href="@routes.BakeController.showBake(bake.recipe.id, bake.buildNumber)">@fragments.timestamp(bake.startedAt, bake.startedBy)</a></td>
-          <td class="has-block-link"><a class="block-link" href="@routes.BakeController.showBake(bake.recipe.id, bake.buildNumber)">@bake.buildNumber</a></td>
-          @if(recentCopies.nonEmpty) {
-            <td class="has-block-link"></td>
-          }
-          <td class="has-block-link"><a class="block-link" href="@routes.BakeController.showBake(bake.recipe.id, bake.buildNumber)">@bake.status</a></td>
-            <td class="absolute-container has-block-link">
-            @if(bake.amiId.isDefined) {
-              <a class="block-link" href="@routes.BakeController.showBake(bake.recipe.id, bake.buildNumber)"><code>@bake.amiId</code></a>
-              <button class="btn btn-primary btn-xs absolute-right copy-button" title="Copy to clipboard" data-clipboard-text="@bake.amiId">
-                <img src="@routes.Assets.versioned("images/clippy.svg")" width="13" alt="Copy to clipboard">
-              </button>
-              <a href="https://amiable.gutools.co.uk/ami?imageId=@bake.amiId" target="_blank" rel="noopener noreferrer">View in AMIable</a>
-            }
+            <td class="has-block-link">
+              <a class="block-link" href="@routes.BakeController.showBake(bake.recipe.id, bake.buildNumber)">
+                @fragments.timestamp(bake.startedAt, bake.startedBy)
+              </a>
             </td>
+            <td class="has-block-link">
+              <a class="block-link" href="@routes.BakeController.showBake(bake.recipe.id, bake.buildNumber)">
+                @bake.buildNumber
+              </a>
+            </td>
+            @if(recentCopies.nonEmpty) {
+              <td class="has-block-link"></td>
+            }
+            <td class="has-block-link">
+              <a class="block-link" href="@routes.BakeController.showBake(bake.recipe.id, bake.buildNumber)">
+                @bake.status
+              </a>
+            </td>
+            @if(bake.amiId.isDefined) {
+              <td class="has-block-link">
+                <a class="block-link" href="@routes.BakeController.showBake(bake.recipe.id, bake.buildNumber)">
+                  <code>@bake.amiId</code>
+                </a>
+              </td>
+              <td class="absolute-container has-block-link">
+                <button class="btn btn-primary btn-xs absolute-right copy-button" title="Copy to clipboard" data-clipboard-text="@bake.amiId">
+                  <img src="@routes.Assets.versioned("images/clippy.svg")" width="13" alt="Copy to clipboard">
+                </button>
+              </td>
+              <td>
+                <a href="https://amiable.gutools.co.uk/ami?imageId=@bake.amiId" target="_blank" rel="noopener noreferrer">View in AMIable</a>
+              </td>
+              </td>
+            } else {
+              <td></td>
+              <td></td>
+              <td></td>
+            }
           </tr>
           @for(copy <- bake.amiId.flatMap(id => recentCopies.get(id)).getOrElse(Nil)){
             <tr>
-              <td></td>
-              <td>  </td>
-              <td><ul class="list-unstyled">
-                <li>Acc: @defining(accounts.find(_.accountNumber == copy.ownerId)){ maybeOwnerAcc =>
-                  @maybeOwnerAcc.map{ ownerAcc => @ownerAcc.accountName (@ownerAcc.accountNumber) }.getOrElse(copy.ownerId)
-                }</li>
-                @copy.encrypted.map{e =>
-                  <li>Encrypted tag: @e</li>
-                }
-              </ul>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+              <td>
+                <ul class="list-unstyled">
+                  <li>Acc: @defining(accounts.find(_.accountNumber == copy.ownerId)){ maybeOwnerAcc =>
+                      @maybeOwnerAcc.map{ ownerAcc => @ownerAcc.accountName (@ownerAcc.accountNumber) }.getOrElse(copy.ownerId)
+                    }
+                  </li>
+                  @copy.encrypted.map{e => <li>Encrypted tag: @e</li>}
+                </ul>
               </td>
-              <td>@copy.state.capitalize</td>
-              <td class="absolute-container">
+              <td>
+                @copy.state.capitalize
+              </td>
+              <td>
                 <code>@copy.imageId</code>
+              </td>
+              <td class="absolute-container">
                 <button class="btn btn-primary btn-xs absolute-right copy-button" title="Copy to clipboard" data-clipboard-text="@copy.imageId">
                   <img src="@routes.Assets.versioned("images/clippy.svg")" width="13" alt="Copy to clipboard">
                 </button>
+              </td>
+              <td>
                 <a href="https://amiable.gutools.co.uk/ami?imageId=@bake.amiId" target="_blank" rel="noopener noreferrer">View in AMIable</a>
               </td>
             </tr>


### PR DESCRIPTION
Easiest to review w/out whitespace https://github.com/guardian/amigo/pull/378/files?w=1.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Deep-link into AMIable. This view in AMIable provides information about the AMI, including:
- creation date
- ARN
- any launch configurations that use it
- any instances that use it
- any available updates

This is useful to double check if we have setup a stack's auto-update correctly: if we see the most recent AMI not used, but an AMI from last month is, then we've likely misconfigured the app in RiffRaff.

NOTE: Although there is a CODE stack for AMIgo, there is only a PROD stack for AMIable.

This also makes the structure of the `table` a bit simpler with a dedicated column for the copy button and the new AMIable link, whereas before the copy button was part of the ami id column.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
- Deploy to CODE
- Open a recipe's recent bake page
- Click the new `View in AMIable` link to open AMIable

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Tighter integration in our tooling, making discovery easier.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Leaking of the AMIable domain, however its been mentioned that the domain is in the AMIable repo already.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
**Before**
![image](https://user-images.githubusercontent.com/836140/90664080-6cd77580-e242-11ea-805d-c7f4333ee197.png)

**After**
![image](https://user-images.githubusercontent.com/836140/90663353-73b1b880-e241-11ea-86be-2ffe0cdbda8c.png)
