### PR TITLE
Add github.com to ssh_known_hosts

### DIFF
--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -103,6 +103,15 @@
   become: yes
   become_user: root
 
+- name: ssh test 1
+  shell: |
+    set -e
+    ssh git@github.com || true
+  become: yes
+  become_user: teamcity
+  args:
+    executable: /bin/bash
+
 # IP address from `dig +short github.com`
 # Public key from `ssh-keyscan -t rsa github.com`
 - name: add github.com to ssh_known_hosts
@@ -112,3 +121,12 @@
     key: github.com,140.82.121.3 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
     path: /etc/ssh/ssh_known_hosts
     state: present
+
+- name: ssh test 2
+  shell: |
+    set -e
+    ssh git@github.com
+  become: yes
+  become_user: teamcity
+  args:
+    executable: /bin/bash

--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -108,7 +108,7 @@
 - name: add github.com to ssh_known_hosts
   known_hosts:
     name: github.com
-    hash_host: true
+    hash_host: false
     key: github.com,140.82.121.3 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
     path: /etc/ssh/ssh_known_hosts
     state: present

--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -103,15 +103,6 @@
   become: yes
   become_user: root
 
-- name: ssh test 1
-  shell: |
-    set -e
-    ssh git@github.com || true
-  become: yes
-  become_user: teamcity
-  args:
-    executable: /bin/bash
-
 # IP address from `dig +short github.com`
 # Public key from `ssh-keyscan -t rsa github.com`
 - name: add github.com to ssh_known_hosts
@@ -121,12 +112,3 @@
     key: github.com,140.82.121.3 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
     path: /etc/ssh/ssh_known_hosts
     state: present
-
-- name: ssh test 2
-  shell: |
-    set -e
-    ssh git@github.com
-  become: yes
-  become_user: teamcity
-  args:
-    executable: /bin/bash

--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -102,3 +102,13 @@
     echo "teamcity  ALL=(root) NOPASSWD: /usr/local/bin/awsconfig_cleanup.sh" > /etc/sudoers.d/awscleanup
   become: yes
   become_user: root
+
+# IP address from `dig +short github.com`
+# Public key from `ssh-keyscan -t rsa github.com`
+- name: add github.com to ssh_known_hosts
+  known_hosts:
+    name: github.com
+    hash_host: true
+    key: github.com,140.82.121.3 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+    path: /etc/ssh/ssh_known_hosts
+    state: present


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Uses [Ansible's known_hosts module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/known_hosts_module.html) to add GitHub's public key into `/etc/ssh/ssh_known_hosts` on the TeamCity agents.

Used in conjunction with [TeamCity's SSH Agent build feature](https://www.jetbrains.com/help/teamcity/ssh-agent.html), this is a more idiomatic solution than #390. It does, however, require us to upload an SSH key to TeamCity via the UI; this action won't be stored in VCS.

This will allow a project to reach GitHub during a build.

**Okay... but we can already reach GitHub...?**
Yes. Correct. We can reach GitHub at the point of fetch/checkout, not at the point of _build_. The key used for fetch/checkout is removed once that step has completed regardless of the checkout mode:

From [SSH Keys Management](https://www.jetbrains.com/help/teamcity/ssh-keys-management.html):

> During the build with agent-side checkout, the Git plugin downloads the key from the server to the agent. It temporarily saves the key on the agent's file system and removes it after git fetch/clone is completed.

**Example**
1. Commit and push to remote
1. TeamCity build gets triggered
1. TeamCity agent checks out branch (or TeamCity server, depending on project setup)
1. SSH key is removed after fetch/checkout step has completed
1. TeamCity agent runs the commands defined in the project. For example `npm install && npm test`

So far, so normal.

Let's say an npm module is installed from GitHub using the [`git+ssh` protocol](https://docs.npmjs.com/cli/v6/commands/npm-install#description:~:text=git%2Bssh,-%2C). The build agent will need to make an ssh request when it is performing the `npm install` build step. In order to make an ssh connection, the client needs to verify the host key. This can be done in two ways: via stdin or by writing a line to `/etc/ssh/ssh_known_hosts`. Stdin isn't applicable in a CI environment.

The primary use case is wanting to install a package from a private repository which is not published to NPM because, say, it holds private information and we're on the [free tier of NPM](https://www.npmjs.com/products) which only allows publishing of public packages.

**Right... so is there practical use case?**
See https://github.com/guardian/deploy-tools-platform/pull/280 for a practical use case.

**That string...?**
Following guidance from [here](https://man.openbsd.org/sshd.8#SSH_KNOWN_HOSTS_FILE_FORMAT), the public key is taken from `ssh-keyscan -t rsa github.com`.

> Note that the lines in these files are typically hundreds of characters long, and you definitely don't want to type in the host keys by hand. Rather, generate them by a script, [ssh-keyscan](https://man.openbsd.org/ssh-keyscan.1) ...

Thanks for the tip on TeamCity SSH Agent @jorgeazevedo and thanks @sihil for pairing!

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

The second commit in this branch performs a rudimentary test (the third commit removes it):
- Attempt ssh connection, watch it fail (`|| true` added for a clean exit)
- Add to ssh_known_hosts
- Attempt another ssh connection, watch it succeed (well, until it tries to use the private key 😅 )

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

New build time workflows are unlocked!

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

The public key looks like it should be a secret, it isn't though as demonstrated by `ssh-keyscan` (it's also a _public_ key).

What if the public key is wrong? It isn't 😄 . The value in `ssh_known_hosts` get's verified on each connection; as the "test" succeeds, we know the key is correct.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

Here's the build output from the aforementioned "test" after a bake on CODE:

![image](https://user-images.githubusercontent.com/836140/99740816-9ca74b00-2ac7-11eb-8b9d-8368924688f8.png)
