### PR TITLE
Update aws-cloudwatch-agent role to support ARM64 architecture

### DIFF
--- a/roles/aws-cloud-watch-agent/README.md
+++ b/roles/aws-cloud-watch-agent/README.md
@@ -4,8 +4,7 @@ Currently the role does not assume anything about how the agent should be config
 Typically both of these actions would be performed in the [User Data](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-userdata)
 made available to EC2 instances.
 
-At the moment, the role is only available for Ubuntu Linux running on AMD64 architecture, though this can be expanded
-as and when needed; for example by following the pattern in the `aws-tools` role.
+At the moment, the role is available for Ubuntu Linux running on AMD64 or ARM64 architectures.
 
 The AWS documentation on Cloud Watch agent is fairly comprehensive, but scattered; for convenience, some relevant
 resources are listed below:

--- a/roles/aws-cloud-watch-agent/tasks/main.yml
+++ b/roles/aws-cloud-watch-agent/tasks/main.yml
@@ -3,6 +3,13 @@
   get_url:
     url: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
     dest: /tmp/amazon-cloudwatch-agent.deb
+  when: ansible_architecture == "x86_64"
+
+- name: Download cloudwatch agent for Ubuntu arm64
+  get_url:
+    url: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/arm64/latest/amazon-cloudwatch-agent.deb
+    dest: /tmp/amazon-cloudwatch-agent.deb
+  when: ansible_architecture == "aarch64"
 
 - name: Install cloudwatch agent
   apt:


### PR DESCRIPTION
## What does this change?

\* worked on with @Fweddi 

Update the `aws-cloudwatch-agent` role to dynamically install the `amazon-cloudwatch-agent.deb` dynamically based on the architecture (architectures supported: amd64, arm64).

Uses the Ansible fact `ansible_architecture` to determine the architecture.

Tested on CODE by:
1. creating a new base image `ARM ubuntu-xenial` (as was done on PROD)
2. cloning the recipe `ubuntu-xenial-capi` (clone name: `ubuntu-xenial-capi-ARM`) and changing the base image to `ARM ubuntu-xenial`
3. baking recipes [`ubuntu-xenial-capi`](https://amigo.code.dev-gutools.co.uk/recipes/ubuntu-xenial-capi/bakes/2) and [`ubuntu-xenial-capi-ARM`](https://amigo.code.dev-gutools.co.uk/recipes/ubuntu-xenial-capi-ARM/bakes/1) and eyeballing the logs to check the appropriate package was installed

