### PR TITLE
Migrate deprecated uses of ansible's apt task

### DIFF
--- a/roles/aws-tools/tasks/install-cfn-tools-Ubuntu-post-focal.yml
+++ b/roles/aws-tools/tasks/install-cfn-tools-Ubuntu-post-focal.yml
@@ -1,7 +1,7 @@
 --- 
   - name: Install an old version of Python
-    apt: name={{item}}
-    with_items:
+    apt:
+      name:
       - python2
       - python-setuptools
 

--- a/roles/cloud-watch-monitoring/tasks/main.yml
+++ b/roles/cloud-watch-monitoring/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
 - name: Install packages
-  apt: name={{ item }} state=present
-  with_items:
-    - unzip
+  apt: name=unzip state=present
 
 - name: Download scripts
   unarchive: src="http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip" dest=/usr/local/ copy=no

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -17,14 +17,13 @@
 
 - name: Install required packages
   apt: 
-    name: "{{ item }}"
-    update_cache: yes
-    state: present
-    force: yes
-  with_items:
+    name:
     - apt-transport-https
     - ca-certificates
     - openssl
+    update_cache: yes
+    state: present
+    force: yes
 
 - name: Add repo key
   apt_key:

--- a/roles/exiftool/tasks/main.yml
+++ b/roles/exiftool/tasks/main.yml
@@ -1,5 +1,3 @@
 ---
 - name: Install exiftool 
-  apt: name={{ item }} state=present
-  with_items:
-    - libimage-exiftool-perl 
+  apt: name=libimage-exiftool-perl state=present

--- a/roles/golang/tasks/main.yml
+++ b/roles/golang/tasks/main.yml
@@ -1,5 +1,3 @@
 ---
 - name: install golang
-  apt: name={{item}} update_cache=yes
-  with_items:
-    - golang
+  apt: name=golang update_cache=yes

--- a/roles/graphicsmagick/tasks/main.yml
+++ b/roles/graphicsmagick/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Install graphicsmagick
-  apt: name={{ item }} state=present
-  with_items:
+  apt:
+    name:
     - graphicsmagick
     - graphicsmagick-imagemagick-compat
+    state: present

--- a/roles/install-ruby/tasks/main.yml
+++ b/roles/install-ruby/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: install ruby and ruby dev
-  apt: name={{item}} update_cache=yes
-  with_items:
+  apt:
+    name:
     - ruby
     - ruby-dev
-
+    update_cache: yes

--- a/roles/java8/tasks/main.yml
+++ b/roles/java8/tasks/main.yml
@@ -4,10 +4,11 @@
   when: ansible_os_family == "Debian" and ansible_distribution_version == "14.04"
 
 - name: Install Java 8 JRE and JDK
-  apt: name={{item}} state=latest
-  with_items:
+  apt:
+    name:
     - openjdk-8-jre-headless
     - openjdk-8-jdk
+    state: latest
   when: ansible_os_family == "Debian"
 
 - name: Install Java 8

--- a/roles/kong/tasks/main.yml
+++ b/roles/kong/tasks/main.yml
@@ -1,13 +1,14 @@
 ---
 - name: Install Kong's dependencies
-  apt: name={{item}} state=latest
-  with_items:
+  apt:
+    name:
     - netcat
     - openssl
     - libpcre3
     - dnsmasq
     - procps
     - postgresql-client-{{postgres_version}}
+    state: latest
 
 - name: Create user for Kong
   user: name={{kong_user}} system=yes

--- a/roles/nginx+pagespeed/tasks/main.yml
+++ b/roles/nginx+pagespeed/tasks/main.yml
@@ -1,12 +1,13 @@
 ---
 - name: Compile and install Nginx with the pagespeed module
-  apt: name={{ item }} state=present
-  with_items:
+  apt:
+    name:
     - build-essential
     - zlib1g-dev
     - libpcre3
     - libpcre3-dev
     - unzip
+    state: present
 
 - name: Create group nginx
   group: name=nginx

--- a/roles/nginx-extras/tasks/main.yml
+++ b/roles/nginx-extras/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
 - name: Install nginx and nginx-extras
-  apt: name={{ item }} state=present
-  with_items:
+  apt:
+    name:
     - nginx
     - nginx-extras
+    state: present
 
 - name: remove default site from sites-enabled
   file: path=/etc/nginx/sites-enabled/default state=absent

--- a/roles/perl-useful-packages/tasks/main.yml
+++ b/roles/perl-useful-packages/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: install libwww-perl and libdatetime-perl
-  apt: name={{item}} update_cache=yes
-  with_items:
+  apt:
+    name:
     - libwww-perl
     - libdatetime-perl
+    update_cache: yes

--- a/roles/pngquant/tasks/main.yml
+++ b/roles/pngquant/tasks/main.yml
@@ -1,5 +1,3 @@
 ---
 - name: Install pngquant
-  apt: name={{ item }} state=present
-  with_items:
-    - pngquant
+  apt: name=pngquant state=present

--- a/roles/useful-packages/tasks/main.yml
+++ b/roles/useful-packages/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
 - name: Install wget, unzip, jq and other useful stuff
-  apt: name={{ item }} state=present
-  with_items:
+  apt:
+    name:
     - language-pack-en
     - cloud-guest-utils
     - jq
     - unzip
+    state: present


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
I noticed some deprecation warnings and decided to fix them as that's better than it breaking when ansible 2.11 appears on our instances.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This should have no impact - all bakes should continue to work as expected.
