### PR TITLE
Detect architecture when baking

### DIFF
--- a/app/models/BakeLog.scala
+++ b/app/models/BakeLog.scala
@@ -16,7 +16,7 @@ object MessagePart {
   val defaultColour = "#DCDCDC" /* iTerm2's default theme */
 
   val HtmlColours = Map(
-    "yellow" -> "#ECE100"  /* iTerm2's default theme */
+    "yellow" -> "#ECE100" /* iTerm2's default theme */
   )
 
 }

--- a/app/schedule/ScheduledBakeRunner.scala
+++ b/app/schedule/ScheduledBakeRunner.scala
@@ -4,9 +4,9 @@ import data.{ Bakes, Dynamo, Recipes }
 import event.EventBus
 import models.RecipeId
 import packer.{ PackerConfig, PackerRunner }
-import services.{ Loggable, PrismAgents }
+import services.{ AmiMetadataLookup, Loggable, PrismAgents }
 
-class ScheduledBakeRunner(stage: String, enabled: Boolean, prism: PrismAgents, eventBus: EventBus, ansibleVars: Map[String, String])(implicit dynamo: Dynamo, packerConfig: PackerConfig) extends Loggable {
+class ScheduledBakeRunner(stage: String, enabled: Boolean, prism: PrismAgents, eventBus: EventBus, ansibleVars: Map[String, String], amiMetadataLookup: AmiMetadataLookup)(implicit dynamo: Dynamo, packerConfig: PackerConfig) extends Loggable {
 
   def bake(recipeId: RecipeId): Unit = {
     if (!enabled) {
@@ -23,7 +23,7 @@ class ScheduledBakeRunner(stage: String, enabled: Boolean, prism: PrismAgents, e
                 val theBake = Bakes.create(recipe, buildNumber, startedBy = "scheduler")
 
                 log.info(s"Starting scheduled bake: ${theBake.bakeId}")
-                PackerRunner.createImage(stage, theBake, prism, eventBus, ansibleVars, false)
+                PackerRunner.createImage(stage, theBake, prism, eventBus, ansibleVars, false, amiMetadataLookup)
               case None =>
                 log.warn(s"Failed to get the next build number for recipe $recipeId")
             }

--- a/app/services/AmiMetadataLookup.scala
+++ b/app/services/AmiMetadataLookup.scala
@@ -1,0 +1,24 @@
+package services;
+
+import cats.syntax.either._
+import com.amazonaws.services.ec2.AmazonEC2
+import com.amazonaws.services.ec2.model.{ DescribeImagesRequest, Image }
+
+import scala.collection.JavaConverters._;
+
+case class AmiMetadata(architecture: String)
+
+class AmiMetadataLookup(ec2Client: AmazonEC2) {
+  def lookupMetadataFor(ami: String): Either[String, AmiMetadata] = {
+    for {
+      result <- Either.catchNonFatal {
+        ec2Client.describeImages(new DescribeImagesRequest().withImageIds(ami))
+      }.leftMap[String](_ => "Call to describe images failed")
+      imageDescription <- result.getImages.asScala.headOption.fold[Either[String, Image]](Left(s"No ami with ID $ami found"))(i => Right(i))
+      architecture = imageDescription.getArchitecture
+    } yield {
+      AmiMetadata(architecture)
+    }
+
+  }
+}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Wth the advent of [Graviton](https://aws.amazon.com/ec2/graviton/) AWS instances we need to update our tooling to build AMIs that can be run on the ARM architecture. This PR detects the architecture of the base AMI and uses an appropriate instance to bake the AMI.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
You can now create a recipe that uses an ARM base AMI. When you do so you will notice that packer will create an instance using a `t4g.small` type rather than a `t3.small` type.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Developers can experiment with using Graviton instance types.