### PR TITLE
Query for ASG tags instead of instance tags

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -91,6 +91,12 @@ Resources:
           Action: ec2:DescribeTags
           Resource: '*'
         - Effect: Allow
+          Action: autoscaling:DescribeAutoScalingGroups
+          Resource: '*'
+        - Effect: Allow
+          Action: autoscaling:DescribeAutoScalingInstances
+          Resource: '*'
+        - Effect: Allow
           Action:
           - sns:ListTopics
           Resource: '*'

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -79,12 +79,13 @@
         REGION=`ec2metadata --availability-zone | sed 's/.$//'`
         INSTANCE_ID=`ec2metadata --instance-id`
 
-        FILTERS="Name=resource-id,Values=$INSTANCE_ID Name=resource-type,Values=instance"
-        OPTIONS="--query Tags[].Value --output text --region $REGION"
+        ASG_NAME=$(aws autoscaling describe-auto-scaling-instances --region "$REGION" --instance-ids "$INSTANCE_ID" --output text --query "AutoScalingInstances[0].AutoScalingGroupName" || true)
 
-        APP=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=App $OPTIONS || true)
-        STACK=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stack $OPTIONS || true)
-        STAGE=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stage $OPTIONS || true)
+        ARGS="describe-auto-scaling-groups --region "$REGION" --auto-scaling-group-name "$ASG_NAME" --output text"
+
+        APP=$(aws autoscaling $ARGS --query "AutoScalingGroups[0].Tags[?Key == 'App'].Value" || true)
+        STACK=$(aws autoscaling $ARGS --query "AutoScalingGroups[0].Tags[?Key == 'Stack'].Value" || true)
+        STAGE=$(aws autoscaling $ARGS --query "AutoScalingGroups[0].Tags[?Key == 'Stage'].Value" || true)
 
         cp /var/ossec/etc/ossec.conf /var/ossec/etc/ossec.conf.bak
 


### PR DESCRIPTION
## What does this change?

This refactors the wazuh agent registration script to fetch tags from the instance's autoscaling group instead of its own tags via `ec2 describe-tags`. Because the script runs on boot, it might be that it queries for tags before they've assigned to the instance. Fetching them from the ASG avoids this issue altogether.

## How to test

I've that it builds in amigo code. I haven't been able to launch the ami in a test instance, as it requires that instance to be in an ASG. I've ran the script in the amiable CODE instance by SSHing though.

I think this needs to be merged and then each service migrated and checked one by one.

## Have we considered potential risks?

The big risk is that the instances don't have permissions to run `describe-auto-scaling-instances` and `describe-auto-scaling-groups` and the whole things bombs. Shouldn't affect the service running on the instance though, so it's fairly low risk.