### PR TITLE
Parameterise architecture for node role.

### DIFF
--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 node_version: 4.x
+architecture: x64

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Download & extract Node.js (from nodejs.org)
   unarchive:
-    src: https://nodejs.org/dist/v{{node_full_version}}/node-v{{node_full_version}}-linux-x64.tar.gz
+    src: https://nodejs.org/dist/v{{node_full_version}}/node-v{{node_full_version}}-linux-{{architecture}}.tar.gz
     dest: /usr/local
     remote_src: yes
     list_files: yes


### PR DESCRIPTION
In order to support both x64 and amr64 architectures for amigo bakes it makes senst to parameterise the architecture in this role. Ideally we'd calculate this based off the architecture of the instance packer is running on, but this is a fairly quick fix in the short term.

**Testing**
This has been tested on CODE https://amigo.code.dev-gutools.co.uk/recipes/devx-arm64-test.

I've also verified that recipes where 'architecture' isn't specified still work