### PR TITLE
Add Wazuh Agent role

### DIFF
--- a/roles/wazuh-agent/meta/main.yml
+++ b/roles/wazuh-agent/meta/main.yml
@@ -1,0 +1,5 @@
+---
+dependencies:
+  - role: aws-tools
+    when:
+      - ansible_os_family == "Debian"

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -19,20 +19,15 @@
 
     sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/wazuh.list
     apt-get update
-    echo installed_agent
+    
     # ----------------- Store the password and register the agent
 
     SECRET_ARN="arn:aws:secretsmanager:{{ secret_region }}:{{ account_id }}:secret:{{ secret_id }}"
-    echo $SECRET_ARN
-
     REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
-    echo fetched_region
 
     aws secretsmanager get-secret-value --secret-id $SECRET_ARN \
        --query SecretString --output text --version-stage AWSCURRENT --region $REGION \
        | jq -r .value > /var/ossec/etc/authd.pass
-
-    echo fetched_secret
 
     cat << 'PARENT_EOF' > /usr/local/bin/connect-to-wazuh-manager.sh
     #!/bin/bash -x
@@ -42,7 +37,6 @@
     INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
     FILTERS="Name=resource-id,Values=$INSTANCE_ID Name=resource-type,Values=instance"
     OPTIONS="--query Tags[].Value --output text --region $REGION"
-
 
     APP=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=App $OPTIONS)
     STACK=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stack $OPTIONS)
@@ -67,17 +61,11 @@
 
     # Boot agent
     systemctl enable wazuh-agent
-    systemctl status wazuh-agent
-    systemctl status wazuh-agent
     systemctl start wazuh-agent
     PARENT_EOF
 
-    echo wrote_script
-
     chmod +x /usr/local/bin/connect-to-wazuh-manager.sh
     chmod 744 /usr/local/bin/connect-to-wazuh-manager.sh
-
-    echo script_permissions
 
     ## Create Systemd service file
     cat << EOF > /etc/systemd/system/wazuh-manager-connection.service
@@ -90,21 +78,11 @@
     [Install]
     WantedBy=default.target
     EOF
-    echo wrote_systemd
     chmod 664 /etc/systemd/system/wazuh-manager-connection.service
-    echo systemd_permissions
-
 
     ## Disable wazuh agent until registration happens
     systemctl disable wazuh-agent
-    echo disable_agent
 
     ## Enable the new service unit so we register on first boot
     systemctl daemon-reload
-    echo daemon_reload
     systemctl enable wazuh-manager-connection.service
-    echo enable_connection_manager_service
-
-    ## Debug commands
-    # status: sudo systemctl status wazuh-manager-connection
-    # full log: journalctl -u wazuh-manager-connection

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -34,8 +34,8 @@
 
     echo fetched_secret
 
-    cat << 'PARENT_EOF' > /var/ossec/etc/connect-to-manager.sh
-    # ----------------- On boot
+    cat << 'PARENT_EOF' > /usr/local/bin/connect-to-wazuh-manager.sh
+    #!/bin/bash -x
     MANAGER_IP="{{ manager_ip }}"
     REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 
@@ -64,12 +64,36 @@
 
     systemctl restart wazuh-agent
     /var/ossec/bin/agent-auth -m $MANAGER_IP -A $INSTANCE_ID
-
     PARENT_EOF
 
     echo wrote_script
 
-    chmod +x /var/ossec/etc/connect-to-manager.sh
-    echo chmoded
-    cat /var/ossec/etc/connect-to-manager.sh
-    echo done
+    chmod +x /usr/local/bin/connect-to-wazuh-manager.sh
+    chmod 744 /usr/local/bin/connect-to-wazuh-manager.sh
+
+    echo script_permissions
+
+    ## Create Systemd service file
+    cat << EOF > /etc/systemd/system/wazuh-manager-connection.service
+    [Unit]
+    After=network.service
+
+    [Service]
+    ExecStart=/usr/local/bin/connect-to-wazuh-manager.sh
+
+    [Install]
+    WantedBy=default.target
+    EOF
+    echo wrote_systemd
+    chmod 664 /etc/systemd/system/disk-space-check.service
+    echo systemd_permissions
+
+    ## Enable the new service unit
+    systemctl daemon-reload
+    echo daemon_reload
+    systemctl enable wazuh-manager-connection.service
+    echo service_enable
+
+    ## Debug commands
+    # status: sudo systemctl status wazuh-manager-connection
+    # full log: journalctl -u wazuh-manager-connection

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -47,7 +47,7 @@
     dest: /usr/local/bin/authenticate-with-wazuh-manager.sh
     mode: '0744'
     content: |
