### PR TITLE
Support version pinning for nginx-extras and fluentbit roles

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision :shell, path: "bootstrap.sh"
 
   config.vm.provision "ansible_local" do |ansible|
-    ansible.install_mode = "pip" # Ubuntu is fine without that. Redhat prefers it.
+    ansible.install_mode = "pip3"
     ansible.verbose = "v" # or "vv", "vvv", "vvvv"
     ansible.playbook = "playbook.yaml"
     ansible.extra_vars = "extra-vars.yaml"

--- a/roles/fluentbit/README.md
+++ b/roles/fluentbit/README.md
@@ -7,9 +7,10 @@ manual](https://docs.fluentbit.io/manual/) provides a good overview.
 
 ## Configure role
 
-    ubuntu_version: xenial | bionic | focal
+    version: 1.7.2. # for example, defaults to 'newest'
+    ubuntu_version: xenial | bionic | focal # defaults to bionic
 
-The default is `bionic` but we recommend you set this var explicitly in Amigo.
+We recommend you set both vars explicitly in Amigo.
 
 ## On your instance...
 

--- a/roles/fluentbit/defaults/main.yml
+++ b/roles/fluentbit/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
+version: newest
 ubuntu_version: bionic

--- a/roles/fluentbit/tasks/main.yml
+++ b/roles/fluentbit/tasks/main.yml
@@ -9,5 +9,5 @@
 
 - name: Install
   apt:
-    name: td-agent-bit
+    name: td-agent-bit={{version}}
     update_cache: yes

--- a/roles/nginx-extras/README.md
+++ b/roles/nginx-extras/README.md
@@ -1,0 +1,7 @@
+# nginx-extras
+
+Installs the `nginx` and `nginx-extras` packages.
+
+Defaults to newest. You can set the `version` variable to pin (recommended for
+production). For available versions, see (e.g. for Bionic):
+https://packages.ubuntu.com/bionic/nginx.

--- a/roles/nginx-extras/tasks/main.yml
+++ b/roles/nginx-extras/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: Install nginx and nginx-extras
   apt:
     name:
-    - nginx
-    - nginx-extras
+      - nginx={{version | default('newest') }}
+      - nginx-extras={{version | default('newest') }}
     state: present
 
 - name: remove default site from sites-enabled


### PR DESCRIPTION
Introduces a `version` var for both roles to allow pinning.

Also some other minor tidyp (a README for the nginx-extras role as it should have one) and a fix for the Vagrant setup on Python versioning.