### PR TITLE
All aboard the Graviton train! 🚂 

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -21,7 +21,6 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: t3.small
   PackerVersion:
     Description: What version of Packer to install
     Type: String
@@ -276,12 +275,12 @@ Resources:
         Fn::Base64: !Sub |
           #!/bin/bash -ev
 
-          wget -P /tmp https://releases.hashicorp.com/packer/${PackerVersion}/packer_${PackerVersion}_linux_amd64.zip
+          wget -P /tmp https://releases.hashicorp.com/packer/${PackerVersion}/packer_${PackerVersion}_linux_arm64.zip
           mkdir /opt/packer
-          unzip -d /opt/packer /tmp/packer_*_linux_amd64.zip
+          unzip -d /opt/packer /tmp/packer_*_linux_arm64.zip
           echo 'export PATH=${!PATH}:/opt/packer' > /etc/profile.d/packer.sh
 
-          wget -P /tmp https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb
+          wget -P /tmp https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_arm64/session-manager-plugin.deb
           dpkg -i /tmp/session-manager-plugin.deb
 
           aws --region eu-west-1 s3 cp s3://deploy-tools-dist/deploy/${Stage}/amigo/amigo_1.0-latest_all.deb /tmp/amigo.deb
@@ -321,10 +320,6 @@ Resources:
         FromPort: '9000'
         ToPort: '9000'
         SourceSecurityGroupId: !Ref 'LoadBalancerSecurityGroup'
-      - IpProtocol: tcp
-        FromPort: '22'
-        ToPort: '22'
-        CidrIp: 10.249.0.0/16
   AmigoDataBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -14,7 +14,7 @@ deployments:
     app: amigo
     parameters:
       amiTags:
-        Recipe: xenial-java8-deploy-infrastructure
+        Recipe: arm64-bionic-java8-deploy-infrastructure
         AmigoStage: PROD
       amiEncrypted: true
       templatePath: cloudformation.yaml


### PR DESCRIPTION
## What does this change?
Switches Amigo over to use AWS ARM64 Graviton instances, including:
 - drop port 22 (nothing to do with this just hygeine)
 - update sesssion manager/packer version
 - Update recipe in riff-raff.yaml

## How to test
Tested on CODE (with one succesful bake). To release to PROD:

 - update stack via console and change the instance type to t4g.small
 - merge this change and wait for CD to kick in.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Amigo still works and costs less to run
