### PR TITLE
Add endpoint to list bake usages

### DIFF
--- a/app/controllers/BakeController.scala
+++ b/app/controllers/BakeController.scala
@@ -73,7 +73,7 @@ class BakeController(
   def allBakeUsages: Action[AnyContent] = AuthAction {
     val usages: Map[Recipe, RecipeUsage] = RecipeUsage.forAll(Recipes.list(), findBakes = recipeId => Bakes.list(recipeId))(prism)
 
-    val bakeUsages = usages.toList.map { usage =>
+    val bakeUsages = usages.toList.flatMap { usage =>
       usage._2.bakeUsage.map(bu => SimpleBakeUsage.fromBakeUsage(bu, amigoDataBucket))
     }
     Ok(Json.toJson(bakeUsages))

--- a/app/controllers/BakeController.scala
+++ b/app/controllers/BakeController.scala
@@ -71,11 +71,10 @@ class BakeController(
   }
 
   def allBakeUsages: Action[AnyContent] = AuthAction {
-    val usages: Map[Recipe, RecipeUsage] = RecipeUsage.forAll(Recipes.list(), findBakes = recipeId => Bakes.list(recipeId))(prism)
 
-    val bakeUsages = usages.toList.flatMap { usage =>
-      usage._2.bakeUsage.map(bu => SimpleBakeUsage.fromBakeUsage(bu, amigoDataBucket))
-    }
+    val allUsages = RecipeUsage.getUsages(Recipes.list())(prism, dynamo)
+
+    val bakeUsages = SimpleBakeUsage.fromRecipeUsages(allUsages)
     Ok(Json.toJson(bakeUsages))
   }
 

--- a/app/controllers/BakeController.scala
+++ b/app/controllers/BakeController.scala
@@ -74,7 +74,7 @@ class BakeController(
 
     val allUsages = RecipeUsage.getUsages(Recipes.list())(prism, dynamo)
 
-    val bakeUsages = SimpleBakeUsage.fromRecipeUsages(allUsages)
+    val bakeUsages = SimpleBakeUsage.fromRecipeUsages(allUsages, amigoDataBucket)
     Ok(Json.toJson(bakeUsages))
   }
 

--- a/app/controllers/RecipeController.scala
+++ b/app/controllers/RecipeController.scala
@@ -7,8 +7,9 @@ import org.quartz.CronExpression
 import play.api.data.{ Form, Mapping }
 import play.api.data.Forms._
 import play.api.i18n.{ I18nSupport, MessagesApi }
+import play.api.libs.json.Json
 import play.api.mvc._
-import prism.RecipeUsage
+import prism.{ BakeUsage, RecipeUsage, SimpleBakeUsage }
 import schedule.BakeScheduler
 import services.PrismAgents
 

--- a/app/data/PackageList.scala
+++ b/app/data/PackageList.scala
@@ -2,13 +2,16 @@ package data
 
 import com.amazonaws.services.s3.AmazonS3
 import models.BakeId
+import models.BakeId.toFilename
 import services.Loggable
 
 import scala.util.control.NonFatal
 
 object PackageList extends Loggable {
 
-  val packageListsPath = "packagelists"
+  val s3PathSlug = "packagelists"
+  def s3Path(bakeId: BakeId) = s"$s3PathSlug/${toFilename(bakeId)}"
+  def s3Url(bakeId: BakeId, bucket: String) = s"s3://$bucket/${s3Path(bakeId)}"
 
   def removeNonPackageLines(packages: List[String]): List[String] = {
     packages.filter { p =>
@@ -17,17 +20,16 @@ object PackageList extends Loggable {
   }
 
   def getPackageList(s3Client: AmazonS3, bakeId: BakeId, bucket: String): List[String] = {
-    val packageListKey = s"$packageListsPath/${BakeId.toFilename(bakeId)}"
+    val packageListKey = s3Path(bakeId)
     try {
-        val list = s3Client.getObjectAsString(bucket, packageListKey)
-        removeNonPackageLines(list.split("\n").toList)
+      val list = s3Client.getObjectAsString(bucket, packageListKey)
+      removeNonPackageLines(list.split("\n").toList)
     } catch {
       case NonFatal(e) =>
         val message = s"Failed to fetch package list from S3 bucket $bucket, key $packageListKey. Has the bake finished?"
         log.warn(message, e)
         List(message)
     }
-
 
   }
 }

--- a/app/models/BakeId.scala
+++ b/app/models/BakeId.scala
@@ -1,9 +1,9 @@
 package models
 
 import com.gu.scanamo.DynamoFormat
-import com.gu.scanamo.error.{ DynamoReadError, TypeCoercionError }
+import com.gu.scanamo.error.{DynamoReadError, TypeCoercionError}
 import data.PackageList
-import play.api.libs.json.{ Json, OWrites }
+import play.api.libs.json.{JsObject, Json, OWrites, Writes}
 
 case class BakeId(recipeId: RecipeId, buildNumber: Int) {
   override def toString: String = s"${recipeId.value} #$buildNumber"
@@ -11,7 +11,12 @@ case class BakeId(recipeId: RecipeId, buildNumber: Int) {
 
 object BakeId {
 
-  implicit val writes: OWrites[BakeId] = Json.writes[BakeId]
+  implicit val writes: Writes[BakeId] = new Writes[BakeId] {
+    def writes(bakeId: BakeId): JsObject = Json.obj(
+      "recipeId"-> bakeId.recipeId.value,
+      "buildNumber" -> bakeId.buildNumber
+    )
+  }
 
   def toFilename(bakeId: BakeId) = s"${bakeId.recipeId.value}--${bakeId.buildNumber}.txt"
 

--- a/app/models/BakeId.scala
+++ b/app/models/BakeId.scala
@@ -1,13 +1,17 @@
 package models
 
 import com.gu.scanamo.DynamoFormat
-import com.gu.scanamo.error.{ TypeCoercionError, DynamoReadError }
+import com.gu.scanamo.error.{ DynamoReadError, TypeCoercionError }
+import data.PackageList
+import play.api.libs.json.{ Json, OWrites }
 
 case class BakeId(recipeId: RecipeId, buildNumber: Int) {
   override def toString: String = s"${recipeId.value} #$buildNumber"
 }
 
 object BakeId {
+
+  implicit val writes: OWrites[BakeId] = Json.writes[BakeId]
 
   def toFilename(bakeId: BakeId) = s"${bakeId.recipeId.value}--${bakeId.buildNumber}.txt"
 

--- a/app/models/BakeId.scala
+++ b/app/models/BakeId.scala
@@ -1,9 +1,9 @@
 package models
 
 import com.gu.scanamo.DynamoFormat
-import com.gu.scanamo.error.{DynamoReadError, TypeCoercionError}
+import com.gu.scanamo.error.{ DynamoReadError, TypeCoercionError }
 import data.PackageList
-import play.api.libs.json.{JsObject, Json, OWrites, Writes}
+import play.api.libs.json.{ JsObject, Json, OWrites, Writes }
 
 case class BakeId(recipeId: RecipeId, buildNumber: Int) {
   override def toString: String = s"${recipeId.value} #$buildNumber"
@@ -13,7 +13,7 @@ object BakeId {
 
   implicit val writes: Writes[BakeId] = new Writes[BakeId] {
     def writes(bakeId: BakeId): JsObject = Json.obj(
-      "recipeId"-> bakeId.recipeId.value,
+      "recipeId" -> bakeId.recipeId.value,
       "buildNumber" -> bakeId.buildNumber
     )
   }

--- a/app/models/BaseImage.scala
+++ b/app/models/BaseImage.scala
@@ -26,7 +26,7 @@ object LinuxDist {
   def packageListTempPath(bakeId: BakeId) = s"/tmp/${toFilename(bakeId)}"
 
   def uploadPackageListCommand(bakeId: BakeId, region: String, bucket: String) =
-    s"aws s3 cp ${packageListTempPath(bakeId)} s3://${bucket}/${PackageList.packageListsPath}/${toFilename(bakeId)} --region ${region} --metadata ${toMetadata(bakeId)}"
+    s"aws s3 cp ${packageListTempPath(bakeId)} ${PackageList.s3Url(bakeId, bucket)} --region ${region} --metadata ${toMetadata(bakeId)}"
 
   val all = Map("ubuntu" -> Ubuntu, "redhat" -> RedHat, "amazon linux 2" -> AmazonLinux2)
 }

--- a/app/models/RecipeId.scala
+++ b/app/models/RecipeId.scala
@@ -1,7 +1,7 @@
 package models
 
 import com.gu.scanamo.DynamoFormat
-import play.api.libs.json.{JsString, Json, OWrites, Writes}
+import play.api.libs.json.{ JsString, Json, OWrites, Writes }
 import play.api.mvc.PathBindable
 
 case class RecipeId(value: String) extends AnyVal with StringId

--- a/app/models/RecipeId.scala
+++ b/app/models/RecipeId.scala
@@ -1,7 +1,7 @@
 package models
 
 import com.gu.scanamo.DynamoFormat
-import play.api.libs.json.{Json, OWrites}
+import play.api.libs.json.{ Json, OWrites }
 import play.api.mvc.PathBindable
 
 case class RecipeId(value: String) extends AnyVal with StringId

--- a/app/models/RecipeId.scala
+++ b/app/models/RecipeId.scala
@@ -1,14 +1,12 @@
 package models
 
 import com.gu.scanamo.DynamoFormat
-import play.api.libs.json.{ Json, OWrites }
+import play.api.libs.json.{JsString, Json, OWrites, Writes}
 import play.api.mvc.PathBindable
 
 case class RecipeId(value: String) extends AnyVal with StringId
 
 object RecipeId {
-  implicit val writes: OWrites[RecipeId] = Json.writes[RecipeId]
-
   implicit val pathBindable: PathBindable[RecipeId] = implicitly[PathBindable[String]].transform(RecipeId(_), _.value)
 
   implicit val dynamoFormat: DynamoFormat[RecipeId] =

--- a/app/models/RecipeId.scala
+++ b/app/models/RecipeId.scala
@@ -1,11 +1,13 @@
 package models
 
 import com.gu.scanamo.DynamoFormat
+import play.api.libs.json.{Json, OWrites}
 import play.api.mvc.PathBindable
 
 case class RecipeId(value: String) extends AnyVal with StringId
 
 object RecipeId {
+  implicit val writes: OWrites[RecipeId] = Json.writes[RecipeId]
 
   implicit val pathBindable: PathBindable[RecipeId] = implicitly[PathBindable[String]].transform(RecipeId(_), _.value)
 

--- a/app/packer/PackerBuildConfigGenerator.scala
+++ b/app/packer/PackerBuildConfigGenerator.scala
@@ -1,9 +1,9 @@
 package packer
 
 import models.packer._
-import models.{Bake, LinuxDist, Ubuntu}
+import models.{ Bake, LinuxDist, Ubuntu }
 import services.AmiMetadata
-import java.nio.file.{Path, Paths}
+import java.nio.file.{ Path, Paths }
 
 object PackerBuildConfigGenerator {
 

--- a/app/prism/RecipeUsage.scala
+++ b/app/prism/RecipeUsage.scala
@@ -1,12 +1,26 @@
 package prism
 
-import models.{ AmiId, Bake, Recipe, RecipeId }
+import data.PackageList
+import models.{ AmiId, Bake, BakeId, Recipe, RecipeId }
+import play.api.libs.json.Json
 import prism.Prism.{ Image, Instance, LaunchConfiguration }
 import services.PrismAgents
 
 case class Ami(account: String, id: AmiId)
 
 case class BakeUsage(amiId: AmiId, bake: Bake, viaCopy: Option[Image], instances: Seq[Instance], launchConfigurations: Seq[LaunchConfiguration])
+
+case class SimpleBakeUsage(bakeId: BakeId, packageListS3Location: String)
+
+object SimpleBakeUsage {
+  implicit val writes = Json.writes[SimpleBakeUsage]
+
+  def fromBakeUsage(bakeUsage: BakeUsage, amigoDataBucket: Option[String]): SimpleBakeUsage =
+    SimpleBakeUsage(
+      bakeUsage.bake.bakeId,
+      PackageList.s3Url(bakeUsage.bake.bakeId, amigoDataBucket.getOrElse("unknown-bucket"))
+    )
+}
 
 case class RecipeUsage(instances: Seq[Instance], launchConfigurations: Seq[LaunchConfiguration], bakeUsage: Seq[BakeUsage])
 

--- a/conf/routes
+++ b/conf/routes
@@ -39,7 +39,7 @@ GET     /recipes/:recipeId/bakes/:buildNumber           controllers.BakeControll
 GET     /recipes/:recipeId/bakes/:buildNumber/packages  controllers.BakeController.bakePackages(recipeId: RecipeId, buildNumber: Int)
 GET     /recipes/:recipeId/bakes/:buildNumber/events    controllers.BakeController.bakeEvents(recipeId: models.RecipeId, buildNumber: Int)
 
-GET     /bakeUsages                 controllers.BakeController.allBakeUsages
+GET     /bake-usages                 controllers.BakeController.allBakeUsages
 
 # Healthcheck
 GET     /healthcheck                controllers.RootController.healthcheck

--- a/conf/routes
+++ b/conf/routes
@@ -39,6 +39,8 @@ GET     /recipes/:recipeId/bakes/:buildNumber           controllers.BakeControll
 GET     /recipes/:recipeId/bakes/:buildNumber/packages  controllers.BakeController.bakePackages(recipeId: RecipeId, buildNumber: Int)
 GET     /recipes/:recipeId/bakes/:buildNumber/events    controllers.BakeController.bakeEvents(recipeId: models.RecipeId, buildNumber: Int)
 
+GET     /bakeUsages                 controllers.BakeController.allBakeUsages
+
 # Healthcheck
 GET     /healthcheck                controllers.RootController.healthcheck
 

--- a/test/data/PackageListTest.scala
+++ b/test/data/PackageListTest.scala
@@ -1,0 +1,23 @@
+package data
+
+import models.{BakeId, RecipeId}
+import org.scalatest.{FlatSpec, Matchers}
+
+class PackageListTest extends FlatSpec with Matchers {
+
+  "s3Url" should "return valid S3 url of expected pattern" in {
+    val url = PackageList.s3Url(BakeId(RecipeId("cauldron-cake"), 1), "mr-hole")
+    url should be ("s3://mr-hole/packagelists/cauldron-cake--1.txt")
+  }
+
+  "removeNonPackageLines" should "remove redundant output" in {
+    val packageList = List(
+      "Installed Packages",
+      "p1",
+      "p2,"
+    )
+    val removed = PackageList.removeNonPackageLines(packageList)
+    removed.head should be("p1")
+    removed.length should be (2)
+  }
+}

--- a/test/models/BakeIdTest.scala
+++ b/test/models/BakeIdTest.scala
@@ -1,0 +1,16 @@
+package models
+import org.scalatest.{FlatSpec, Matchers}
+
+class BakeIdTest extends FlatSpec with Matchers {
+
+  "toFilename" should "produce expected filename" in {
+    val bakeId = BakeId(RecipeId("puking-pastilles"), 1)
+    BakeId.toFilename(bakeId) should be ("puking-pastilles--1.txt")
+  }
+
+  "toMetadata" should "produce valid metadata" in {
+    val bakeId = BakeId(RecipeId("nosebleed-nougat"), 1)
+    BakeId.toMetadata(bakeId) should be ("Recipe=nosebleed-nougat,BuildNumber=1")
+  }
+
+}


### PR DESCRIPTION
## What does this change?
This adds a /bakeUsages endpoint to list all the bakes in AMIgo that are currently in use. One use for this would be to fetch package lists for all bakes currently in use.

As part of this changed I've added some tests for the messty string manipulation bits of the package list work
## How to test
I've tested this on CODE but it's not easy to test locally or on CODE as no locally or CODE baked images are 'in use' so you might have  to take my word for it

## How can we measure success?
The endpoint works, and gets used at some point. 

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<img width="838" alt="Screenshot 2021-01-12 at 12 09 25" src="https://user-images.githubusercontent.com/3606555/104312807-08f26980-54cf-11eb-936d-426d0e638582.png">

