### PR TITLE
Adds SSM capability to Packer

### DIFF
--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -175,7 +175,8 @@ class AppComponents(context: Context)
     stage = identity.stage,
     vpcId = configuration.getString("packer.vpcId"),
     subnetId = configuration.getString("packer.subnetId"),
-    instanceProfile = configuration.getString("packer.instanceProfile")
+    instanceProfile = configuration.getString("packer.instanceProfile"),
+    securityGroupId = configuration.getString("packer.securityGroupId")
   )
 
   val ansibleVariables: Map[String, String] =

--- a/app/models/packer/PackerBuilderConfig.scala
+++ b/app/models/packer/PackerBuilderConfig.scala
@@ -17,6 +17,7 @@ case class PackerBuilderConfig(
   source_ami: String,
   instance_type: String,
   ssh_username: String,
+  ssh_interface: String,
   run_tags: Map[String, String],
   ami_name: String,
   ami_description: String,
@@ -25,7 +26,8 @@ case class PackerBuilderConfig(
   iam_instance_profile: Option[String],
   tags: Map[String, String],
   ami_block_device_mappings: Option[List[BlockDeviceMapping]],
-  launch_block_device_mappings: Option[List[BlockDeviceMapping]])
+  launch_block_device_mappings: Option[List[BlockDeviceMapping]],
+  security_group_id: Option[String])
 
 object PackerBuilderConfig {
   implicit val jsonDiskWrites: OWrites[BlockDeviceMapping] = Json.writes[BlockDeviceMapping]

--- a/app/packer/PackerBuildConfigGenerator.scala
+++ b/app/packer/PackerBuildConfigGenerator.scala
@@ -41,6 +41,7 @@ object PackerBuildConfigGenerator {
       instance_type = instanceType,
 
       ssh_username = bake.recipe.baseImage.linuxDist.getOrElse(Ubuntu).loginName,
+      ssh_interface = "session_manager",
 
       run_tags = Map(
         "Stage" -> stage,
@@ -56,8 +57,8 @@ object PackerBuildConfigGenerator {
       iam_instance_profile = packerConfig.instanceProfile,
       tags = imageDetails.tags,
       ami_block_device_mappings = disk,
-      launch_block_device_mappings = disk
-
+      launch_block_device_mappings = disk,
+      security_group_id = packerConfig.securityGroupId
     )
 
     val baseImage = bake.recipe.baseImage.linuxDist.getOrElse(Ubuntu)

--- a/app/packer/PackerConfig.scala
+++ b/app/packer/PackerConfig.scala
@@ -7,5 +7,6 @@ case class PackerConfig(
   stage: String,
   vpcId: Option[String],
   subnetId: Option[String],
-  instanceProfile: Option[String])
+  instanceProfile: Option[String],
+  securityGroupId: Option[String])
 

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -25,7 +25,9 @@ Parameters:
   PackerVersion:
     Description: What version of Packer to install
     Type: String
-    Default: 1.1.2
+  PackerInstanceProfile:
+    Description: Instance profile given to instances created by Packer #find this in the PackerUser-PackerRole in IAM
+    Type: String
   TLSCert:
     Type: String
     Description: ARN of a TLS certificate to install on the load balancer
@@ -110,6 +112,10 @@ Resources:
             - s3:GetObject
           Resource:
             - !Sub 'arn:aws:s3:::${AmigoDataBucket}/*'
+        - Effect: Allow
+          Action:
+            - iam:GetInstanceProfile
+          Resource: !Ref PackerInstanceProfile
       Roles:
       - !Ref 'RootRole'
 
@@ -133,6 +139,7 @@ Resources:
           - ssm:ListInstanceAssociations
           - ssm:DescribeInstanceProperties
           - ssm:DescribeDocumentParameters
+          - ssm:StartSession
           - ssmmessages:CreateControlChannel
           - ssmmessages:CreateDataChannel
           - ssmmessages:OpenControlChannel
@@ -267,6 +274,9 @@ Resources:
           unzip -d /opt/packer /tmp/packer_*_linux_amd64.zip
           echo 'export PATH=${!PATH}:/opt/packer' > /etc/profile.d/packer.sh
 
+          wget -P /tmp https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb
+          dpkg -i /tmp/session-manager-plugin.deb
+
           aws --region eu-west-1 s3 cp s3://deploy-tools-dist/deploy/${Stage}/amigo/amigo_1.0-latest_all.deb /tmp/amigo.deb
           dpkg -i /tmp/amigo.deb
 
@@ -323,3 +333,14 @@ Resources:
           Value: deploy
         - Key: App
           Value: amigo
+  PackerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: !Sub 'amigo-packer-${Stage}'
+      GroupDescription: Security group for instances created by Packer
+      VpcId: !Ref 'VPC'
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 0
+          ToPort: 65535
+          CidrIp: 0.0.0.0/0


### PR DESCRIPTION
## What is the problem?
Security HQ was showing an error when trying to collect the security groups of the Deploy Tools account. After debugging, we learnt that AWS Trusted Advisor was unable to return a response for an account with over 200 security groups. The Deploy Tools account had over 850! Most of these were temporary Packer security groups created by Amigo. Whilst we wrote a script to delete the unused security groups, we wanted to find a way to stop Amigo creating all of these security groups.

## What is the solution?
We decided to add SSM support to Packer and create two dedicated security groups (one for CODE and another for PROD), so that the security groups do not need any inbound access rules and also so that we no longer create a new temporary security group for each new Packer instance created by Amigo.

> Support for the AWS Systems Manager session manager lets users manage EC2 instances without the need to open inbound ports, or maintain bastion hosts...Once the tunnel has been created all SSH communication will be tunnelled through SSM to the remote instance. https://www.packer.io/docs/builders/amazon/ebs#ssh_interface-1

## How to test
We've tested this on CODE.

When deploying to PROD:
1. upload the new cloudformation to amigo PROD
2. copy the security group id that is created
3. add this to the config in dynamodb
4. push the latest change to teamcity and deploy

## How can we measure success?
No more temporary Packer security groups are created by Amigo, we just have 2 dedicated security groups.