-      #!/bin/bash -xe
+      #!/bin/bash -x
       if [ -f "/var/ossec/etc/authd.pass" ]; then
         MANAGER_IP="{{ manager_ip }}"
         REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -19,17 +19,20 @@
 
     sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/wazuh.list
     apt-get update
-
+    echo installed_agent
     # ----------------- Store the password and register the agent
 
     SECRET_ARN="arn:aws:secretsmanager:{{ secret_region }}:{{ account_id }}:secret:{{ secret_id }}"
     echo $SECRET_ARN
 
     REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+    echo fetched_region
 
     aws secretsmanager get-secret-value --secret-id $SECRET_ARN \
        --query SecretString --output text --version-stage AWSCURRENT --region $REGION \
        | jq -r .value > /var/ossec/etc/authd.pass
+
+    echo fetched_secret
 
     cat << 'PARENT_EOF' > /var/ossec/etc/connect-to-manager.sh
     # ----------------- On boot
@@ -64,5 +67,9 @@
 
     PARENT_EOF
 
+    echo wrote_script
+
     chmod +x /var/ossec/etc/connect-to-manager.sh
+    echo chmoded
     cat /var/ossec/etc/connect-to-manager.sh
+    echo done

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Install required dependencies
+  apt:
+    state: present
+    name: [
+        'curl',
+        'apt-transport-https',
+        'lsb-release',
+        'gnupg2',
+        'jq'
+    ]
+
+- name: Run main script
+  shell: |
+    curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+    echo "deb https://packages.wazuh.com/3.x/apt/ stable main" | tee /etc/apt/sources.list.d/wazuh.list
+    apt-get update
+    apt-get install wazuh-agent=3.13.1-1
+
+    sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/wazuh.list
+    apt-get update
+
+    # ----------------- Store the password and register the agent
+    echo {{ secret_arn }}

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -35,9 +35,8 @@
 
 - name: Store the password
   shell: |
-    SECRET_ARN="arn:aws:secretsmanager:{{ secret_region }}:{{ account_id }}:secret:{{ secret_id }}"
+    SECRET_ARN="{{ secret_id }}"
     REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
-    echo {{ secret_id }}
 
     aws secretsmanager get-secret-value --secret-id $SECRET_ARN \
        --query SecretString --output text --version-stage AWSCURRENT --region $REGION \

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -88,7 +88,7 @@
     WantedBy=default.target
     EOF
     echo wrote_systemd
-    chmod 664 /etc/systemd/system/disk-space-check.service
+    chmod 664 /etc/systemd/system/wazuh-manager-connection.service
     echo systemd_permissions
 
     ## Enable the new service unit

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -34,10 +34,12 @@
     cat << 'PARENT_EOF' > /var/ossec/etc/connect-to-manager.sh
     # ----------------- On boot
     MANAGER_IP="{{ manager_ip }}"
+    REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 
     INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
     FILTERS="Name=resource-id,Values=$INSTANCE_ID Name=resource-type,Values=instance"
     OPTIONS="--query Tags[].Value --output text --region $REGION"
+
 
     APP=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=App $OPTIONS)
     STACK=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stack $OPTIONS)

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -62,9 +62,12 @@
     </ossec_config>
     EOF
 
+    # Enroll with manager
+    /var/ossec/bin/agent-auth -m $MANAGER_IP -A $INSTANCE_ID
+
+    # Boot agent
     systemctl enable wazuh-agent
     systemctl status wazuh-agent
