### PR TITLE
Add end of life date to base images 

### DIFF
--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -215,7 +215,7 @@ class AppComponents(context: Context)
   val debugAvailable = identity.stage != "PROD"
 
   val rootController = new RootController(googleAuthConfig)
-  val baseImageController = new BaseImageController(googleAuthConfig, messagesApi)
+  val baseImageController = new BaseImageController(googleAuthConfig, messagesApi, prismAgents)
   val housekeepingController = new HousekeepingController(googleAuthConfig)
   val roleController = new RoleController(googleAuthConfig)
   val recipeController = new RecipeController(bakeScheduler, prismAgents, googleAuthConfig, messagesApi, debugAvailable)

--- a/app/data/BaseImages.scala
+++ b/app/data/BaseImages.scala
@@ -15,22 +15,23 @@ object BaseImages {
     amiId: AmiId,
     builtinRoles: List[CustomisedRole],
     createdBy: String,
-    linuxDist: LinuxDist)(implicit dynamo: Dynamo): BaseImage = {
+    linuxDist: LinuxDist, eolDate: Option[DateTime])(implicit dynamo: Dynamo): BaseImage = {
     val now = DateTime.now()
-    val baseImage = BaseImage(id, description, amiId, builtinRoles, createdBy, createdAt = now, modifiedBy = createdBy, modifiedAt = now, Some(linuxDist))
+    val baseImage = BaseImage(id, description, amiId, builtinRoles, createdBy, createdAt = now, modifiedBy = createdBy, modifiedAt = now, Some(linuxDist), eolDate)
 
     table.put(baseImage).exec()
     baseImage
   }
 
