### PR TITLE
Move Kong base image to bionic LTS. Version postgres client to match

### DIFF
--- a/roles/kong/defaults/main.yml
+++ b/roles/kong/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 kong_version: 0.14.0
 kong_user: content-api
-postgres_version: 9.5
+postgres_version: 10

--- a/roles/kong/tasks/main.yml
+++ b/roles/kong/tasks/main.yml
@@ -14,7 +14,7 @@
   user: name={{kong_user}} system=yes
 
 - name: Download Kong package
-  get_url: url=https://bintray.com/kong/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{kong_version}}.xenial.all.deb dest=/tmp/kong-{{kong_version}}.deb
+  get_url: url=https://bintray.com/kong/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{kong_version}}.bionic.all.deb dest=/tmp/kong-{{kong_version}}.deb
 
 - name: Install Kong package
   command: dpkg -i /tmp/kong-{{kong_version}}.deb


### PR DESCRIPTION
## What does this change?

Updates Kong role to assume an ubuntu 18.04 base image rather than 16.04.

Provoked by the AWS CLI Python 3.6 fail this week but also gets us ready for the 16.04 end of support.

Levels the postgres client from 9.5 to the 10 provided in bionic (this is safe because it's only used for ad hoc queries).


## How to test

Baked by deploying this branch to CODE.
Deployed the AMI to CODE Kong.
Checked access logs and logstashing.


## How can we measure success?

No used facing impact should be visible.

## Have we considered potential risks?

Wierd Kong / Perl errors.
Should be safe as Kong provide a specific bionic .deb package.


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