-    /var/ossec/bin/agent-auth -m $MANAGER_IP -A $INSTANCE_ID
     systemctl status wazuh-agent
     systemctl start wazuh-agent
     PARENT_EOF

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -76,31 +76,39 @@
       # Enroll with manager
       /var/ossec/bin/agent-auth -m $MANAGER_IP -A $INSTANCE_ID
 
-      # Boot agent
-      systemctl enable wazuh-agent
-      systemctl start wazuh-agent
-
-- name: Inject systemd service unit wazuh-manager-connection.service
-  copy:
-    dest: /etc/systemd/system/wazuh-manager-connection.service
-    mode: '0644'
-    content: |
-      [Unit]
-      After=network.service
-
-      [Service]
-      ExecStart=/usr/local/bin/connect-to-wazuh-manager.sh
-
-      [Install]
-      WantedBy=default.target
-
-- name: Configure system to connect on first boot
+- name: Disable service
   shell: |
     # Disable wazuh agent until registration happens
     systemctl disable wazuh-agent
 
-    # Load wazuh-manager-connection.service, which we just created
+- name: Inject ExecStartPre
+  copy:
+    dest: /etc/systemd/system/wazuh-agent.service
+    mode: '0644'
+    content: |
+      [Unit]
+      Description=Wazuh agent
+      Wants=network-online.target
+      After=network.target network-online.target
+
+      [Service]
+      Type=forking
+      EnvironmentFile=/etc/ossec-init.conf
+
+      ExecStartPre=/usr/local/bin/connect-to-wazuh-manager.sh
+      ExecStart=/usr/bin/env ${DIRECTORY}/bin/ossec-control start
+      ExecStop=/usr/bin/env ${DIRECTORY}/bin/ossec-control stop
+      ExecReload=/usr/bin/env ${DIRECTORY}/bin/ossec-control reload
+      KillMode=none
+      RemainAfterExit=yes
+
+      [Install]
+      WantedBy=multi-user.target
+
+- name: Configure system to connect on first boot
+  shell: |
+    # Reload  wazuh-agent, which we just patched
     systemctl daemon-reload
 
     # Enable it so it runs on first boot
-    systemctl enable wazuh-manager-connection.service
+    systemctl enable wazuh-agent

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -76,11 +76,6 @@
       # Enroll with manager
       /var/ossec/bin/agent-auth -m $MANAGER_IP -A $INSTANCE_ID
 
-- name: Disable service
-  shell: |
-    # Disable wazuh agent until registration happens
-    systemctl disable wazuh-agent
-
 - name: Inject ExecStartPre
   copy:
     dest: /etc/systemd/system/wazuh-agent.service
@@ -104,11 +99,3 @@
 
       [Install]
       WantedBy=multi-user.target
-
-- name: Configure system to connect on first boot
-  shell: |
-    # Reload  wazuh-agent, which we just patched
-    systemctl daemon-reload
-
-    # Enable it so it runs on first boot
-    systemctl enable wazuh-agent

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -80,4 +80,4 @@
   lineinfile:
     path: /etc/systemd/system/wazuh-agent.service
     insertbefore: '^ExecStart'
-    line: ExecStartPre=/usr/local/bin/connect-to-wazuh-manager.sh
+    line: ExecStartPre=/usr/local/bin/authenticate-with-wazuh-manager.sh

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -48,7 +48,7 @@
     dest: /usr/local/bin/authenticate-with-wazuh-manager.sh
     mode: '0744'
     content: |
-      #!/bin/bash -x
+      #!/bin/bash -xe
       if [ -f "/var/ossec/etc/authd.pass" ]; then
         MANAGER_IP="{{ manager_ip }}"
         EC2_METADATA="169.254.169.254"
@@ -59,9 +59,9 @@
         FILTERS="Name=resource-id,Values=$INSTANCE_ID Name=resource-type,Values=instance"
         OPTIONS="--query Tags[].Value --output text --region $REGION"
 
