### PR TITLE
Disable systemd DNS on teamcity

### DIFF
--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -90,6 +90,11 @@
   systemd:
     name: teamcityagent
     enabled: yes
+
+# this fixes an issue with running docker on ubuntu bionic, see here for details: https://github.com/moby/libnetwork/issues/2187
+- name: disable systemd as default ddns server
+  shell: ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
+
 - name: SBT
   include: sbt.yml
 - name: ".aws Cleanup Script"


### PR DESCRIPTION
## What does this change?

This disables [systemd-resolved](http://manpages.ubuntu.com/manpages/bionic/man8/systemd-resolved.service.8.html) as the default DNS resolver on teamcity-agent. Systemd resolved was introduced in ubuntu bionic, and is causing problems for docker containers running on teamcity.

The Systemd dns resolver modifies  /etc/resolve.conf - which is also consumed by docker. Docker doen't understand the local IP address systemd generates (as it's only accessible on the host) and so switches to using google's DNS servers (8.8.8.8). This fails (I think) because the agents are in a private subnet.

 For a massive discussion of this bug see [this github thread](https://github.com/moby/libnetwork/issues/2187#issuecomment-403372190) - which also includes the solution I copy pasted 🥳 

## Testing
I've tested this on AMIgo code, baked an AMI and checked a build that was previously broken on bionic teamcity agent AMI. 

## How can we measure success?
Bionic can be used on teamcity agents
