### PR TITLE
use the correct AMI ID

### DIFF
--- a/app/views/showRecipe.scala.html
+++ b/app/views/showRecipe.scala.html
@@ -143,7 +143,7 @@
                 </button>
               </td>
               <td>
-                <a href="https://amiable.gutools.co.uk/ami?imageId=@bake.amiId" target="_blank" rel="noopener noreferrer">View in AMIable</a>
+                <a href="https://amiable.gutools.co.uk/ami?imageId=@copy.imageId" target="_blank" rel="noopener noreferrer">View in AMIable</a>
               </td>
             </tr>
           }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
For the encrypted copy row, use the correct AMI ID when crafting the link to AMIable. Previously this was using the AMI ID from the vanilla bake, which is incorrect.

Related to https://github.com/guardian/amigo/pull/378.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
- Deploy to CODE
- Observe the correct AMI ID is used when clicking on the AMIable link

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Link destination is correct.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![image](https://user-images.githubusercontent.com/836140/90669814-1cfcac80-e24a-11ea-9c8d-1ac96d781550.png)
