### PR TITLE
Correct URL to GitHub search

### DIFF
--- a/app/views/showRecipe.scala.html
+++ b/app/views/showRecipe.scala.html
@@ -38,7 +38,7 @@
         <p><b>This recipe is not used</b></p>
       }
       <p>
-        <a href="@(s"https://github.com/search?q=${helper.urlEncode(s"""org:guardian+"${recipe.id}"+filename:riff-raff.yaml""")}&type=code")">
+        <a href="@(s"https://github.com/search?q=${helper.urlEncode(s"""org:guardian "${recipe.id}" filename:riff-raff.yaml""")}&type=code")">
           Search GitHub for usage
         </a>
       </p>


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Following from https://github.com/guardian/amigo/pull/383.

Remove the `+`s from the URL. `+` is what Chrome appears to encode ` ` to in the URL bar. As we're running `+` through `helper.urlEncode`, the `+` is ending up as `%2B` which is totally incorrect.

Replacing it with ` ` results in `%20`, which is correct.

Not entirely sure how I missed this, maybe the browser cached something?