### PR TITLE
Fix reading of friendly hostnames file for Bionic

### DIFF
--- a/roles/friendly-hostnames/files/set-hostname.sh
+++ b/roles/friendly-hostnames/files/set-hostname.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-FRIENDLY_HOSTNAME=`iconv -f utf8 -t ascii//TRANSLIT /opt/features/friendly-hostnames/hostnames.txt | sed s/[^A-Za-z]*//g | awk 'length>4 && length<30' | shuf -n 1`
+FRIENDLY_HOSTNAME=`iconv -c -f utf8 -t ascii//TRANSLIT /opt/features/friendly-hostnames/hostnames.txt | sed s/[^A-Za-z]*//g | awk 'length>4 && length<30' | shuf -n 1`
 
 echo "Chosen hostname=$FRIENDLY_HOSTNAME"
 


### PR DESCRIPTION
[This role](https://amigo.gutools.co.uk/roles#friendly-hostnames) failed when trying to generate a new id using the hostnames.txt file, giving the following error on Ubuntu Bionic:

```
iconv: illegal input sequence at position 0
```

Ubuntu Bionic has iconv version 2.27, while Xenial is 2.23. Bionic has a version of iconv that is seemingly stricter with invalid character encoding so this fix skips over invalid ones:

```
Output control:
  -c                         omit invalid characters from output
```