-        APP=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=App $OPTIONS)
-        STACK=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stack $OPTIONS)
-        STAGE=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stage $OPTIONS)
+        APP=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=App $OPTIONS || true)
+        STACK=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stack $OPTIONS || true)
+        STAGE=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stage $OPTIONS || true)
 
         cp /var/ossec/etc/ossec.conf /var/ossec/etc/ossec.conf.bak
 

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -10,18 +10,22 @@
         'jq'
     ]
 
-- name: Run main script
+- name: Add the Wazuh Manager repository and GPG key
   shell: |
     curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
     echo "deb https://packages.wazuh.com/3.x/apt/ stable main" | tee /etc/apt/sources.list.d/wazuh.list
-    apt-get update
-    apt-get install wazuh-agent=3.13.1-1
 
-    sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/wazuh.list
-    apt-get update
-    
-    # ----------------- Store the password and register the agent
+- name: Install Wazuh Manager
+  apt:
+    name: wazuh-agent=3.13.1-1
+    update_cache: yes
 
+- name: Disable the Wazuh updates
+  shell: |
+    echo "wazuh-agent hold" | sudo dpkg --set-selections
+
+- name: Store the password
+  shell: |
     SECRET_ARN="arn:aws:secretsmanager:{{ secret_region }}:{{ account_id }}:secret:{{ secret_id }}"
     REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 
@@ -29,60 +33,65 @@
        --query SecretString --output text --version-stage AWSCURRENT --region $REGION \
        | jq -r .value > /var/ossec/etc/authd.pass
 
-    cat << 'PARENT_EOF' > /usr/local/bin/connect-to-wazuh-manager.sh
-    #!/bin/bash -x
-    MANAGER_IP="{{ manager_ip }}"
-    REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+- name: Inject boot script
+  copy:
+    dest: /usr/local/bin/connect-to-wazuh-manager.sh
+    mode: '0744'
+    content: |
+      #!/bin/bash -x
+      MANAGER_IP="{{ manager_ip }}"
+      REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 
-    INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
-    FILTERS="Name=resource-id,Values=$INSTANCE_ID Name=resource-type,Values=instance"
-    OPTIONS="--query Tags[].Value --output text --region $REGION"
+      INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
+      FILTERS="Name=resource-id,Values=$INSTANCE_ID Name=resource-type,Values=instance"
+      OPTIONS="--query Tags[].Value --output text --region $REGION"
 
-    APP=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=App $OPTIONS)
-    STACK=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stack $OPTIONS)
-    STAGE=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stage $OPTIONS)
+      APP=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=App $OPTIONS)
+      STACK=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stack $OPTIONS)
+      STAGE=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stage $OPTIONS)
 
-    cp /var/ossec/etc/ossec.conf /var/ossec/etc/ossec.conf.bak
+      cp /var/ossec/etc/ossec.conf /var/ossec/etc/ossec.conf.bak
 
-    sed -i "s/MANAGER_IP/$MANAGER_IP/" /var/ossec/etc/ossec.conf
-    sed -i "s/<protocol>udp<\/protocol>/<protocol>tcp<\/protocol>/" /var/ossec/etc/ossec.conf
-    cat >> /var/ossec/etc/ossec.conf << EOF
-    <ossec_config>
-      <labels>
-        <label key="aws.app">$APP</label>
-        <label key="aws.stack">$STACK</label>
-        <label key="aws.stage">$STAGE</label>
-      </labels>
-    </ossec_config>
-    EOF
+      sed -i "s/MANAGER_IP/$MANAGER_IP/" /var/ossec/etc/ossec.conf
+      sed -i "s/<protocol>udp<\/protocol>/<protocol>tcp<\/protocol>/" /var/ossec/etc/ossec.conf
+      cat >> /var/ossec/etc/ossec.conf << EOF
+      <ossec_config>
+        <labels>
+          <label key="aws.app">$APP</label>
+          <label key="aws.stack">$STACK</label>
+          <label key="aws.stage">$STAGE</label>
+        </labels>
+      </ossec_config>
+      EOF
 
