### PR TITLE
Add libxss1 dependency to fix time-machine

### DIFF
--- a/roles/puppeteer/tasks/main.yml
+++ b/roles/puppeteer/tasks/main.yml
@@ -5,7 +5,7 @@
     name: [
       'npm', # we need this to *install* Puppeteer
       'nodejs', # we need this to *run* Puppeteer
-      'chromium-browser' # we used to use this to get all the X11 libraries required by Puppeteer's bundled copy of Chrome, but as of September 2020 need to specify libxss1 (see below)
+      'chromium-browser', # we used to use this to get all the X11 libraries required by Puppeteer's bundled copy of Chrome, but as of September 2020 need to specify libxss1 (see below)
       'libxss1' # required by Puppeteer as detailed https://github.com/guardian/ophan/issues/3932
     ]
 

--- a/roles/puppeteer/tasks/main.yml
+++ b/roles/puppeteer/tasks/main.yml
@@ -5,7 +5,8 @@
     name: [
       'npm', # we need this to *install* Puppeteer
       'nodejs', # we need this to *run* Puppeteer
-      'chromium-browser' # easiest way to get all the X11 libraries required by Puppeteer's bundled copy of Chrome
+      'chromium-browser' # we used to use this to get all the X11 libraries required by Puppeteer's bundled copy of Chrome, but as of September 2020 need to specify libxss1 (see below)
+      'libxss1' # required by Puppeteer as detailed https://github.com/guardian/ophan/issues/3932
     ]
 
 - name: Install "puppeteer" node.js package so that it is available to any program on the system


### PR DESCRIPTION
## What does this change?
Time machine stopped working on Monday 14 September due to the wrong version of libxss1. This PR adds the libxss1 dependency to this AMI, used only by ophan-time-machine. 

See further details here: https://github.com/guardian/ophan/issues/3932