### PR TITLE
Add pip3 role to support Ubuntu 20.04

### DIFF
--- a/roles/pip-packages/README.md
+++ b/roles/pip-packages/README.md
@@ -1,7 +1,13 @@
-# packages
+# pip-packages
 
-Install package(s) with `pip`. The `packages` parameter specifies which package(s) are installed, e.g.
+Install Python 2 package(s) with `pip`. The `packages` parameter specifies which
+package(s) are installed, e.g.
 
 ```
-packages: [package-1, package-2]
+packages: [flask, ocrmypdf]
 ```
+
+**NB**: this role depends on the `pip` role, which in turn depends on the `python-pip`
+package. This is no longer available after Ubuntu 20.04 (Focal), where Python 3 becomes
+the only version available. Python 2 is EOL so please use `pip3-packages` where
+possible.

--- a/roles/pip/README.md
+++ b/roles/pip/README.md
@@ -1,0 +1,7 @@
+# pip
+
+Installs pip, using the `python-pip` package.
+
+**NB**: For Python 3 (the only version packaged on Ubuntu 20.04 Focal and above), use the `pip3`
+role. Python 2 is EOL so please use `pip3-packages` where
+possible.

--- a/roles/pip/tasks/main.yml
+++ b/roles/pip/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: install pip
   apt:
-    name: ['python-pip']
+    name: ["{{ 'python3-pip' if (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int >= 20) else 'python-pip' }}"]
     update_cache: yes
     state: latest

--- a/roles/pip/tasks/main.yml
+++ b/roles/pip/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Check Ubuntu version
-    fail:
-      msg: Ubuntu 20.04 (Focal) and above no longer package Python 2. Use the `pip3` role instead.
-    when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int >= 20
+  fail:
+    msg: Ubuntu 20.04 (Focal) and above no longer package Python 2. Use the `pip3` role instead.
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int >= 20
 
 - name: install pip
   apt:

--- a/roles/pip/tasks/main.yml
+++ b/roles/pip/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Check Ubuntu version
+    fail:
+      msg: Ubuntu 20.04 (Focal) and above no longer package Python 2. Use the `pip3` role instead.
+    when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int >= 20
+
 - name: install pip
   apt:
     name: ['python-pip']

--- a/roles/pip3-packages/README.md
+++ b/roles/pip3-packages/README.md
@@ -1,0 +1,8 @@
+# pip3-packages
+
+Install Python 3 package(s) with `pip`. The `packages` parameter specifies which
+package(s) are installed, e.g.
+
+```
+packages: [flask, ocrmypdf]
+```

--- a/roles/pip3-packages/defaults/main.yml
+++ b/roles/pip3-packages/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+package_state: present

--- a/roles/pip3-packages/meta/main.yml
+++ b/roles/pip3-packages/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - pip3

--- a/roles/pip3-packages/tasks/main.yml
+++ b/roles/pip3-packages/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Install a package with pip
+  pip:
+    name: "{{ packages }}"
+    state: "{{ package_state }}"

--- a/roles/pip3-packages/tasks/main.yml
+++ b/roles/pip3-packages/tasks/main.yml
@@ -3,3 +3,4 @@
   pip:
     name: "{{ packages }}"
     state: "{{ package_state }}"
+    executable: pip3

--- a/roles/pip3/README.md
+++ b/roles/pip3/README.md
@@ -1,0 +1,5 @@
+# pip3
+
+Installs pip for Python 3, using the `python3-pip` package.
+
+This is the only version packaged on Ubuntu 20.04 Focal and above.

--- a/roles/pip3/meta/main.yml
+++ b/roles/pip3/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - apt

--- a/roles/pip3/tasks/main.yml
+++ b/roles/pip3/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: install pip
   apt:
-    name: ['python-pip']
+    name: ['python3-pip']
     update_cache: yes
     state: latest


### PR DESCRIPTION
The package in Focal is `python3-pip` even though there's no Python 2 in that release. Before this PR, the `pip-packages` role didn't work on that release as it hard-codes a dependency on `python-pip`.

This PR adds two new roles, `pip3` and `pip3-packages` that can be used on both Focal and Bionic to install Python 3 packages. As Python 2.7 is EOL we would expect users to migrate to using these roles and we can eventually remove the old ones. The naming however makes it clear which version of Python you are expecting to use, regardless of if the distribution packages 2.7 or not (thanks @AWare for the suggestion).

In fact, most of our AMIs already have Python 3 pip. We install it as as a dependency of [aws-tools](https://github.com/guardian/amigo/blob/a6323b56801b5880d683ff293bb74fb600595a6b/roles/aws-tools/tasks/install-pip-aws-cli-Debian.yml#L3). So in the actual bake the `pip3` role install is a no-op but we have kept the package around for consistency. It feels sensible for `pip-packages` to depend on `pip`, even if in reality our all images also include the `aws-tools` role already.