### PR TITLE
Add role to reserve disk space for .ssh directory

### DIFF
--- a/roles/ssh-reserve-disk-space/README.md
+++ b/roles/ssh-reserve-disk-space/README.md
@@ -1,4 +1,4 @@
 SSH reserve disk space
 ======================
 
-This role reserves disk space for the authorized_keys file so that you can connect to an instance that has run out of disk space.
+This role reserves disk space for amazon ssm and the authorized_keys file so that you can connect to an instance that has run out of disk space.

--- a/roles/ssh-reserve-disk-space/README.md
+++ b/roles/ssh-reserve-disk-space/README.md
@@ -1,0 +1,4 @@
+SSH reserve disk space
+======================
+
+This role reserves disk space for the authorized_keys file so that you can connect to an instance that has run out of disk space.

--- a/roles/ssh-reserve-disk-space/tasks/main.yml
+++ b/roles/ssh-reserve-disk-space/tasks/main.yml
@@ -22,3 +22,27 @@
     owner: ubuntu
     group: ubuntu
     mode: '0700'
+
+- name: Reserve 10MB for ssm
+  command: "dd if=/dev/zero of=/root/ssm.img bs=1024 count=10k"
+  args:
+    creates: "/root/ssm.img"
+
+- name: Create ext2 filesystem
+  filesystem:
+    fstype: ext2
+    dev: /root/ssm.img
+
+- name: Mount ssm
+  mount:
+    path: /var/lib/amazon/ssm
+    src: /root/ssm.img
+    fstype: ext2
+    state: mounted
+
+- name: Set permissions for ssm dir
+  file:
+    path: /var/lib/amazon/ssm
+    owner: root
+    group: root
+    mode: '0700'

--- a/roles/ssh-reserve-disk-space/tasks/main.yml
+++ b/roles/ssh-reserve-disk-space/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Reserve 10MB for ssh config
+  command: "dd if=/dev/zero of=/home/ubuntu/ssh.img bs=1024 count=10k"
+  args:
+    creates: "/home/ubuntu/ssh.img"
+
+- name: Create ext2 filesystem
+  filesystem:
+    fstype: ext2
+    dev: /home/ubuntu/ssh.img
+    
+- name: Mount ssh config in homedir
+  mount:
+    path: /home/ubuntu/.ssh
+    src: /home/ubuntu/ssh.img
+    fstype: ext2
+    state: mounted
+
+- name: Set permissions for ssh config dir
+  file:
+    path: /home/ubuntu/.ssh
+    owner: ubuntu
+    group: ubuntu
+    mode: '0700'


### PR DESCRIPTION
## What does this change?

On many occasions teams have been unable to SSH to instances using SSM because the instance has run out of disk space.  This adds a role which reserves 10MB of diskspace for `/home/ubuntu/.ssh` which should avoid this issue.

## How to test

Based on https://docs.google.com/document/d/1IvLH8jt5JNYWwsr8S2mDEISVtSDwCnjBMfSmmYun_FI/edit

- [x] Create an AMI with this role
- [x] Create an instance of this AMI
- [x] Use ssm ssh to get onto the instance
- [x] Run `fallocate -l $(($(df . --output=avail | tail -1) * 1024)) filler` to fill the root partition
- [x] Try to use ssm ssh again from another local terminal. It should work