### PR TITLE
WIP: Add BakeInstance parameter to BaseImage to allow use of arm64 images.

### DIFF
--- a/app/data/BaseImages.scala
+++ b/app/data/BaseImages.scala
@@ -13,22 +13,24 @@ object BaseImages {
     amiId: AmiId,
     builtinRoles: List[CustomisedRole],
     createdBy: String,
-    linuxDist: LinuxDist)(implicit dynamo: Dynamo): BaseImage = {
+    linuxDist: LinuxDist,
+    bakeInstance: BakeInstance)(implicit dynamo: Dynamo): BaseImage = {
     val now = DateTime.now()
-    val baseImage = BaseImage(id, description, amiId, builtinRoles, createdBy, createdAt = now, modifiedBy = createdBy, modifiedAt = now, Some(linuxDist))
+    val baseImage = BaseImage(id, description, amiId, builtinRoles, createdBy, createdAt = now, modifiedBy = createdBy, modifiedAt = now, Some(linuxDist), Some(bakeInstance))
 
     table.put(baseImage).exec()
     baseImage
   }
 
-  def update(baseImage: BaseImage, description: String, amiId: AmiId, linuxDist: LinuxDist, builtinRoles: List[CustomisedRole], modifiedBy: String)(implicit dynamo: Dynamo): Unit = {
+  def update(baseImage: BaseImage, description: String, amiId: AmiId, linuxDist: LinuxDist, builtinRoles: List[CustomisedRole], modifiedBy: String, bakeInstance: BakeInstance)(implicit dynamo: Dynamo): Unit = {
     val updated = baseImage.copy(
       description = description,
       amiId = amiId,
       linuxDist = Some(linuxDist),
       builtinRoles = builtinRoles,
       modifiedBy = modifiedBy,
-      modifiedAt = DateTime.now()
+      modifiedAt = DateTime.now(),
+      bakeInstance = Some(bakeInstance)
     )
     table.put(updated).exec()
   }

--- a/app/data/Dynamo.scala
+++ b/app/data/Dynamo.scala
@@ -6,6 +6,7 @@ import com.gu.scanamo.{ DynamoFormat, Scanamo, Table => ScanamoTable }
 import com.gu.scanamo.ops.ScanamoOps
 import models.{ Bake, BakeLog, BaseImage, Recipe }
 import services.Loggable
+import models.BakeInstance.dynamoFormat
 
 import scala.annotation.tailrec
 import scala.util.Try

--- a/app/models/BakeLog.scala
+++ b/app/models/BakeLog.scala
@@ -16,7 +16,7 @@ object MessagePart {
   val defaultColour = "#DCDCDC" /* iTerm2's default theme */
 
   val HtmlColours = Map(
-    "yellow" -> "#ECE100"  /* iTerm2's default theme */
+    "yellow" -> "#ECE100" /* iTerm2's default theme */
   )
 
 }

--- a/app/packer/PackerBuildConfigGenerator.scala
+++ b/app/packer/PackerBuildConfigGenerator.scala
@@ -2,7 +2,7 @@ package packer
 
 import java.nio.file.{ Path, Paths }
 
-import models.{ Bake, Ubuntu }
+import models.{ Bake, BakeInstances, Ubuntu }
 import models.packer._
 
 object PackerBuildConfigGenerator {
@@ -31,7 +31,7 @@ object PackerBuildConfigGenerator {
       vpc_id = packerConfig.vpcId,
       subnet_id = packerConfig.subnetId,
       source_ami = "{{user `base_image_ami_id`}}",
-      instance_type = "t3.small",
+      instance_type = s"${bake.recipe.baseImage.bakeInstance.getOrElse(BakeInstances.x86).instanceType}",
 
       ssh_username = bake.recipe.baseImage.linuxDist.getOrElse(Ubuntu).loginName,
 

--- a/app/views/editBaseImage.scala.html
+++ b/app/views/editBaseImage.scala.html
@@ -8,6 +8,7 @@
     @b3.static("ID"){@image.id.value}
     @b3.text( form("amiId"), '_label -> "AMI ID", 'placeholder -> "ami-a1b2c3d4" )
     @b3.select( form("linuxDist"), models.LinuxDist.all.toList.map{ case (k,v) => k -> v.name }, '_label -> "Linux Distribution" )
+    @b3.select( form("bakeInstance"), models.BakeInstances.all.map{ case b: BakeInstance => b.architecture -> b.toString }, '_label -> "Bake Instance Type" )
     @b3.textarea( form("description"), '_label -> "Description" )
 
     <div class="form-group">

--- a/app/views/newBaseImage.scala.html
+++ b/app/views/newBaseImage.scala.html
@@ -8,6 +8,7 @@
     @b3.text(form("id"), '_label -> "ID", 'placeholder -> "my-lovely-image" )
     @b3.text( form("amiId"), '_label -> "AMI ID", 'placeholder -> "ami-a1b2c3d4" )
     @b3.select( form("linuxDist"), models.LinuxDist.all.toList.map{ case (k,v) => k -> v.name }, '_label -> "Linux Distribution" )
+    @b3.select( form("bakeInstance"), models.BakeInstances.all.map{ case b: BakeInstance => b.architecture -> b.toString }, '_label -> "Bake Instance Type" )
     @b3.textarea( form("description"), '_label -> "Description" )
 
     <div class="form-group">

--- a/test/ansible/PlaybookGeneratorSpec.scala
+++ b/test/ansible/PlaybookGeneratorSpec.scala
@@ -21,7 +21,8 @@ class PlaybookGeneratorSpec extends FlatSpec with Matchers {
         createdBy = "Testy McTest",
         createdAt = DateTime.now(),
         modifiedBy = "Testy McTest",
-        modifiedAt = DateTime.now()
+        modifiedAt = DateTime.now(),
+        bakeInstance = Some(BakeInstances.x86)
       ),
       diskSize = None,
       roles = List(

--- a/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
+++ b/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
@@ -14,7 +14,7 @@ class MarkOldUnusedBakesForDeletionSpec extends FlatSpec with Matchers {
   val newBake2: Bake = fixtureBake(fixtureRecipe("recipe-4", newDate), Some(AmiId("ami-4")), newDate)
 
   def fixtureBaseImage(baseImageId: String, createdDate: DateTime): BaseImage = {
-    BaseImage(BaseImageId(baseImageId), "MyDescription", AmiId("ami-1"), List(), "Test", createdDate, "Test", createdDate)
+    BaseImage(BaseImageId(baseImageId), "MyDescription", AmiId("ami-1"), List(), "Test", createdDate, "Test", createdDate, bakeInstance = Some(BakeInstances.x86))
   }
   def fixtureRecipe(id: String, createdDate: DateTime): Recipe = {
     Recipe(RecipeId(id), None, fixtureBaseImage(s"base-image-$id", createdDate), None, List(), "Test", createdDate, "Test", createdDate, None, Nil)

--- a/test/prism/RecipeUsageSpec.scala
+++ b/test/prism/RecipeUsageSpec.scala
@@ -11,7 +11,7 @@ import services.PrismAgents
 
 class RecipeUsageSpec extends FlatSpec with Matchers with MockitoSugar {
 
-  def fixtureBaseImage(baseImageId: String): BaseImage = BaseImage(BaseImageId(baseImageId), "MyDescription", AmiId("ami-1"), List(), "Test", DateTime.now, "Test", DateTime.now)
+  def fixtureBaseImage(baseImageId: String): BaseImage = BaseImage(BaseImageId(baseImageId), "MyDescription", AmiId("ami-1"), List(), "Test", DateTime.now, "Test", DateTime.now, bakeInstance = Some(BakeInstances.x86))
   def fixtureRecipe(id: String): Recipe = Recipe(RecipeId(id), None, fixtureBaseImage(s"base-image-$id"), None, List(), "Test", DateTime.now, "Test", DateTime.now, None, Nil)
   def fixtureRecipeWithSize(id: String, size: Int): Recipe = Recipe(RecipeId(id), None, fixtureBaseImage(s"base-image-$id"), Some(100), List(), "Test", DateTime.now, "Test", DateTime.now, None, Nil)
   def fixtureBake(recipe: Recipe, amiId: Option[AmiId]): Bake = Bake(recipe, 1, amiId.map(_ => BakeStatus.Complete).getOrElse(BakeStatus.Failed), amiId, "Test", DateTime.now, false)


### PR DESCRIPTION
## What does this change?
This introduces a new propety to the 'base image' type called BakeInstance. This will determine the AWS instance type that is used to bake AMIs for that base image. This is currently hard coded to `t3.small` but following the [release of t4g instances](https://aws.amazon.com/ec2/instance-types/t4/) we might want to be running the `arm64` architecture at the guardian. 

## How to test
Deploy to amigo CODE, create base image with arm64 and an arm64 base AMI, try to perform a bake. Currently on AMIgo you'll get an error: `Error launching source instance: InvalidParameterValue: The requested instance type's architecture (x86_64) does not match the architecture in the manifest for ami-0346ee471bb2c892a (arm64)` - this should resolve that

## How can we measure success?
being able to bake arm64 images at the Guardian

## Have we considered potential risks?
Introducing an entirely new archiecturecould have unexpected side effects so we should roll this out carefully if we decide to go down the arm64 route.

<img width="1188" alt="Screenshot 2020-12-08 at 19 27 25" src="https://user-images.githubusercontent.com/3606555/101531627-6e60b100-398b-11eb-9dea-f51cf5d640da.png">