-  def update(baseImage: BaseImage, description: String, amiId: AmiId, linuxDist: LinuxDist, builtinRoles: List[CustomisedRole], modifiedBy: String)(implicit dynamo: Dynamo): Unit = {
+  def update(baseImage: BaseImage, description: String, amiId: AmiId, linuxDist: LinuxDist, builtinRoles: List[CustomisedRole], modifiedBy: String, eolDate: DateTime)(implicit dynamo: Dynamo): Unit = {
     val updated = baseImage.copy(
       description = description,
       amiId = amiId,
       linuxDist = Some(linuxDist),
       builtinRoles = builtinRoles,
       modifiedBy = modifiedBy,
-      modifiedAt = DateTime.now()
+      modifiedAt = DateTime.now(),
+      eolDate = Some(eolDate)
     )
     table.put(updated).exec()
   }

--- a/app/data/BaseImages.scala
+++ b/app/data/BaseImages.scala
@@ -15,7 +15,8 @@ object BaseImages {
     amiId: AmiId,
     builtinRoles: List[CustomisedRole],
     createdBy: String,
-    linuxDist: LinuxDist, eolDate: Option[DateTime])(implicit dynamo: Dynamo): BaseImage = {
+    linuxDist: LinuxDist,
+    eolDate: Option[DateTime])(implicit dynamo: Dynamo): BaseImage = {
     val now = DateTime.now()
     val baseImage = BaseImage(id, description, amiId, builtinRoles, createdBy, createdAt = now, modifiedBy = createdBy, modifiedAt = now, Some(linuxDist), eolDate)
 

--- a/app/views/baseImages.scala.html
+++ b/app/views/baseImages.scala.html
@@ -16,12 +16,14 @@
     <thead>
       <th>Name</th>
       <th>Description</th>
+      <th>Status</th>
     </thead>
     <tbody>
     @for(image <- images.toList.sortBy(_.id.value.toLowerCase)) {
       <tr>
         <td class="has-block-link"><a href="@routes.BaseImageController.showBaseImage(image.id)" class="block-link">@image.id</a></td>
         <td class="has-block-link"><a href="@routes.BaseImageController.showBaseImage(image.id)" class="block-link">@image.description</a></td>
+        <td class="has-block-link"><a href="@routes.BaseImageController.showBaseImage(image.id)" class="block-link">@fragments.eolStatus(image)</a></td>
       </tr>
     }
     </tbody>

--- a/app/views/editBaseImage.scala.html
+++ b/app/views/editBaseImage.scala.html
@@ -9,7 +9,15 @@
     @b3.text( form("amiId"), '_label -> "AMI ID", 'placeholder -> "ami-a1b2c3d4" )
     @b3.select( form("linuxDist"), models.LinuxDist.all.toList.map{ case (k,v) => k -> v.name }, '_label -> "Linux Distribution" )
     @b3.textarea( form("description"), '_label -> "Description" )
-
+    <div class="row">
+      <div class="col-md-1"></div>
+    <div class="col-md-6">
+    @b3.date(form("eolDate"), '_label-> "End of Life Date")
+    </div>
+      <div class="col-md-3">
+    <p>(Find Ubuntu support info <a href="https://wiki.ubuntu.com/Releases" target="_blank">here</a>)</p>
+      </div>
+    </div>
     <div class="form-group">
       <label class="control-label col-md-2" for="builtin-roles">Builtin roles</label>
       <div class="col-md-10" id="builtin-roles">

--- a/app/views/fragments/eolStatus.scala.html
+++ b/app/views/fragments/eolStatus.scala.html
@@ -1,0 +1,7 @@
+@(image: BaseImage)
+
+@BaseImage.eolStatus(image) match {
+    case Supported => { <span class="label label-success">Supported</span> }
+    case EndOfLife => { <span class="label label-error">End of Life</span> }
+    case EndOfLifeSoon => { <span class="label label-warning">End of Life Soon</span> }
+}

--- a/app/views/fragments/usagesColumn.scala.html
+++ b/app/views/fragments/usagesColumn.scala.html
@@ -1,0 +1,15 @@
+@(
+    recipe: Recipe,
+    usages: Map[Recipe, prism.RecipeUsage]
+)
+
+@defining(usages.getOrElse(recipe, prism.RecipeUsage.noUsage)) { usage =>
+    <td class="recipe-usage" title="Used in @usage.instances.size instance@if(usage.instances.size != 1) {s} and @usage.launchConfigurations.size launch configuration@if(usage.launchConfigurations.size != 1) {s}">
+        <a href="@routes.RecipeController.showUsages(recipe.id)">
+            <img src="@routes.Assets.versioned("images/computer.svg")" width="16" alt="Instances" />
+            <span>@usage.instances.size</span>
+            <img src="@routes.Assets.versioned("images/spanner.svg")" width="14" alt="Launch Configurations" />
+            <span>@usage.launchConfigurations.size</span>
+        </a>
+    </td>
+}

--- a/app/views/newBaseImage.scala.html
+++ b/app/views/newBaseImage.scala.html
@@ -9,6 +9,8 @@
     @b3.text( form("amiId"), '_label -> "AMI ID", 'placeholder -> "ami-a1b2c3d4" )
     @b3.select( form("linuxDist"), models.LinuxDist.all.toList.map{ case (k,v) => k -> v.name }, '_label -> "Linux Distribution" )
     @b3.textarea( form("description"), '_label -> "Description" )
+    @b3.date(form("eolDate"), '_label-> "End of Life Date")
+    <p>(Find Ubuntu support info <a href="https://wiki.ubuntu.com/Releases">here</a></p>
 
     <div class="form-group">
       <label class="control-label col-md-2" for="builtin-roles">Builtin roles</label>

--- a/app/views/recipes.scala.html
+++ b/app/views/recipes.scala.html
@@ -20,22 +20,15 @@
       <th>Name</th>
       <th>Description</th>
       <th>Usage</th>
+      <th>Status</th>
     </thead>
     <tbody>
     @for(recipe <- recipes.toList.sortBy(_.id.value.toLowerCase)) {
-      <tr>
+      <tr class="@BaseImage.eolStatusClass(recipe.baseImage)">
         <td class="has-block-link"><a href="@routes.RecipeController.showRecipe(recipe.id)" class="block-link">@recipe.id</a></td>
         <td class="has-block-link"><a href="@routes.RecipeController.showRecipe(recipe.id)" class="block-link">@recipe.description</a></td>
-         @defining(usages.getOrElse(recipe, prism.RecipeUsage.noUsage)) { usage =>
-        <td class="recipe-usage" title="Used in @usage.instances.size instance@if(usage.instances.size != 1){s} and @usage.launchConfigurations.size launch configuration@if(usage.launchConfigurations.size != 1){s}">
-            <a href="@routes.RecipeController.showUsages(recipe.id)">
-              <img src="@routes.Assets.versioned("images/computer.svg")" width="16" alt="Instances" />
-              <span>@usage.instances.size</span>
-              <img src="@routes.Assets.versioned("images/spanner.svg")" width="14" alt="Launch Configurations" />
-              <span>@usage.launchConfigurations.size</span>
-            </a>
-        </td>
-        }
+        @fragments.usagesColumn(recipe, usages)
+        <td>@fragments.eolStatus(recipe.baseImage) </td>
       </tr>
     }
     </tbody>

--- a/app/views/showBaseImage.scala.html
+++ b/app/views/showBaseImage.scala.html
@@ -1,5 +1,5 @@
 @import data.Roles
-@(image: BaseImage, allRoles: Seq[RoleSummary], usedByRecipes: Seq[Recipe], cloneForm: Form[_])(implicit flash: Flash, messages: play.api.i18n.Messages)
+@(image: BaseImage, allRoles: Seq[RoleSummary], usedByRecipes: Seq[Recipe], cloneForm: Form[_], usages: Map[Recipe, prism.RecipeUsage])(implicit flash: Flash, messages: play.api.i18n.Messages)
 
 @implicitFieldConstructor = @{ b3.inline.fieldConstructor }
 
@@ -31,6 +31,7 @@
     <div class="panel-body">
       <p>Created @fragments.timestamp(image.createdAt, image.createdBy)</p>
       <p>Modified @fragments.timestamp(image.modifiedAt, image.modifiedBy)</p>
+      @image.eolDate.map{eolDate => <p class="@BaseImage.eolStatusClass(image)">End of Life @eolDate.toString("dd/MM/yyyy")</p>}
       <p>@image.description</p>
     </div>
   </div>
@@ -57,11 +58,14 @@
         This base image is not used by any recipe
       } else {
         This base image is used by the following recipes:
-        <ul>
+        <table class="table">
         @usedByRecipes.map { recipe =>
-          <li><a href="@routes.RecipeController.showRecipe(recipe.id)">@recipe.id</a></li>
+          <tr>
+            <td><a href="@routes.RecipeController.showRecipe(recipe.id)">@recipe.id</a></td>
+            @fragments.usagesColumn(recipe, usages)
+          </tr>
         }
-        </ul>
+        </table>
       }
     </div>
   </div>

--- a/app/views/showRecipe.scala.html
+++ b/app/views/showRecipe.scala.html
@@ -58,6 +58,7 @@
           Search GitHub for usage
         </a>
       </p>
+      <p class="@BaseImage.eolStatusClass(recipe.baseImage)">@BaseImage.eolStatusString(recipe.baseImage)</p>
     </div>
   </div>
 

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -103,3 +103,11 @@ td.recipe-usage {
 .role-usage {
     margin-top: 34px;
 }
+
+.end-of-life {
+    background: repeating-linear-gradient(45deg, #fcd7d7, #fcd7d7 10px, #dddddd 10px, #dddddd 20px)
+}
+
+.end-of-life-soon {
+    background: repeating-linear-gradient(45deg, #ffd9b3,  #ffd9b3 10px, #dddddd 10px, #dddddd 20px)
+}

--- a/test/data/PackageListTest.scala
+++ b/test/data/PackageListTest.scala
@@ -1,13 +1,13 @@
 package data
 
-import models.{BakeId, RecipeId}
-import org.scalatest.{FlatSpec, Matchers}
+import models.{ BakeId, RecipeId }
+import org.scalatest.{ FlatSpec, Matchers }
 
 class PackageListTest extends FlatSpec with Matchers {
 
   "s3Url" should "return valid S3 url of expected pattern" in {
     val url = PackageList.s3Url(BakeId(RecipeId("cauldron-cake"), 1), "mr-hole")
-    url should be ("s3://mr-hole/packagelists/cauldron-cake--1.txt")
+    url should be("s3://mr-hole/packagelists/cauldron-cake--1.txt")
   }
 
   "removeNonPackageLines" should "remove redundant output" in {
@@ -18,6 +18,6 @@ class PackageListTest extends FlatSpec with Matchers {
     )
     val removed = PackageList.removeNonPackageLines(packageList)
     removed.head should be("p1")
-    removed.length should be (2)
+    removed.length should be(2)
   }
 }

--- a/test/models/BakeIdTest.scala
+++ b/test/models/BakeIdTest.scala
@@ -1,16 +1,16 @@
 package models
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{ FlatSpec, Matchers }
 
 class BakeIdTest extends FlatSpec with Matchers {
 
   "toFilename" should "produce expected filename" in {
     val bakeId = BakeId(RecipeId("puking-pastilles"), 1)
-    BakeId.toFilename(bakeId) should be ("puking-pastilles--1.txt")
+    BakeId.toFilename(bakeId) should be("puking-pastilles--1.txt")
   }
 
   "toMetadata" should "produce valid metadata" in {
     val bakeId = BakeId(RecipeId("nosebleed-nougat"), 1)
-    BakeId.toMetadata(bakeId) should be ("Recipe=nosebleed-nougat,BuildNumber=1")
+    BakeId.toMetadata(bakeId) should be("Recipe=nosebleed-nougat,BuildNumber=1")
   }
 
 }

--- a/test/models/BaseImageTest.scala
+++ b/test/models/BaseImageTest.scala
@@ -1,0 +1,28 @@
+package models
+
+import org.joda.time.DateTime
+import org.scalatest.{ FlatSpec, Matchers }
+
+class BaseImageTest extends FlatSpec with Matchers {
+
+  def makeBaseImage(eolDate: DateTime): BaseImage =
+    BaseImage(
+      BaseImageId("discworld-image"),
+      "deteriorated cabbage",
+      AmiId("ami-123"),
+      List(),
+      "Detritus",
+      DateTime.now,
+      "Rincewind",
+      DateTime.now, None, Some(eolDate))
+
+  "eolStatus" should "determinee correct eol status" in {
+    val baseImageLongSupport = makeBaseImage(DateTime.now.plusMonths(24))
+    val baseImageExpiresSoon = makeBaseImage(DateTime.now.plusMonths(1))
+    val baseImageExpired = makeBaseImage(DateTime.now.minusMonths(1))
+    BaseImage.eolStatus(baseImageLongSupport) should be(Supported)
+    BaseImage.eolStatus(baseImageExpiresSoon) should be(EndOfLifeSoon)
+    BaseImage.eolStatus(baseImageExpired) should be(EndOfLife)
+  }
+
+}


### PR DESCRIPTION
## What does this change?
This PR aims to help prepare us for ubuntu Xenial being deprecated at the end of this month. It adds warning colours and labels next to Recipes and AMI's that are using a base image which is due to expire soon.

To make this work I've added a new property to the `BaseImage` case class and associated forms  - eolDate. Play Forms provides an adequate date picker for this purpose, it could be prettier but does  the job.

Most of the rest of the changes are to the views in order to expose this information. The CSS isn't super pretty (I copied it from riffraff) but given that our aim is to have zero images that are EOL soon I think it's probably fine to look a bit ugly.

Once this change is live we'll need to manually go through the existing base images and add an eolDate to them all. A link is provided in the UI to the ubuntu releases page to help with this. 

The different views where the eolDate is exposed look like this:
<img width="1102" alt="Screenshot 2021-04-14 at 18 42 09" src="https://user-images.githubusercontent.com/3606555/114847773-fb9e9100-9dd5-11eb-95aa-1c8e78556716.png">
<img width="446" alt="Screenshot 2021-04-14 at 18 17 41" src="https://user-images.githubusercontent.com/3606555/114847779-fccfbe00-9dd5-11eb-9d04-58a86c673da6.png">
<img width="1167" alt="Screenshot 2021-04-14 at 18 17 33" src="https://user-images.githubusercontent.com/3606555/114847782-fd685480-9dd5-11eb-94cc-7397507285fb.png">

Finally, this change also makes recipe usages information (i.e. whether a recipe is used by any instances or launch configs) available in the 'show bake' view - so you can see at a glance whether a base image is in use anywhere:

<img width="1086" alt="Screenshot 2021-04-15 at 10 36 16" src="https://user-images.githubusercontent.com/3606555/114848268-6fd93480-9dd6-11eb-9762-bffa2f158c91.png">

## How to test
This is currently live on CODE: amigo.code.dev-gutools.co.uk/

