### PR TITLE
Revert "Prevent AMIgo housekeeping from removing TeamCity AMIs"

### DIFF
--- a/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
+++ b/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
@@ -22,17 +22,10 @@ object MarkOldUnusedBakesForDeletion {
       val duration = new Duration(bake.startedAt, now)
       duration.getStandardDays > MAX_AGE
     }
-
-    // Exclude TeamCity Agent AMIs, which have been incorrectly assumed to be unused in the past. This happens
-    // because TeamCity Agents are typically terminated overnight and are not linked to a launch configuration.
-    val oldBakesExcludingTeamCityAgents = oldBakes.filterNot { bake =>
-      bake.recipe.id.value == "teamcity-agent"
-    }
-
-    val recipeUsage = getRecipeUsage(oldBakesExcludingTeamCityAgents)
+    val recipeUsage = getRecipeUsage(oldBakes)
     val usedBakes = recipeUsage.bakeUsage.map(_.bake).distinct.toSet
 
-    oldBakesExcludingTeamCityAgents -- usedBakes
+    oldBakes -- usedBakes
   }
 }
 

--- a/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
+++ b/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
@@ -57,14 +57,4 @@ class MarkOldUnusedBakesForDeletionSpec extends FlatSpec with Matchers {
     markedBakes.size shouldEqual 1
     markedBakes.map(_.bakeId) shouldEqual Set(BakeId(RecipeId("recipe-1"), 1))
   }
-
-  it should "not include TeamCity agent AMIs, even if they are old" in {
-    val housekeepingDate = new DateTime(2018, 7, 12, 0, 0, 0, DateTimeZone.UTC)
-    val recipeIds = Set(RecipeId("teamcity-agent"))
-    val oldTeamCityAgent = fixtureBake(fixtureRecipe("teamcity-agent", oldDate), Some(AmiId("ami-1")), oldDate)
-    def getBakesWithTeamCityAgent(recipeId: RecipeId): Iterable[Bake] = Iterable(oldTeamCityAgent)
-    val markedBakes = MarkOldUnusedBakesForDeletion.getOldUnusedBakes(recipeIds, housekeepingDate, getBakesWithTeamCityAgent, getEmptyRecipeUsage)
-
-    markedBakes.size shouldEqual 0
-  }
 }


### PR DESCRIPTION
Reverts guardian/amigo#553.

https://github.com/guardian/amigo/pull/554 fixes baking for the [`teamcity-agent` recipe](https://amigo.gutools.co.uk/recipes/teamcity-agent) and I have updated all TeamCity agents to use a new AMI. 

Consequently, I think it's safe to revert this (as long as we remember to regularly update the AMI associated with our Cloud Profile going forwards). Alternatively, we could leave this hack in until we have a proper (i.e. automated) solution for updating the TeamCity agent AMI. What do you think @philmcmahon? 