### PR TITLE
Add AWS Java 11 (Corretto)

### DIFF
--- a/roles/java11corretto/README.md
+++ b/roles/java11corretto/README.md
@@ -1,0 +1,6 @@
+Java 11 Corretto
+================
+
+This is the AWS flavour of the JVM for which support is provided via AWS enterprise agreements.
+
+This role installs the JDK and also modifies the default DNS cache control to cache for 30s instead of forever.

--- a/roles/java11corretto/meta/main.yml
+++ b/roles/java11corretto/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - role: apt
+    when: ansible_os_family == "Debian"

--- a/roles/java11corretto/spec/java11_spec.rb
+++ b/roles/java11corretto/spec/java11_spec.rb
@@ -1,0 +1,4 @@
+
+describe command('java -version') do
+  its(:stdout) { should match /java version "11\..*/ }
+end

--- a/roles/java11corretto/tasks/main.yml
+++ b/roles/java11corretto/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Add AWS Corretto signing key
+  apt_key:
+    url: "https://apt.corretto.aws/corretto.key"
+    state: present
+
+- name: Add AWS Corretto repo
+  apt_repository:
+    repo: 'deb https://apt.corretto.aws stable main'
+    state: present
+
+- name: Install Java 11 Corretto JDK
+  apt:
+    name:
+    - java-11-amazon-corretto-jdk
+    state: latest
+  when: ansible_os_family == "Debian"
+
+## This modifies the JVM's DNS cache TTL, changing it from the default of INFINITY to 60
+## seconds. See this issue for full details: https://github.com/guardian/amigo/issues/238
+- name: Change JVM DNS cache TTL
+  replace:
+    path: /usr/lib/jvm/java-11-amazon-corretto/conf/security/java.security
+    regexp: '#networkaddress.cache.ttl=.*'
+    replace: 'networkaddress.cache.ttl=60'
+    backup: yes
+  when: ansible_os_family == "Debian"
+


### PR DESCRIPTION
## What does this change?
This adds an alternative Java11 distribution (AWS's Corretto). The advantage of this distribution over OpenJDK is that AWS provide support if we have issues with it. This is of particular interest right now as we are having performance issues as we migrate applications onto ARM64.

## How to test
I've tested that this role builds in CODE. If you install this then `java -version` should return a Corretto runtime.

## How can we measure success?
Switching to use this might reduce CPU usage if it is better optimised for Graviton than OpenJDK. If it doesn't then we can raise a support ticket.

## Have we considered potential risks?
This distribution has better commercial support than the OpenJDK so the risks should be reduced.
