### PR TITLE
Make docker pull via nexus.gutools

### DIFF
--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -30,6 +30,8 @@
     dest: /usr/local/bin/docker-compose
     mode: 0555
     checksum: sha256:f679a24b93f291c3bffaff340467494f388c0c251649d640e661d509db9d57e9
+- name: set docker to use nexus pull through proxy
+  shell: echo '{"registry-mirrors":["https://nexus.gutools.co.uk:8082"]}' > /etc/docker/daemon.json
 - name: create etc gu
   file:
     path: /etc/gu


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This configures the docker daemon to pull via nexus rather than straight from docker hub. This is to avoid failures due docker hub rate limiting.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
A new spot instance that runs a teamcity build that triggers a docker pull should have an effect on nexus. Docker images should start to be cached at https://nexus.gutools.co.uk/#browse/browse:docker

## How can we measure success?
N/A

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
If this is misconfigured, docker pulls will fail. So every teamcity build that relies on it will grind to a halt.
