### PR TITLE
Add retry logic to friendly-hostnames role

### DIFF
--- a/roles/friendly-hostnames/files/set-hostname.sh
+++ b/roles/friendly-hostnames/files/set-hostname.sh
@@ -13,4 +13,14 @@ rm /opt/features/friendly-hostnames/hostnames.txt
 INSTANCE_ID="`wget -qO- http://instance-data/latest/meta-data/instance-id`"
 REGION="`wget -qO- http://instance-data/latest/meta-data/placement/availability-zone | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:'`"
 
-aws ec2 --region $REGION create-tags --resources $INSTANCE_ID --tags Key=Name,Value=$FRIENDLY_HOSTNAME
+for i in {1..12}
+do
+    if aws ec2 --region $REGION create-tags --resources $INSTANCE_ID --tags Key=Name,Value=$FRIENDLY_HOSTNAME ; then
+        echo "Tagged $INSTANCE_ID with name=$FRIENDLY_HOSTNAME"
+        exit 0
+    fi
+    echo "Failed to tag instance with friendly hostname, retrying after 5s"
+    sleep 5
+done
+
+echo "Failed to tag instance with friendly hostname"


### PR DESCRIPTION
In the past 2 days, the Ophan team have seen this error from the friendly-hostnames role:

```
An error occurred (InvalidInstanceID.NotFound) when calling the CreateTags operation: The instance ID 'i-059607dad87f615d7' does not exist
```

We are quite surprised that this is happening, since we had assumed that the aws-await-tags step would ensure that the EC2 API was ready, but it seems like the [apis eventual consistency](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html#eventual-consistency) isn't as straightforward as that.

Rather than spend too much more time investigating what the rules are of the AWS API, I've added retry logic to the friendly-hostnames role.  This is copied from the aws-await-tags role.
