### PR TITLE
Ansible facts role

### DIFF
--- a/roles/ansible-facts/README.md
+++ b/roles/ansible-facts/README.md
@@ -11,6 +11,8 @@ is dependent on the architecture and operating system e.g. for Ubuntu:
 - ARM64: `https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/arm64/latest/amazon-cloudwatch-agent.deb`
 
 The Ansible fact `ansible_architecture` can be used to determine the architecture of the image and therefore which
-url link to use. By (temporarily) including this role in the recipes `ubuntu-xenial-capi` and `ubuntu-xenial-capi-ARM`
-(and baking the recipes) we were able to determine that the values of `ansible_architecture` were `x86_64` and `aarch64`
-respectively.
+url link to use. 
+
+We temporarily included this role in the recipes `ubuntu-xenial-capi` and `ubuntu-xenial-capi-ARM` for testing purposes.
+After baking the recipes, we were able to determine that the values of `ansible_architecture` were `x86_64` and 
+`aarch64` respectively. We then removed the role from the recipes.

--- a/roles/ansible-facts/README.md
+++ b/roles/ansible-facts/README.md
@@ -1,5 +1,4 @@
 # Ansible facts
 
 This role facilitates the discovery of Ansible facts and magic variables by printing out the variable 
-[`ansible_facts`](https://docs.ansible.com/ansible/latest/user_guide/playbooks_vars_facts.html) e.g. (for a given
-base image) getting the values for `ansible_os_family` and `ansible_architecture`. 
+[`ansible_facts`](https://docs.ansible.com/ansible/latest/user_guide/playbooks_vars_facts.html).

--- a/roles/ansible-facts/README.md
+++ b/roles/ansible-facts/README.md
@@ -1,4 +1,16 @@
 # Ansible facts
 
-This role facilitates the discovery of Ansible facts and magic variables by printing out the variable 
+This role facilitates the discovery of Ansible facts (and their values) by printing out the variable 
 [`ansible_facts`](https://docs.ansible.com/ansible/latest/user_guide/playbooks_vars_facts.html).
+
+## Example
+
+For the role `aws-cloudwatch-agent` we wanted to install the CloudWatch agent package. The url to download the package 
+is dependent on the architecture and operating system e.g. for Ubuntu:
+- AMD64: `https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb`
+- ARM64: `https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/arm64/latest/amazon-cloudwatch-agent.deb`
+
+The Ansible fact `ansible_architecture` can be used to determine the architecture of the image and therefore which
+url link to use. By (temporarily) including this role in the recipes `ubuntu-xenial-capi` and `ubuntu-xenial-capi-ARM`
+(and baking the recipes) we were able to determine that the values of `ansible_architecture` were `x86_64` and `aarch64`
+respectively.

--- a/roles/ansible-facts/README.md
+++ b/roles/ansible-facts/README.md
@@ -1,7 +1,8 @@
 # Ansible facts
 
-This role facilitates the discovery of Ansible facts (and their values) by printing out the variable 
-[`ansible_facts`](https://docs.ansible.com/ansible/latest/user_guide/playbooks_vars_facts.html).
+This role can be included in a recipe to discover Ansible facts (and their values) by printing out the variable 
+[`ansible_facts`](https://docs.ansible.com/ansible/latest/user_guide/playbooks_vars_facts.html). Once these facts are
+discovered, the role can be removed from the recipe.
 
 ## Example
 
@@ -11,7 +12,7 @@ is dependent on the architecture and operating system e.g. for Ubuntu:
 - ARM64: `https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/arm64/latest/amazon-cloudwatch-agent.deb`
 
 The Ansible fact `ansible_architecture` can be used to determine the architecture of the image and therefore which
-url link to use. 
+url link to use.
 
 We temporarily included this role in the recipes `ubuntu-xenial-capi` and `ubuntu-xenial-capi-ARM` for testing purposes.
 After baking the recipes, we were able to determine that the values of `ansible_architecture` were `x86_64` and 

--- a/roles/ansible-facts/README.md
+++ b/roles/ansible-facts/README.md
@@ -1,0 +1,5 @@
+# Ansible facts
+
+This role facilitates the discovery of Ansible facts and magic variables by printing out the variable 
+[`ansible_facts`](https://docs.ansible.com/ansible/latest/user_guide/playbooks_vars_facts.html) e.g. (for a given
+base image) getting the values for `ansible_os_family` and `ansible_architecture`. 

--- a/roles/ansible-facts/tasks/main.yml
+++ b/roles/ansible-facts/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Print all available Ansible facts
+  ansible.builtin.debug:
+    var: ansible_facts


### PR DESCRIPTION
## What does this change?

\* worked on with @Fweddi 

Adds a role to facilitate the discovery of Ansible facts. This role helped us extend the `aws-cloudwatch-agent` role (#540) to ARM64 architecture. See example in README in PR for more details.