### PR TITLE
Wazuh: Inclue app,stack,stage tags in agent name

### DIFF
--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -97,12 +97,13 @@
             <label key="aws.app">$APP</label>
             <label key="aws.stack">$STACK</label>
             <label key="aws.stage">$STAGE</label>
+            <label key="aws.instanceId">$INSTANCE_ID</label>
           </labels>
         </ossec_config>
       EOF
 
         # Enroll with manager
-        /var/ossec/bin/agent-auth -m $MANAGER_ADDRESS -A $INSTANCE_ID
+        /var/ossec/bin/agent-auth -m $MANAGER_ADDRESS -A "$APP-$STACK-$STAGE-$INSTANCE_ID"
 
         # Cleanup
         rm /var/ossec/etc/authd.pass

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -103,7 +103,7 @@
       EOF
 
         # Enroll with manager
-        /var/ossec/bin/agent-auth -m $MANAGER_ADDRESS -A "$APP-$STACK-$STAGE-$INSTANCE_ID"
+        /var/ossec/bin/agent-auth -m $MANAGER_ADDRESS -A "$STACK-$STAGE-$APP-$INSTANCE_ID"
 
         # Cleanup
         rm /var/ossec/etc/authd.pass


### PR DESCRIPTION
## What does this change?
Modifies the wazuh agent bootstrap script to include the app, stack and stage tags as part of the instance. The motivation for this is that wazuh doesn't include labels in the main agent list, so you just get a wall of instance ids which are kinda hard for the average brain to parse. The new format is app-stack-stage-instanceId - the idea being that unless we're doing a search for a specific instance the instance ID is the least useful piece of info.

## How to test
I've performed a test bake on CODE but the real test will be using the new script in an AMI that is actually used by an app that reports to wazuh. Testinig this all out on CODE would be pretty time consuming so I propose just merging to prod then immediately running a bake for [this AMI](https://amigo.gutools.co.uk/recipes/arm64-bionic-java8-deploy-infrastructure) and then redeploying AMIable on CODE and verifying that the new instance connects to wazuh.

## How can we measure success?
Readable dashboards

## Have we considered potential risks?
This could somehow break the wazuh agent script, in which case every bake on amigo that happened until it was reverted would also have a dodgy script. This is easy to check though and just re bake everything. 

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![identity is important](https://media1.giphy.com/media/QX84fiPOBG0E7QCbIn/giphy.gif)