### PR TITLE
Add JDK 11 as a role

### DIFF
--- a/roles/java11/meta/main.yml
+++ b/roles/java11/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - role: apt
+    when: ansible_os_family == "Debian"

--- a/roles/java11/spec/java11_spec.rb
+++ b/roles/java11/spec/java11_spec.rb
@@ -1,0 +1,4 @@
+
+describe command('java -version') do
+  its(:stdout) { should match /java version "11\..*/ }
+end

--- a/roles/java11/tasks/main.yml
+++ b/roles/java11/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Install Java 11 JRE and JDK
+  apt:
+    name:
+    - openjdk-11-jdk
+    state: latest
+  when: ansible_os_family == "Debian"
+
+## This modifies the JVM's DNS cache TTL, changing it from the default of INFINITY to 60
+## seconds. See this issue for full details: https://github.com/guardian/amigo/issues/238
+- name: Change JVM DNS cache TTL
+  replace:
+    path: /etc/java-11-openjdk/security/java.security
+    regexp: '#networkaddress.cache.ttl=.*'
+    replace: 'networkaddress.cache.ttl=60'
+    backup: yes
+  when: ansible_os_family == "Debian"
+


### PR DESCRIPTION
## What does this change?
JRE11 has been supported by Scala for [some time now](https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html#version-compatibility-table) and has some [key optimisations for ARM64 machines](https://bugs.openjdk.java.net/browse/JDK-8189104).

This adds a role that should be a simple swap out for recipes switching from version 8.

## How to test
This impacts baked AMIs so best tested by converting an AMI over.