### PR TITLE
Show a diff of modified packages between bakes

### DIFF
--- a/app/controllers/BakeController.scala
+++ b/app/controllers/BakeController.scala
@@ -43,7 +43,7 @@ class BakeController(
     }
   }
 
-  def showBake(recipeId: RecipeId, buildNumber: Int) = AuthAction {
+  def showBake(recipeId: RecipeId, buildNumber: Int): Action[AnyContent] = AuthAction {
     val previousBakeId = Bakes.findPreviousSuccessfulBake(recipeId, buildNumber - 1).map(_.bakeId)
     Bakes.findById(recipeId, buildNumber).fold[Result](NotFound) { bake: Bake =>
       val bakeLogs = BakeLogs.list(BakeId(recipeId, buildNumber))

--- a/app/data/Bakes.scala
+++ b/app/data/Bakes.scala
@@ -71,6 +71,15 @@ object Bakes {
     }
   }
 
+  @scala.annotation.tailrec
+  def findPreviousSuccessfulBake(recipeId: RecipeId, buildNumber: Int)(implicit dynamo: Dynamo): Option[Bake] = {
+    if (buildNumber > 0) {
+      val bake = findById(recipeId, buildNumber)
+      if (bake.isEmpty) findPreviousSuccessfulBake(recipeId, buildNumber - 1)
+      else bake
+    } else None
+  }
+
   def scanForAll()(implicit dynamo: Dynamo): List[Bake.DbModel] = {
     table
       .scan()

--- a/app/data/Bakes.scala
+++ b/app/data/Bakes.scala
@@ -75,7 +75,7 @@ object Bakes {
   def findPreviousSuccessfulBake(recipeId: RecipeId, buildNumber: Int)(implicit dynamo: Dynamo): Option[Bake] = {
     if (buildNumber > 0) {
       val bake = findById(recipeId, buildNumber)
-      if (bake.isEmpty) findPreviousSuccessfulBake(recipeId, buildNumber - 1)
+      if (bake.isEmpty || bake.exists(_.status != BakeStatus.Complete)) findPreviousSuccessfulBake(recipeId, buildNumber - 1)
       else bake
     } else None
   }

--- a/app/data/PackageList.scala
+++ b/app/data/PackageList.scala
@@ -1,12 +1,9 @@
 package data
 
 import com.amazonaws.services.s3.AmazonS3
-<<<<<<< HEAD
 import models.BakeId
 import models.BakeId.toFilename
-=======
 import models.{ Bake, BakeId }
->>>>>>> 7e17422 (Diff bake package list with previous bake.)
 import services.Loggable
 import fun.mike.dmp.{ Diff, DiffMatchPatch }
 
@@ -30,7 +27,7 @@ object PackageList extends Loggable {
 
   def getPackageList(s3Client: AmazonS3, bakeId: BakeId, bucket: Option[String]): Either[String, List[String]] = {
     val maybePackageList: Option[Either[String, List[String]]] = bucket.map { b =>
-      val packageListKey = s"$packageListsPath/${BakeId.toFilename(bakeId)}"
+      val packageListKey = s3Path(bakeId)
       try {
         val list = s3Client.getObjectAsString(b, packageListKey)
         Right(removeNonPackageLines(list.split("\n").toList))
@@ -53,6 +50,7 @@ object PackageList extends Loggable {
     dmp.diffCleanupSemantic(diff)
     dmp.Diff_EditCost = 6
     dmp.diff_cleanupEfficiency(diff)
+    diff.asScala.foreach(d => d.text = d.text.replace("\n", "<br />"))
     val scalaDiff: List[Diff] = diff.asScala.toList
 
     PackageListDiff(removedPackages, newPackages, scalaDiff)

--- a/app/views/fragments/bakeOutput.scala.html
+++ b/app/views/fragments/bakeOutput.scala.html
@@ -1,0 +1,7 @@
+@(output: List[String])
+
+<div class="well package-list" id="packer-output">
+    @for(o <- output) {
+        <div class="bake-log">@o</div>
+    }
+</div>

--- a/app/views/fragments/bakeOutput.scala.html
+++ b/app/views/fragments/bakeOutput.scala.html
@@ -1,6 +1,6 @@
 @(output: List[String])
 
-<div class="well package-list" id="packer-output">
+<div class="well package-list">
     @for(o <- output) {
         <div class="bake-log">@o</div>
     }

--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -1,4 +1,6 @@
 @import data.PackageListDiff
+@import fun.mike.dmp.Operation
+@import fun.mike.dmp.Diff
 @(bake: Bake, bakeLogs: Iterable[BakeLog], packageList: Either[String, List[String]], packageListDiff: Either[String, PackageListDiff])
 @layout("AMIgo"){
 
@@ -49,7 +51,7 @@
     <div class="row">
       @packageListDiff match {
         case Left(message) => {
-          <p>packageListDiff.left.get</p>
+          <p>message</p>
         }
         case Right(diff) => {
           <div class="col-md-6">
@@ -59,6 +61,29 @@
           <div class="col-md-6">
             <h3>New Packages</h3>
             @views.html.fragments.bakeOutput(diff.newPackages)
+          </div>
+         </div>
+         <div class="row">
+          <div class="col-md-12">
+            <h3>New Packages</h3>
+              <div class="well package-list" id="packer-output">
+                <div class="bake-log">
+              @for(o <- diff.diff) {
+                @o.operation match {
+                  case Operation.EQUAL => {
+                    <span>@Html(HtmlFormat.escape(o.text).toString.replace("\n", "<br />"))</span>
+                  }
+                  case Operation.INSERT => {
+                    <ins class="package-diff-insert">@Html(HtmlFormat.escape(o.text).toString.replace("\n", "<br />"))</ins>
+                  }
+                  case Operation.DELETE => {
+                    <del class="package-diff-delete">@Html(HtmlFormat.escape(o.text).toString.replace("\n", "<br />"))</del>
+                  }
+                }
+
+              }
+                </div>
+              </div>
           </div>
         }
       }

--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -51,12 +51,12 @@
           feedback to the devx team.
         </p>
       </div>
+    </div>
       @packageListDiff match {
         case Left(message) => {
           <p>@message</p>
         }
         case Right(PackageListDiff(removed, added, diff)) => {
-         </div>
          <div class="row">
           <div class="col-md-12">
               <div class="well package-list">
@@ -75,6 +75,7 @@
               }
               </div>
           </div>
+         </div>
         }
       }
     </div>

--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -43,23 +43,18 @@
   </div>
 
   <div class="package-list">
-    <h2>Package Changes</h2>
-    <div class="row">
-      <div class="col-md-12">
-        <p>
-          This data comes from the OS default package manager (e.g. apt on Ubuntu, yum on amazon linux). Please give any
-          feedback to the devx team.
-        </p>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-md-12">
-        <div class="well package-list">
+
       @packageListDiff match {
-        case Left(message) => {
-          <p>@message</p>
-        }
-        case Right(PackageListDiff(removed, added, diff)) => {
+        case Right(PackageListDiff(previousBakeId, removed, added, diff)) => {
+          <h2>Package Changes</h2>
+          <div class="row">
+            <div class="col-md-12">
+              Package changes since the <a href="@routes.BakeController.showBake(previousBakeId.recipeId, previousBakeId.buildNumber)">last succesful bake</a>.
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-md-12">
+              <div class="well package-list">
 
               @for(d <- diff) {
                 @d.operation match {
@@ -78,10 +73,14 @@
           </div>
          </div>
         }
+        case Left(message) => {Unit}
       }
     </div>
 
     <h2>All installed packages</h2>
+      <p>
+        This data comes from the OS default package manager (e.g. apt on Ubuntu, yum on amazon linux).
+      </p>
     @packageList match {
       case Left(message) => {
         @views.html.fragments.bakeOutput(List(message))

--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -1,4 +1,5 @@
-@(bake: Bake, bakeLogs: Iterable[BakeLog], packageList: List[String])
+@import data.PackageListDiff
+@(bake: Bake, bakeLogs: Iterable[BakeLog], packageList: Either[String, List[String]], packageListDiff: Either[String, PackageListDiff])
 @layout("AMIgo"){
 
   <h1><a href="@routes.RecipeController.showRecipe(bake.recipe.id)">@bake.recipe.id</a></h1>
@@ -40,15 +41,39 @@
   </div>
 
   <div class="package-list">
-    <h2>Package List</h2>
     <p>
       This list contains the packages installed by the OS default package manager (e.g. apt on Ubuntu, yum on amazon linux)
     </p>
-    <div class="well" id="packer-output">
-    @for(p <- packageList) {
-      <div class="bake-log">@p</div>
-    }
+
+    <h2>Package Diff</h2>
+    <div class="row">
+      @packageListDiff match {
+        case Left(message) => {
+          <p>packageListDiff.left.get</p>
+        }
+        case Right(diff) => {
+          <div class="col-md-6">
+            <h3>Removed Packages</h3>
+            @views.html.fragments.bakeOutput(diff.removedPackages)
+          </div>
+          <div class="col-md-6">
+            <h3>New Packages</h3>
+            @views.html.fragments.bakeOutput(diff.newPackages)
+          </div>
+        }
+      }
     </div>
+
+    <h2>Package List</h2>
+    @packageList match {
+      case Left(message) => {
+        <p>@message</p>
+      }
+     case Right(list) => {
+       @views.html.fragments.bakeOutput(packageList.right.get)
+     }
+    }
+
   </div>
 
 } {

--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -43,59 +43,49 @@
   </div>
 
   <div class="package-list">
-    <p>
-      This list contains the packages installed by the OS default package manager (e.g. apt on Ubuntu, yum on amazon linux)
-    </p>
-
-    <h2>Package Diff</h2>
+    <h2>Package Changes</h2>
     <div class="row">
+      <div class="col-md-12">
+        <p>
+          This data comes from the OS default package manager (e.g. apt on Ubuntu, yum on amazon linux). Please give any
+          feedback to the devx team.
+        </p>
+      </div>
       @packageListDiff match {
         case Left(message) => {
           <p>message</p>
         }
-        case Right(diff) => {
-          <div class="col-md-6">
-            <h3>Removed Packages</h3>
-            @views.html.fragments.bakeOutput(diff.removedPackages)
-          </div>
-          <div class="col-md-6">
-            <h3>New Packages</h3>
-            @views.html.fragments.bakeOutput(diff.newPackages)
-          </div>
+        case Right(PackageListDiff(removed, added, diff)) => {
          </div>
          <div class="row">
           <div class="col-md-12">
-            <h3>New Packages</h3>
-              <div class="well package-list" id="packer-output">
-                <div class="bake-log">
-              @for(o <- diff.diff) {
-                @o.operation match {
+              <div class="well package-list">
+              @for(d <- diff) {
+                @d.operation match {
                   case Operation.EQUAL => {
-                    <span>@Html(HtmlFormat.escape(o.text).toString.replace("\n", "<br />"))</span>
+                    <span>@Html(d.text)</span>
                   }
                   case Operation.INSERT => {
-                    <ins class="package-diff-insert">@Html(HtmlFormat.escape(o.text).toString.replace("\n", "<br />"))</ins>
+                    <ins class="package-diff-insert">@Html(d.text)</ins>
                   }
                   case Operation.DELETE => {
-                    <del class="package-diff-delete">@Html(HtmlFormat.escape(o.text).toString.replace("\n", "<br />"))</del>
+                    <del class="package-diff-delete">@Html(d.text)</del>
                   }
                 }
-
               }
-                </div>
               </div>
           </div>
         }
       }
     </div>
 
-    <h2>Package List</h2>
+    <h2>All installed packages</h2>
     @packageList match {
       case Left(message) => {
         <p>@message</p>
       }
      case Right(list) => {
-       @views.html.fragments.bakeOutput(packageList.right.get)
+       @views.html.fragments.bakeOutput(list)
      }
     }
 

--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -53,7 +53,7 @@
       </div>
       @packageListDiff match {
         case Left(message) => {
-          <p>message</p>
+          <p>@message</p>
         }
         case Right(PackageListDiff(removed, added, diff)) => {
          </div>

--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -52,14 +52,15 @@
         </p>
       </div>
     </div>
+    <div class="row">
+      <div class="col-md-12">
+        <div class="well package-list">
       @packageListDiff match {
         case Left(message) => {
           <p>@message</p>
         }
         case Right(PackageListDiff(removed, added, diff)) => {
-         <div class="row">
-          <div class="col-md-12">
-              <div class="well package-list">
+
               @for(d <- diff) {
                 @d.operation match {
                   case Operation.EQUAL => {
@@ -83,7 +84,7 @@
     <h2>All installed packages</h2>
     @packageList match {
       case Left(message) => {
-        <p>@message</p>
+        @views.html.fragments.bakeOutput(List(message))
       }
      case Right(list) => {
        @views.html.fragments.bakeOutput(list)

--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,8 @@ libraryDependencies ++= Seq(
   "net.logstash.logback" % "logstash-logback-encoder" % "5.1",
   "com.gu" % "kinesis-logback-appender" % "1.4.2",
   "org.scalatest" %% "scalatest" % "2.2.6" % Test,
-  "org.mockito" % "mockito-core" % "2.7.19" % Test
+  "org.mockito" % "mockito-core" % "2.7.19" % Test,
+  "fun.mike" % "diff-match-patch" % "0.0.2"
 )
 routesGenerator := InjectedRoutesGenerator
 routesImport += "models._"

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -23,6 +23,10 @@ body { padding-top: 70px; }
     color: #DCDCDC; /* iTerm2's default theme */
 }
 
+.package-list {
+    white-space: nowrap;
+}
+
 .btn--success:after {
     content: 'Successful';
     display: inline-block;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -23,6 +23,20 @@ body { padding-top: 70px; }
     color: #DCDCDC; /* iTerm2's default theme */
 }
 
+.package-diff-insert {
+    color:rgb(239, 246, 252);
+    background: rgb(10, 108, 54);
+    text-decoration: underline;
+}
+
+.package-diff-delete {
+    color: rgb(239, 246, 252);
+    background: rgb(144, 37, 42);
+    text-decoration: line-through;
+}
+
+
+
 .package-list {
     white-space: nowrap;
 }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -13,13 +13,10 @@ body { padding-top: 70px; }
     border-radius: 0 0 0.5em 0.5em;
 }
 
-#packer-output {
-    max-height: 400px; /* This gets updated to match the screen size using JS */
-    overflow-y: scroll;
+.well {
     background-color: #15191F; /* iTerm2's default theme */
-}
-
-.bake-log {
+    overflow-y: scroll;
+    max-height: 400px; /* This gets updated to match the screen size using JS */
     color: #DCDCDC; /* iTerm2's default theme */
 }
 
@@ -34,8 +31,6 @@ body { padding-top: 70px; }
     background: rgb(144, 37, 42);
     text-decoration: line-through;
 }
-
-
 
 .package-list {
     white-space: nowrap;


### PR DESCRIPTION
## What does this change?
This change makes use of google's [diff-match-patch](https://github.com/google/diff-match-patch) library to generate a diff of the package lists of the current bake and the previous bake. This results in a more useful indication of what changed in the current bake.

## How to test
Perform at least 2 bakes on a recipe with some change between them. You should see the diff show up on the bake page. Locally you can experiment with [this recipe](http://localhost:9000/recipes/node-is-theft/bakes/3)

## How can we measure success?
Next time someone has an issue they suspect is caused by a change in an AMI it should be more obvious to them what has changed. 

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

<img width="1205" alt="Screenshot 2021-02-02 at 10 19 32" src="https://user-images.githubusercontent.com/3606555/106586285-294a9c80-6540-11eb-8e94-0bc1f543a39c.png">

