### PR TITLE
Allow amigo to terminate ssm sessions.

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -150,6 +150,7 @@ Resources:
           - ssmmessages:CreateDataChannel
           - ssmmessages:OpenControlChannel
           - ssmmessages:OpenDataChannel
+          - ssm:TerminateSession
       Roles:
       - !Ref RootRole
 


### PR DESCRIPTION
## What does this change?
Allows AMIgo to terminate ssm sessions. I've noticed some (but strangely not all) bakes failing because amigo can't terminate the ssm session, e.g. https://amigo.gutools.co.uk/recipes/centralised-elk-es/bakes/184. This change solves the problem by giving amigo the permision to do this.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
[This bake](https://amigo.gutools.co.uk/recipes/centralised-elk-es/bakes/184) is consistently failing right now, after this change it should work.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![terminate dalek](https://media4.giphy.com/media/TElUQ8phjH7qr8lI1r/giphy.gif)

