### PR TITLE
Add support for single instance configs

### DIFF
--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -87,6 +87,17 @@
         STACK=$(aws autoscaling $ARGS --query "AutoScalingGroups[0].Tags[?Key == 'Stack'].Value" || true)
         STAGE=$(aws autoscaling $ARGS --query "AutoScalingGroups[0].Tags[?Key == 'Stage'].Value" || true)
 
+        if [ -z "$APP" ] || [ "$APP" == "None"  ]; then
+              echo "Failed to fetch ASG tags, fetching instance tags instead"
+              FILTERS="Name=resource-id,Values=$INSTANCE_ID Name=resource-type,Values=instance"
+              OPTIONS="--query Tags[].Value --output text --region $REGION"
+              APP=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=App $OPTIONS || true)
+              STACK=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stack $OPTIONS || true)
+              STAGE=$(aws ec2 describe-tags --filters $FILTERS Name=key,Values=Stage $OPTIONS || true)
+        else
+              echo "Successfully fetched ASG tags"
+        fi
+
         cp /var/ossec/etc/ossec.conf /var/ossec/etc/ossec.conf.bak
 
         sed -i "s/MANAGER_IP/$MANAGER_ADDRESS/" /var/ossec/etc/ossec.conf


### PR DESCRIPTION
## What does this change?
This makes the wazuh registration script try to fetch tags from the instance if the result from the ASG fetch is an empty string or the word "None". This will cover single instances, but ends up also covering if an instance only has permission to query its own tags and now its ASG ones.

## How to test
Writing an if statement in bash is a known high risk situation. I've actually tested this code by running it
- In a single instance
- In an instance in an ASG without asg:describeTags, but with ec2:describeTags
- In an instance in an ASG with asg:describeTags

For completeness' sake, it would be worth baking an image in amigo CODE and then launching it somewhere to see it running end to end. I'll do that before merging for sure

## How can we measure success?
The single instance that cannot currently connect to wazuh will indeed connect

## Have we considered potential risks?
There's over 500 servers relying on this code. If this is broken, next time they deploy the wazuh agent will fail to connect
