### PR TITLE
Use correct amigo-data bucket in roles. Delete mongo role

### DIFF
--- a/roles/language-tool-ngrams/defaults/main.yml
+++ b/roles/language-tool-ngrams/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-source_tarball: s3://amigo-data/data/language-tool/ngrams.tar.gz
+source_tarball: s3://amigo-data-prod/data/language-tool/ngrams.tar.gz
 target_dir: /opt/ngram-data


### PR DESCRIPTION
amigo-data is now amigo-data-prod - see https://github.com/guardian/amigo/pull/395 for details. There's also an amigo-data-code bucket. This creates some confusion as if the language-tool-ngrams role (the only one which accesses amigo-data) runs on Amigo CODE it will still query the amigo-data-prod bucket, which doesn't make much sense, but since this bucket contains other data that is useful to split between CODE/PROD, this awkward situation seems reasonable. A cleaner solution would be for thte langauge-tool-ngrams role to detect which stage it's running on, but that would add unnecessary complexity to the role.

We no longer use Mongo DB at the guardian, so I've deleted those roles.