### PR TITLE
Stop installing python packages as part of Docker role

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -5,16 +5,6 @@
     state: absent
     force: yes
 
-- name: Install required python packages for 2.7.6
-  include_role:
-    name: pip-packages
-  vars:
-    packages:
-      - urllib3
-      - pyOpenSSL
-      - ndg-httpsclient
-      - pyasn1
-
 - name: Install required packages
   apt: 
     name:


### PR DESCRIPTION
## What does this change?

We no longer install `urllib3`, `pyOpenSSL`, `ndg-httpsclient` and `pyasn1` as part of the Docker role. The installation of these Python dependencies has been causing [recent bakes to fail](https://amigo.gutools.co.uk/recipes/teamcity-agent/bakes/148). More specifically, I think that the failure occurs because a transitive dependency for `ndg-httpsclient` [dropped support for Python 2.x recently](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#34---2021-02-07).

It wasn't clear to me why these packages were needed, so I tried removing them and everything still seems to work 🤷‍♂️ 

## How to test

Testing done: 

1. Created a [copy](https://amigo.code.dev-gutools.co.uk/recipes/teamcity-agent-jw) of the [`teamcity-agent` recipe](https://amigo.gutools.co.uk/recipes/teamcity-agent) in `CODE`, which makes use of this updated role
1. Baked a [new AMI](https://amigo.code.dev-gutools.co.uk/recipes/teamcity-agent-jw/bakes/2)
1. Launched a [build agent](https://teamcity.gutools.co.uk/agentDetails.html?id=21360&agentTypeId=498&realAgentName=Test%20New%20TeamCity%20Agent%20AMI-i-0430dd61dceca914c) using the new AMI
1. Ran a [build which uses Docker,](https://teamcity.gutools.co.uk/viewLog.html?buildId=629168&buildTypeId=Apps_Android_AndroidNewsAppMasterTest) confirmed that it passed as expected

## How can we measure success?

* We can bake `teamcity-agent` AMIs again successfully
* The new agents still run builds which make use of Docker correctly

## Have we considered potential risks?

* I don't really understand why these packages were needed... perhaps we'll find out there was a very good reason for installing them!