-    # Enroll with manager
-    /var/ossec/bin/agent-auth -m $MANAGER_IP -A $INSTANCE_ID
+      # Enroll with manager
+      /var/ossec/bin/agent-auth -m $MANAGER_IP -A $INSTANCE_ID
 
-    # Boot agent
-    systemctl enable wazuh-agent
-    systemctl start wazuh-agent
-    PARENT_EOF
+      # Boot agent
+      systemctl enable wazuh-agent
+      systemctl start wazuh-agent
 
-    chmod +x /usr/local/bin/connect-to-wazuh-manager.sh
-    chmod 744 /usr/local/bin/connect-to-wazuh-manager.sh
+- name: Inject systemd service unit wazuh-manager-connection.service
+  copy:
+    dest: /etc/systemd/system/wazuh-manager-connection.service
+    mode: '0644'
+    content: |
+      [Unit]
+      After=network.service
 
-    ## Create Systemd service file
-    cat << EOF > /etc/systemd/system/wazuh-manager-connection.service
-    [Unit]
-    After=network.service
+      [Service]
+      ExecStart=/usr/local/bin/connect-to-wazuh-manager.sh
 
-    [Service]
-    ExecStart=/usr/local/bin/connect-to-wazuh-manager.sh
+      [Install]
+      WantedBy=default.target
 
-    [Install]
-    WantedBy=default.target
-    EOF
-    chmod 664 /etc/systemd/system/wazuh-manager-connection.service
-
-    ## Disable wazuh agent until registration happens
+- name: Configure system to connect on first boot
+  shell: |
+    # Disable wazuh agent until registration happens
     systemctl disable wazuh-agent
 
-    ## Enable the new service unit so we register on first boot
+    # Load wazuh-manager-connection.service, which we just created
     systemctl daemon-reload
+
+    # Enable it so it runs on first boot
     systemctl enable wazuh-manager-connection.service

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -37,14 +37,15 @@
   shell: |
     SECRET_ARN="arn:aws:secretsmanager:{{ secret_region }}:{{ account_id }}:secret:{{ secret_id }}"
     REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+    echo {{ secret_id }}
 
     aws secretsmanager get-secret-value --secret-id $SECRET_ARN \
        --query SecretString --output text --version-stage AWSCURRENT --region $REGION \
        | jq -r .value > /var/ossec/etc/authd.pass
 
-- name: Inject boot script
+- name: Inject authentication script
   copy:
-    dest: /usr/local/bin/connect-to-wazuh-manager.sh
+    dest: /usr/local/bin/authenticate-with-wazuh-manager.sh
     mode: '0744'
     content: |
       #!/bin/bash -x

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -47,34 +47,40 @@
     dest: /usr/local/bin/authenticate-with-wazuh-manager.sh
     mode: '0744'
     content: |
-      #!/bin/bash -x
-      MANAGER_IP="{{ manager_ip }}"
-      REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+      #!/bin/bash -xe
+      if [ -f "/var/ossec/etc/authd.pass" ]; then
+        MANAGER_IP="{{ manager_ip }}"
+        REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 
-      INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
-      FILTERS="Name=resource-id,Values=$INSTANCE_ID Name=resource-type,Values=instance"
-      OPTIONS="--query Tags[].Value --output text --region $REGION"
+        INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
+        FILTERS="Name=resource-id,Values=$INSTANCE_ID Name=resource-type,Values=instance"
+        OPTIONS="--query Tags[].Value --output text --region $REGION"
 
-      APP=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=App $OPTIONS)
-      STACK=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stack $OPTIONS)
-      STAGE=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stage $OPTIONS)
+        APP=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=App $OPTIONS)
+        STACK=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stack $OPTIONS)
+        STAGE=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stage $OPTIONS)
 
-      cp /var/ossec/etc/ossec.conf /var/ossec/etc/ossec.conf.bak
+        cp /var/ossec/etc/ossec.conf /var/ossec/etc/ossec.conf.bak
 
