### PR TITLE
Add exit code 143 as success exit code for teamcity agent

### DIFF
--- a/roles/teamcity-agent/files/teamcityagent.service
+++ b/roles/teamcity-agent/files/teamcityagent.service
@@ -15,5 +15,8 @@ Type=forking
 PIDFile=/opt/teamcity/buildAgent/logs/buildAgent.pid
 RemainAfterExit=yes
 
+# agent will exit with 143 during upgrade process
+SuccessExitStatus=143 0
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I'm trying to get teamcity to work on ubuntu bionic. Currently the bionic AMI starts up, registers with teamcity, realises it needs to upgrade then shuts down to prepare for the upgrade then gets stuck. This issue is discussed here https://stackoverflow.com/questions/12483230/teamcity-build-agent-wont-upgrade/25393243

This PR should solve this issue by adding exit code 143 as a success exit code. 

How to test
========
Merge this change, bake a new teamcity ami, add it to the cloud profile (there is a 'test teamcity' profile within the default one), spin up an agent and verify that it succesfully starts up.

Risks
====
None as far as I can think of, other than 143 turning out to be 'critical error please don't start me again' - which would be odd to use for that as well as for the upgrade restart code!