### PR TITLE
Install arm64 version of docker when on arm64 architecture.

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -32,6 +32,11 @@
 
 - name: Add docker.io repo
   apt_repository: repo='deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_lsb.codename }} stable' state=present
+  when: ansible_architecture == "x86_64"
+
+- name: Add docker.io repo
+  apt_repository: repo='deb [arch=arm64] https://download.docker.com/linux/ubuntu {{ ansible_lsb.codename }} stable' state=present
+  when: ansible_architecture == "aarch64"
 
 - name: Install docker
   apt:


### PR DESCRIPTION
This does what is says on the tin - sets up the docker role to install the correct version of docker-ce based off the current architecture.

How to test
========
Deploy to Amigo CODE, run the teamcity-agent recipe (or any recipe that uses docker): amigo.code.dev-gutools.co.uk/