-      sed -i "s/MANAGER_IP/$MANAGER_IP/" /var/ossec/etc/ossec.conf
-      sed -i "s/<protocol>udp<\/protocol>/<protocol>tcp<\/protocol>/" /var/ossec/etc/ossec.conf
-      cat >> /var/ossec/etc/ossec.conf << EOF
-      <ossec_config>
-        <labels>
-          <label key="aws.app">$APP</label>
-          <label key="aws.stack">$STACK</label>
-          <label key="aws.stage">$STAGE</label>
-        </labels>
-      </ossec_config>
-      EOF
+        sed -i "s/MANAGER_IP/$MANAGER_IP/" /var/ossec/etc/ossec.conf
+        sed -i "s/<protocol>udp<\/protocol>/<protocol>tcp<\/protocol>/" /var/ossec/etc/ossec.conf
+        cat >> /var/ossec/etc/ossec.conf << EOF
+        <ossec_config>
+          <labels>
+            <label key="aws.app">$APP</label>
+            <label key="aws.stack">$STACK</label>
+            <label key="aws.stage">$STAGE</label>
+          </labels>
+        </ossec_config>
+        EOF
 
-      # Enroll with manager
-      /var/ossec/bin/agent-auth -m $MANAGER_IP -A $INSTANCE_ID
+        # Enroll with manager
+        /var/ossec/bin/agent-auth -m $MANAGER_IP -A $INSTANCE_ID
+
+        # Cleanup
+        rm /var/ossec/etc/authd.pass
+      fi
+
 
 - name: Patch wazuh-agent service to call boot script before starting agent
   lineinfile:

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -24,3 +24,43 @@
 
     SECRET_ARN="arn:aws:secretsmanager:{{ secret_region }}:{{ account_id }}:secret:{{ secret_id }}"
     echo $SECRET_ARN
+
+    REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+    aws secretsmanager get-secret-value --secret-id $SECRET_ARN \
+       --query SecretString --output text --version-stage AWSCURRENT --region $REGION \
+       | jq -r .value > /var/ossec/etc/authd.pass
+
+    cat << PARENT_EOF > /var/ossec/etc/connect-to-manager.sh
+    # ----------------- On boot
+    MANAGER_IP="{{ manager_ip }}"
+
+    INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
+    FILTERS="Name=resource-id,Values=$INSTANCE_ID Name=resource-type,Values=instance"
+    OPTIONS="--query Tags[].Value --output text --region $REGION"
+
+    APP=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=App $OPTIONS)
+    STACK=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stack $OPTIONS)
+    STAGE=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stage $OPTIONS)
+
+    cp /var/ossec/etc/ossec.conf /var/ossec/etc/ossec.conf.bak
+
+    sed -i "s/MANAGER_IP/$MANAGER_IP/" /var/ossec/etc/ossec.conf
+    sed -i "s/<protocol>udp<\/protocol>/<protocol>tcp<\/protocol>/" /var/ossec/etc/ossec.conf
+    cat >> /var/ossec/etc/ossec.conf << EOF
+    <ossec_config>
+      <labels>
+        <label key="aws.app">$APP</label>
+        <label key="aws.stack">$STACK</label>
+        <label key="aws.stage">$STAGE</label>
+      </labels>
+    </ossec_config>
+    EOF
+
+    systemctl restart wazuh-agent
+    /var/ossec/bin/agent-auth -m $MANAGER_IP -A $INSTANCE_ID
+
+    PARENT_EOF
+
+    chmod +x /var/ossec/etc/connect-to-manager.sh
+    cat /var/ossec/etc/connect-to-manager.sh

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -52,10 +52,10 @@
       if [ -f "/var/ossec/etc/authd.pass" ]; then
         MANAGER_IP="{{ manager_ip }}"
         EC2_METADATA="169.254.169.254"
-        
+
         REGION=`curl -s http://${EC2_METADATA}/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 
-        INSTANCE_ID=`curl -s http://${EC2_METADATA}.254/latest/meta-data/instance-id`
+        INSTANCE_ID=`curl -s http://${EC2_METADATA}/latest/meta-data/instance-id`
         FILTERS="Name=resource-id,Values=$INSTANCE_ID Name=resource-type,Values=instance"
         OPTIONS="--query Tags[].Value --output text --region $REGION"
 

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -35,7 +35,7 @@
 
 - name: Store the password
   shell: |
