### PR TITLE
Add some min lengths for IDs

### DIFF
--- a/app/controllers/BaseImageController.scala
+++ b/app/controllers/BaseImageController.scala
@@ -144,14 +144,14 @@ object BaseImageController {
     ))
 
     val createBaseImage = Form(tuple(
-      "id" -> text(maxLength = 50).transform[BaseImageId](BaseImageId.apply, _.value),
+      "id" -> text(minLength = 3, maxLength = 50).transform[BaseImageId](BaseImageId.apply, _.value),
       "description" -> text(maxLength = 10000),
       "amiId" -> amiId,
       "linuxDist" -> linuxDist
     ))
 
     val cloneBaseImage = Form(
-      "newId" -> text(maxLength = 50).transform[BaseImageId](BaseImageId.apply, _.value)
+      "newId" -> text(minLength = 3, maxLength = 50).transform[BaseImageId](BaseImageId.apply, _.value)
     )
   }
 }

--- a/app/controllers/RecipeController.scala
+++ b/app/controllers/RecipeController.scala
@@ -213,7 +213,7 @@ object RecipeController {
     ))
 
     val createRecipe = Form(tuple(
-      "id" -> text(maxLength = 50).transform[RecipeId](RecipeId.apply, _.value),
+      "id" -> text(minLength = 3, maxLength = 50).transform[RecipeId](RecipeId.apply, _.value),
       "description" -> optional(text(maxLength = 10000)),
       "baseImageId" -> baseImageIdMapping,
       "diskSize" -> optional(number),
@@ -222,7 +222,7 @@ object RecipeController {
     ))
 
     val cloneRecipe = Form(
-      "newId" -> text(maxLength = 50).transform[RecipeId](RecipeId.apply, _.value)
+      "newId" -> text(minLength = 3, maxLength = 50).transform[RecipeId](RecipeId.apply, _.value)
     )
 
   }


### PR DESCRIPTION
## What does this change?
There is currently no check on whether an ID for a new (or cloned) base image or recipe has characters in it. The quickest solution is to add a minlength to the form.
 
## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Try to create or clone a recipe with no name.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Better errors than a unknown exception explosion.