### PR TITLE
Install Java 8 and Java 11 on teamcity-agent

### DIFF
--- a/roles/teamcity-agent/meta/main.yml
+++ b/roles/teamcity-agent/meta/main.yml
@@ -9,3 +9,5 @@ dependencies:
       - zip
   - role: pip-packages 
     packages: [boto3, botocore]
+  - role: java8
+  - role: java11corretto

--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -91,9 +91,13 @@
     name: teamcityagent
     enabled: yes
 
+
 # this fixes an issue with running docker on ubuntu bionic, see here for details: https://github.com/moby/libnetwork/issues/2187
 - name: disable systemd as default ddns server
   shell: ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
+
+- name: set default java version # to get available versions run update-alternatives --list java
+  shell: update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 - name: SBT
   include: sbt.yml

--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -95,10 +95,9 @@
 - name: disable systemd as default ddns server
   shell: ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 
-- name: set default java version # to get available versions run update-alternatives --list java
+- name: set default java version # to get available versions run `update-java-alternatives --list`
   shell: |
-    update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
-    update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
+    update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-amd64
 
 
 - name: SBT

--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -96,9 +96,7 @@
   shell: ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 
 - name: set default java version # to get available versions run `update-java-alternatives --list`
-  shell: |
-    update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-amd64
-
+  shell: update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-amd64
 
 - name: SBT
   include: sbt.yml

--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -91,13 +91,15 @@
     name: teamcityagent
     enabled: yes
 
-
 # this fixes an issue with running docker on ubuntu bionic, see here for details: https://github.com/moby/libnetwork/issues/2187
 - name: disable systemd as default ddns server
   shell: ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 
 - name: set default java version # to get available versions run update-alternatives --list java
-  shell: update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+  shell: |
+    update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+    update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
+
 
 - name: SBT
   include: sbt.yml


### PR DESCRIPTION
## What does this change?
This adds java8 and java11corretto as dependencies of the teamcity agent role, then adds a step to the agent role to set the default  java version, using [update-alternatives](https://linux.die.net/man/8/update-alternatives) to java8.

This will allow teams to optionall build stuff with Java 11 on teamcity.

Unfortunately, the SBT runner appears to ignore the java version set by update-alternatives. When I ssh onto a box and run `java -version` the correct version is returned, but sbt runner builds, which are set to <default> java (`JAVA_HOME environment variable or the agent's own Java.`) end up using java11.

In order to work round this issue, I think I will need to set a global JAVA_HOME environment variable in teamcity which people can optionally override. I am open to alternative suggestions though. I think it makes sense to do this in teamcity rather than in the teamcity-agent role so that it's obvious to everyone without having to open up amigo. 

## How to test
I have tested this role on the amigo project in teamcity, which uses the sbt runner and noticed the above behaviour. I also tried on prism, which uses a build bash script and noticed that it built with java 8.
