### PR TITLE
Update logstash-deb role to support ARM64 architecture for logstash versions >= 7.10.0 (fail if < 7.10.0)

### DIFF
--- a/roles/logstash-deb/tasks/main.yml
+++ b/roles/logstash-deb/tasks/main.yml
@@ -2,8 +2,13 @@
 - name: Add Elasticsearch repository key
   apt_key: url=https://artifacts.elastic.co/GPG-KEY-elasticsearch state=present
 
-- name: Ensure Logstash is installed
+- name: Ensure Logstash is installed (version < 7.10.0)
   apt: deb=https://artifacts.elastic.co/downloads/logstash/logstash-{{ version }}.deb state=present
+  when: version is version('7.10.0', '<')
+
+- name: Ensure Logstash is installed (version >= 7.10.0)
+  apt: deb=https://artifacts.elastic.co/downloads/logstash/logstash-{{ version }}-{{ansible_architecture}}.deb state=present
+  when: version is version(('7.10.0', '>=')
 
 - name: Install Logstash plugins
   command: "{{ ls_home }}/bin/logstash-plugin install {{ item }}"

--- a/roles/logstash-deb/tasks/main.yml
+++ b/roles/logstash-deb/tasks/main.yml
@@ -2,17 +2,22 @@
 - name: Add Elasticsearch repository key
   apt_key: url=https://artifacts.elastic.co/GPG-KEY-elasticsearch state=present
 
-- name: Ensure Logstash is installed (version < 7.10.0)
-  apt: deb=https://artifacts.elastic.co/downloads/logstash/logstash-{{ version }}.deb state=present
-  when: version is version('7.10.0', '<')
+- name: Fail when we attempt to install Logstash (version < 7.10.0) for ARM64
+  fail:
+    msg: Logstash (version < 7.10.0) does not work for ARM64 architecture
+  when: version is version('7.10.0', '<') and ansible_architecture == "aarch64"
 
-- name: Ensure Logstash is installed (version >= 7.10.0) for AMD64
-  apt: deb=https://artifacts.elastic.co/downloads/logstash/logstash-{{ version }}-amd64.deb state=present
-  when: version is version('7.10.0', '>=') and ansible_architecture == "x86_64"
+- name: Ensure Logstash is installed (version < 7.10.0) for AMD64
+  apt: deb=https://artifacts.elastic.co/downloads/logstash/logstash-{{ version }}.deb state=present
+  when: version is version('7.10.0', '<') and ansible_architecture == "x86_64"
 
 - name: Ensure Logstash is installed (version >= 7.10.0) for ARM64
   apt: deb=https://artifacts.elastic.co/downloads/logstash/logstash-{{ version }}-arm64.deb state=present
   when: version is version('7.10.0', '>=') and ansible_architecture == "aarch64"
+
+- name: Ensure Logstash is installed (version >= 7.10.0) for AMD64
+  apt: deb=https://artifacts.elastic.co/downloads/logstash/logstash-{{ version }}-amd64.deb state=present
+  when: version is version('7.10.0', '>=') and ansible_architecture == "x86_64"
 
 - name: Install Logstash plugins
   command: "{{ ls_home }}/bin/logstash-plugin install {{ item }}"

--- a/roles/logstash-deb/tasks/main.yml
+++ b/roles/logstash-deb/tasks/main.yml
@@ -6,9 +6,13 @@
   apt: deb=https://artifacts.elastic.co/downloads/logstash/logstash-{{ version }}.deb state=present
   when: version is version('7.10.0', '<')
 
-- name: Ensure Logstash is installed (version >= 7.10.0)
-  apt: deb=https://artifacts.elastic.co/downloads/logstash/logstash-{{ version }}-{{ansible_architecture}}.deb state=present
-  when: version is version(('7.10.0', '>=')
+- name: Ensure Logstash is installed (version >= 7.10.0) for AMD64
+  apt: deb=https://artifacts.elastic.co/downloads/logstash/logstash-{{ version }}-amd64.deb state=present
+  when: version is version('7.10.0', '>=') and ansible_architecture == "x86_64"
+
+- name: Ensure Logstash is installed (version >= 7.10.0) for ARM64
+  apt: deb=https://artifacts.elastic.co/downloads/logstash/logstash-{{ version }}-arm64.deb state=present
+  when: version is version('7.10.0', '>=') and ansible_architecture == "aarch64"
 
 - name: Install Logstash plugins
   command: "{{ ls_home }}/bin/logstash-plugin install {{ item }}"

--- a/roles/logstash-deb/tasks/main.yml
+++ b/roles/logstash-deb/tasks/main.yml
@@ -2,16 +2,14 @@
 - name: Add Elasticsearch repository key
   apt_key: url=https://artifacts.elastic.co/GPG-KEY-elasticsearch state=present
 
-#- name: Fail when we attempt to install Logstash (version < 7.10.0) for ARM64
-#  fail:
-#    msg: Logstash (version < 7.10.0) does not work for ARM64 architecture
-#  when: version is version('7.10.0', '<') and ansible_architecture == "aarch64"
+- name: Fail when we attempt to install Logstash (version < 7.10.0) for ARM64
+  fail:
+    msg: Logstash (version < 7.10.0) does not work for ARM64 architecture
+  when: version is version('7.10.0', '<') and ansible_architecture == "aarch64"
 
-- name: Ensure Logstash is installed (version < 7.10.0)
-#    for AMD64
+- name: Ensure Logstash is installed (version < 7.10.0) for AMD64
   apt: deb=https://artifacts.elastic.co/downloads/logstash/logstash-{{ version }}.deb state=present
-  when: version is version('7.10.0', '<')
-#    and ansible_architecture == "x86_64"
+  when: version is version('7.10.0', '<') and ansible_architecture == "x86_64"
 
 - name: Ensure Logstash is installed (version >= 7.10.0) for ARM64
   apt: deb=https://artifacts.elastic.co/downloads/logstash/logstash-{{ version }}-arm64.deb state=present

--- a/roles/logstash-deb/tasks/main.yml
+++ b/roles/logstash-deb/tasks/main.yml
@@ -2,14 +2,16 @@
 - name: Add Elasticsearch repository key
   apt_key: url=https://artifacts.elastic.co/GPG-KEY-elasticsearch state=present
 
-- name: Fail when we attempt to install Logstash (version < 7.10.0) for ARM64
-  fail:
-    msg: Logstash (version < 7.10.0) does not work for ARM64 architecture
-  when: version is version('7.10.0', '<') and ansible_architecture == "aarch64"
+#- name: Fail when we attempt to install Logstash (version < 7.10.0) for ARM64
+#  fail:
+#    msg: Logstash (version < 7.10.0) does not work for ARM64 architecture
+#  when: version is version('7.10.0', '<') and ansible_architecture == "aarch64"
 
-- name: Ensure Logstash is installed (version < 7.10.0) for AMD64
+- name: Ensure Logstash is installed (version < 7.10.0)
+#    for AMD64
   apt: deb=https://artifacts.elastic.co/downloads/logstash/logstash-{{ version }}.deb state=present
-  when: version is version('7.10.0', '<') and ansible_architecture == "x86_64"
+  when: version is version('7.10.0', '<')
+#    and ansible_architecture == "x86_64"
 
 - name: Ensure Logstash is installed (version >= 7.10.0) for ARM64
   apt: deb=https://artifacts.elastic.co/downloads/logstash/logstash-{{ version }}-arm64.deb state=present


### PR DESCRIPTION
## What does this change?
* worked on with @Mullefa 

Update the logstash-deb role to dynamically install the logstash.deb based on the architecture and version of logstash (architectures supported: amd64, arm64).

Uses the Ansible fact ansible_architecture to determine the architecture. 

Installs for logstash < v7.10.0 are not supported for ARM architecture, so we fail the build. For v7.10.0 and above, we install either the ARM or AMD variant of logstash depending on ansible_architecture.

Test bakes:
* [AMD64 pre-7.10](https://amigo.code.dev-gutools.co.uk/recipes/ubuntu-xenial-capi/bakes/3)
* [AMD64 post-7.10](https://amigo.code.dev-gutools.co.uk/recipes/ubuntu-xenial-capi/bakes/4)
* [ARM64 pre-7.10](https://amigo.code.dev-gutools.co.uk/recipes/ubuntu-xenial-capi-ARM/bakes/6)
* [ARM64 post-7.10](https://amigo.code.dev-gutools.co.uk/recipes/ubuntu-xenial-capi-ARM/bakes/4)

Affected recipes:
* ubuntu-xenial-capi
* ubuntu-xenial-capi-ARM
* xenial-java8-deploy-infrastructure
* bionic-java8-deploy-infrastructure
* arm64-bionic-java8-deploy-infrastructure
* gateway
* arm-gateway
* grid-elasticsearch
* identity-base
* editorial-tools-cypress-integration-tests
* infosec-wazuh-kibana
* frontend-router
* centralised-elk-logstash
* ubuntu-xenial-capi-logstash-7.x

We have so far only baked for `ubuntu-xenial-capi` and `ubuntu-xenial-capi-ARM`. We do not envisage that the conditional logic introduced here will affect pre v7.10.0, amd-64 recipes. 

This will disable the installation of logstash on `arm64-bionic-java8-deploy-infrastructure`, `arm-identity-base` and `arm-gateway` (we currently believe logstash is failing to work on these AMIs). This will also render invalid the version parameter for `ubuntu-xenial-capi-logstash-7.x`, however this recipe is currently failing to bake and not being used.