### PR TITLE
Make wazuh agent bake fail on aws error

### DIFF
--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -42,6 +42,8 @@
     aws secretsmanager get-secret-value --secret-id $SECRET_ARN \
        --query SecretString --output text --version-stage AWSCURRENT --region $REGION \
        | jq -r .value > /var/ossec/etc/authd.pass
+  register: command_result
+  failed_when: "'error' in command_result.stderr"
 
 - name: Inject authentication script
   copy:


### PR DESCRIPTION
## What does this change?
This change makes the ansible step that fetches and stores wazuh's password fail if `aws secretsmanager get-secret-value` fails. Right now it doesn't fail because the aws command always has a return code of 0 - even when it fails!!

Luckily, ansible has a built in function to fail based on an error message, and in the examples I've seen there's always the word "error" in the error message.

```
* An error occurred (AccessDeniedException) when calling the GetSecretValue operation:
* aws: error: argument --region: expected one argument
```

## How to test
Trying to bake `wazuh-agent-test` in amigo code should fail, and it does! https://amigo.code.dev-gutools.co.uk/recipes/wazuh-agent-test/bakes/48