### PR TITLE
Use dpkg-query instead of apt list to generate package list

### DIFF
--- a/app/models/BaseImage.scala
+++ b/app/models/BaseImage.scala
@@ -48,7 +48,7 @@ case object Ubuntu extends LinuxDist {
     ))
   )
   def savePackageListCommand(bakeId: BakeId) =
-    s"apt list --installed > ${LinuxDist.packageListTempPath(bakeId)}"
+    s"dpkg-query -W > ${LinuxDist.packageListTempPath(bakeId)}"
 }
 case object RedHat extends LinuxDist {
   val name = "redhat"


### PR DESCRIPTION
## What does this change?
This changes the tool used to generate the package list on Ubuntu bakes from `apt list` to `dpkg-query`. The motivation here is mainly to generate a file in a format that can be scanned for vulnerabilities using https://github.com/canonical/sec-cvescan but the package list generated is also a bit less verbose which is perhaps a good thing 

## How to test
Run a bake, observe changes to the package list (see below for examples)

## How can we measure success?
If the package list continues to be generated and, longer term, we can try scanning package lists with sec-cvescan then happy days.

## Have we considered potential risks?
There will be an awkward period whilst the package lists are being switched from the apt list to the dpkg format which will mess up the diff introduced in https://github.com/guardian/amigo/pull/535 but since that feature is brand new this shouldn't bother people too much! 

## Images
Before
```
accountsservice/bionic-updates,now 0.6.45-1ubuntu1.3 arm64 [installed,automatic]
acl/bionic,now 2.2.52-3build1 arm64 [installed,automatic]
acpid/bionic,now 1:2.0.28-1ubuntu1 arm64 [installed,automatic]
adduser/bionic,now 3.116ubuntu1 all [installed,automatic]
adwaita-icon-theme/bionic,now 3.28.0-1ubuntu1 all [installed,automatic]
amiable/now 1.0-SNAPSHOT all [installed,local]
ansible/bionic,now 2.9.17-1ppa~bionic all [installed]
apparmor/bionic-updates,now 2.12-4ubuntu5.1 arm64 [installed,automatic]
apport/bionic-updates,now 2.20.9-0ubuntu7.21 all [installed,automatic]
apport-symptoms/bionic,now 0.20 all [installed,automatic]
```
After
```
accountsservice 0.6.45-1ubuntu1.3
acl     2.2.52-3build1
acpid   1:2.0.28-1ubuntu1
adduser 3.116ubuntu1
adwaita-icon-theme      3.28.0-1ubuntu1
amiable 1.0-SNAPSHOT
ansible 2.9.17-1ppa~bionic
apparmor        2.12-4ubuntu5.1
apport  2.20.9-0ubuntu7.21
apport-symptoms 0.20
```
