### PR TITLE
Prevent AMIgo housekeeping from removing TeamCity AMIs

### DIFF
--- a/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
+++ b/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
@@ -23,7 +23,7 @@ object MarkOldUnusedBakesForDeletion {
       duration.getStandardDays > MAX_AGE
     }
 
-    // Exclude TeamCity Agent AMIs, which have been incorrectly assumed to be as unused in the past. This happens
+    // Exclude TeamCity Agent AMIs, which have been incorrectly assumed to be unused in the past. This happens
     // because TeamCity Agents are typically terminated overnight and are not linked to a launch configuration.
     val oldBakesExcludingTeamCityAgents = oldBakes.filterNot { bake =>
       bake.recipe.id.value == "teamcity-agent"

--- a/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
+++ b/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
@@ -57,4 +57,14 @@ class MarkOldUnusedBakesForDeletionSpec extends FlatSpec with Matchers {
     markedBakes.size shouldEqual 1
     markedBakes.map(_.bakeId) shouldEqual Set(BakeId(RecipeId("recipe-1"), 1))
   }
+
+  it should "not include TeamCity agent AMIs, even if they are old" in {
+    val housekeepingDate = new DateTime(2018, 7, 12, 0, 0, 0, DateTimeZone.UTC)
+    val recipeIds = Set(RecipeId("teamcity-agent"))
+    val oldTeamCityAgent = fixtureBake(fixtureRecipe("teamcity-agent", oldDate), Some(AmiId("ami-1")), oldDate)
+    def getBakesWithTeamCityAgent(recipeId: RecipeId): Iterable[Bake] = Iterable(oldTeamCityAgent)
+    val markedBakes = MarkOldUnusedBakesForDeletion.getOldUnusedBakes(recipeIds, housekeepingDate, getBakesWithTeamCityAgent, getEmptyRecipeUsage)
+
+    markedBakes.size shouldEqual 0
+  }
 }


### PR DESCRIPTION
## What does this change?

Last month we experienced a problem launching new TeamCity agents, because [AMIgo had deleted the AMI associated with our TeamCity Cloud Profile](https://docs.google.com/document/d/1Qu5tPLMcAFzHx9Tzu3U_aAKHiEZkvdQKgpsGKrXpb9Y/edit).

In order to avoid a repeat of this problem, I was hoping to update the AMI associated with our Cloud Profile. Unfortunately the [bakes for this recipe](https://amigo.gutools.co.uk/recipes/teamcity-agent) have been failing for several weeks, so as things stand we run the risk of losing our only working AMI.

I'd like to prevent AMIgo from deleting `teamcity-agent` AMIs as a short-term measure so that we have time to debug and fix the failing bakes.

## How to test

I've added a unit test to cover the new behaviour.

## How can we measure success?

* Our [current `teamcity-agent` AMI](https://amigo.gutools.co.uk/recipes/teamcity-agent/bakes/147) should not be deleted by AMIgo's housekeeping
* Old, unused AMIs associated with other recipes should still be deleted

## Have we considered potential risks?

* If we forget to revert this PR we will accumulate a significant number of `teamcity-agent` AMIs over time