-    SECRET_ARN="{{ secret_id }}"
+    SECRET_ARN="{{ secret_arn }}"
     REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 
     aws secretsmanager get-secret-value --secret-id $SECRET_ARN \

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -72,7 +72,7 @@
             <label key="aws.stage">$STAGE</label>
           </labels>
         </ossec_config>
-        EOF
+      EOF
 
         # Enroll with manager
         /var/ossec/bin/agent-auth -m $MANAGER_IP -A $INSTANCE_ID

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -31,7 +31,7 @@
        --query SecretString --output text --version-stage AWSCURRENT --region $REGION \
        | jq -r .value > /var/ossec/etc/authd.pass
 
-    cat << PARENT_EOF > /var/ossec/etc/connect-to-manager.sh
+    cat << 'PARENT_EOF' > /var/ossec/etc/connect-to-manager.sh
     # ----------------- On boot
     MANAGER_IP="{{ manager_ip }}"
 

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -36,7 +36,8 @@
 - name: Store the password
   shell: |
     SECRET_ARN="{{ secret_arn }}"
-    REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+    EC2_METADATA="169.254.169.254"
+    REGION=`curl -s http://${EC2_METADATA}/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 
     aws secretsmanager get-secret-value --secret-id $SECRET_ARN \
        --query SecretString --output text --version-stage AWSCURRENT --region $REGION \
@@ -50,9 +51,11 @@
       #!/bin/bash -x
       if [ -f "/var/ossec/etc/authd.pass" ]; then
         MANAGER_IP="{{ manager_ip }}"
-        REGION=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+        EC2_METADATA="169.254.169.254"
+        
+        REGION=`curl -s http://${EC2_METADATA}/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 
-        INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
+        INSTANCE_ID=`curl -s http://${EC2_METADATA}.254/latest/meta-data/instance-id`
         FILTERS="Name=resource-id,Values=$INSTANCE_ID Name=resource-type,Values=instance"
         OPTIONS="--query Tags[].Value --output text --region $REGION"
 

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -76,26 +76,8 @@
       # Enroll with manager
       /var/ossec/bin/agent-auth -m $MANAGER_IP -A $INSTANCE_ID
 
-- name: Inject ExecStartPre
-  copy:
-    dest: /etc/systemd/system/wazuh-agent.service
-    mode: '0644'
-    content: |
-      [Unit]
-      Description=Wazuh agent
-      Wants=network-online.target
-      After=network.target network-online.target
-
-      [Service]
-      Type=forking
-      EnvironmentFile=/etc/ossec-init.conf
-
-      ExecStartPre=/usr/local/bin/connect-to-wazuh-manager.sh
-      ExecStart=/usr/bin/env ${DIRECTORY}/bin/ossec-control start
-      ExecStop=/usr/bin/env ${DIRECTORY}/bin/ossec-control stop
-      ExecReload=/usr/bin/env ${DIRECTORY}/bin/ossec-control reload
-      KillMode=none
-      RemainAfterExit=yes
-
-      [Install]
-      WantedBy=multi-user.target
+- name: Patch wazuh-agent service to call boot script before starting agent
+  lineinfile:
+    path: /etc/systemd/system/wazuh-agent.service
+    insertbefore: '^ExecStart'
+    line: ExecStartPre=/usr/local/bin/connect-to-wazuh-manager.sh

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -10,19 +10,28 @@
         'jq'
     ]
 
-- name: Add the Wazuh Manager repository and GPG key
-  shell: |
-    curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
-    echo "deb https://packages.wazuh.com/3.x/apt/ stable main" | tee /etc/apt/sources.list.d/wazuh.list
+- name: Add wazuh apt-key
+  apt_key: 
+    url: https://packages.wazuh.com/key/GPG-KEY-WAZUH
+    state: present 
 
-- name: Install Wazuh Manager
-  apt:
-    name: wazuh-agent=3.13.1-1
+- name: Add wazuh apt repository
+  apt_repository: 
+    repo: 'deb https://packages.wazuh.com/3.x/apt/ stable main' 
+    state: present 
+    filename: wazuh 
     update_cache: yes
 
