### PR TITLE
Add concurrent bake limit

### DIFF
--- a/app/schedule/ScheduledBakeRunner.scala
+++ b/app/schedule/ScheduledBakeRunner.scala
@@ -6,7 +6,9 @@ import models.RecipeId
 import packer.{ PackerConfig, PackerRunner }
 import services.{ AmiMetadataLookup, Loggable, PrismAgents }
 
-class ScheduledBakeRunner(stage: String, enabled: Boolean, prism: PrismAgents, eventBus: EventBus, ansibleVars: Map[String, String], amiMetadataLookup: AmiMetadataLookup, amigoDataBucket: Option[String])(implicit dynamo: Dynamo, packerConfig: PackerConfig) extends Loggable {
+class ScheduledBakeRunner(stage: String, enabled: Boolean, prism: PrismAgents, eventBus: EventBus,
+    ansibleVars: Map[String, String], amiMetadataLookup: AmiMetadataLookup, amigoDataBucket: Option[String],
+    packerRunner: PackerRunner)(implicit dynamo: Dynamo, packerConfig: PackerConfig) extends Loggable {
 
   def bake(recipeId: RecipeId): Unit = {
     if (!enabled) {
@@ -23,7 +25,7 @@ class ScheduledBakeRunner(stage: String, enabled: Boolean, prism: PrismAgents, e
                 val theBake = Bakes.create(recipe, buildNumber, startedBy = "scheduler")
 
                 log.info(s"Starting scheduled bake: ${theBake.bakeId}")
-                PackerRunner.createImage(stage, theBake, prism, eventBus, ansibleVars, false, amiMetadataLookup, amigoDataBucket)
+                packerRunner.createImage(stage, theBake, prism, eventBus, ansibleVars, false, amiMetadataLookup, amigoDataBucket)
               case None =>
                 log.warn(s"Failed to get the next build number for recipe $recipeId")
             }


### PR DESCRIPTION
## What does this change?
This implements a brutally simple limiter to cap the number of bakes running at once. It seems that AMIgo can become overwhelmed when a large number of scheduled bakes kick off and this should limit the impact of that.

## How to test
Deploy to CODE and try to kick off more than five bakes. Anything over five should not start until prior bakes have completed.

## How can we measure success?
We have fewer scheduled bake failures.