### PR TITLE
Use IMDSv2 metadata service

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -272,6 +272,8 @@ Resources:
       - !Ref 'ApplicationSecurityGroup'
       InstanceType: !Ref 'InstanceType'
       IamInstanceProfile: !Ref 'InstanceProfile'
+      MetadataOptions:
+        HttpTokens: required
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash -ev


### PR DESCRIPTION
## What does this change?
This PR aims to resolve https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#ec2-8-remediation by making HTTPTokens 'required' when using the EC2 metadata service. Essentially amazon has released a more secure way of fetching metadata and they think that it should be enforced on all instances as the previous approach presented a security risk.

For more details on the metadata options see here https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-launch-config.html#launch-configurations-imds 

## How to test
Tested on CODE. I've also searched the repo for uses of the metadata service IP address - `169.254.169.254` and verified that it's not used within amigo (it is used by packer roles, but that's a separate configuratoin). 