-- name: Disable the Wazuh updates
-  shell: |
-    echo "wazuh-agent hold" | sudo dpkg --set-selections
+- name: Install Wazuh Agent
+  apt:
+    name: wazuh-agent={{ agent_version }}
+    state: present
+    update_cache: yes
+
+- name: Prevent wazuh-agent from being upgraded to a different version
+  dpkg_selections:
+    name: wazuh-agent
+    selection: hold
 
 - name: Store the password
   shell: |

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -91,11 +91,14 @@
     chmod 664 /etc/systemd/system/wazuh-manager-connection.service
     echo systemd_permissions
 
-    ## Enable the new service unit
-    systemctl daemon-reload
-    echo daemon_reload
+
+    ## Disable wazuh agent until registration happens
     systemctl disable wazuh-agent
     echo disable_agent
+
+    ## Enable the new service unit so we register on first boot
+    systemctl daemon-reload
+    echo daemon_reload
     systemctl enable wazuh-manager-connection.service
     echo enable_connection_manager_service
 

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -62,8 +62,11 @@
     </ossec_config>
     EOF
 
-    systemctl restart wazuh-agent
+    systemctl enable wazuh-agent
+    systemctl status wazuh-agent
     /var/ossec/bin/agent-auth -m $MANAGER_IP -A $INSTANCE_ID
+    systemctl status wazuh-agent
+    systemctl start wazuh-agent
     PARENT_EOF
 
     echo wrote_script
@@ -91,8 +94,10 @@
     ## Enable the new service unit
     systemctl daemon-reload
     echo daemon_reload
+    systemctl disable wazuh-agent
+    echo disable_agent
     systemctl enable wazuh-manager-connection.service
-    echo service_enable
+    echo enable_connection_manager_service
 
     ## Debug commands
     # status: sudo systemctl status wazuh-manager-connection

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -21,4 +21,6 @@
     apt-get update
 
     # ----------------- Store the password and register the agent
-    echo {{ secret_arn }}
+
+    SECRET_ARN="arn:aws:secretsmanager:{{ secret_region }}:{{ account_id }}:secret:{{ secret_id }}"
+    echo $SECRET_ARN


### PR DESCRIPTION
## What does this change?

This adds a new role called wazuh-agent. It installs the `wazuh-agent` package and patches its systemd unit so it calls `authenticate-with-wazuh-manager.sh` _before_ the actual agent runs.

`authenticate-with-wazuh-manager.sh` patches wazuh-agent's config file so it connects properly, and registers the box using `agent-auth`

The role is parameterised and requires a number of variables to run, namely

* manager_ip
* agent_version
* secret_arn


For reference: bash version https://github.com/guardian/amigo/blob/f8c1745bd4ee96172dd26a11a3665324e0a2cd69/roles/wazuh-agent/tasks/main.yml

### Notes on systemd

systemd is the way modern ubuntu manages services. Each service has an associated text file that describes its implementation according to systemd's interface. These include properties like what commands do you run to start and stop it, which other services it depends on etc. More importantly for our purposes, the systemd interface also includes a notion of a **prestart command**, which we can use as a hook to call the authentication script before the agent proper starts. Here's a minimal example

```
      [Unit]
      After=network.service

      [Service]
      ExecStartPre=authenticate.sh
      ExecStart=start-agent.sh

      [Install]
      WantedBy=default.target
```

systemd has a really neat interface based on `systemctl` for actions and `journalctl` for logs . These are useful for debugging

```
# Print current status
systemctl status wazuh-agent

# Print full log
journalctl -u wazuh-agent
```

## How to test
Deploy to CODE and launch an instance with the ami. That's enough to test that we can add it to the base ubuntu image though?

## Have we considered potential risks?
TBD

## Outstanding:
* Set -e on /usr/local/bin/authenticate-with-wazuh-manager.sh . Requires handling the aws failure on lack of permissions to describe tags
* Remove jq, it's already installed