### PR TITLE
Replace ec2metadata with native calls

### DIFF
--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Get region
   shell: |
-    ec2metadata --availability-zone | sed 's/.$//'
+    curl -s -H "X-aws-ec2-metadata-token: `curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`" http://169.254.169.254/latest/meta-data/placement/availability-zone |  sed 's/.$//'
   register: aws_region
 
 - name: Bring in ssm script
@@ -76,8 +76,8 @@
       if [ -f "/var/ossec/etc/authd.pass" ]; then
         MANAGER_ADDRESS="{{ manager_address.stdout }}"
 
-        REGION=`ec2metadata --availability-zone | sed 's/.$//'`
-        INSTANCE_ID=`ec2metadata --instance-id`
+        REGION=$(curl -s -H "X-aws-ec2-metadata-token: `curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`" http://169.254.169.254/latest/meta-data/placement/availability-zone |  sed 's/.$//')
+        INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: `curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`" http://169.254.169.254/latest/meta-data/instance-id)
 
         ASG_NAME=$(aws autoscaling describe-auto-scaling-instances --region "$REGION" --instance-ids "$INSTANCE_ID" --output text --query "AutoScalingInstances[0].AutoScalingGroupName" || true)
 


### PR DESCRIPTION
## What does this change?

This PR replaces `ec2metadata` calls with direct curl calls to the instance metadata service.

### Why?

`ec2metadata` only works with IMDSv1, which some of our ec2 instances have blocked in favour of IMDSv2. Here's some detective work I did

* `ec2metadata` was originally a bash script published by amazon in `s3://ec2metadata/ec2-metadata` (really)
*  It was rewritten in python and made available for ubuntu distribution in the package `cloud-guest-utils`, which we install as part of the `useful-packages` recipe.
* Neither of these supports IMDSv2
* The ubuntu equivalent of a PR was opened in 2020 and it's been sitting there unmerged ever since https://bugs.launchpad.net/ubuntu/+source/cloud-utils/+bug/1882389
* According to the documentation we should be querying the service directly. Amazon seemed to have disowned `ec2metadata`, I can't find any mention of it in their docs https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html


## How to test
Should do a bake in CODE and use it somehow?

## How can we measure success?
Mobile will be able to use the wazuh-agent role now!

## Have we considered potential risks?
Some! This patch specifically uses the IMDSv2 API calls. If one of our servers has it blocked in favour of v1, I suppose this will fail. From what I gather, this isn't exactly possible

The CLI command to control this is [modify-instance-metadata-options](https://docs.aws.amazon.com/cli/latest/reference/ec2/modify-instance-metadata-options.html). The options available are enable/disable the endpoint itself, and making tokens optional/required. So it's either completely unavailable, IMDSv1 and 2, or just IMDSv2.

I think (famous later words)
