### PR TITLE
Don't try and set plugin alternatives for java

### DIFF
--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -96,7 +96,7 @@
   shell: ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 
 - name: set default java version # to get available versions run `update-java-alternatives --list`
-  shell: update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-amd64
+  shell: update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-amd64 --jre-headless --jre
 
 - name: SBT
   include: sbt.yml

--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -96,7 +96,9 @@
   shell: ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 
 - name: set default java version # to get available versions run `update-java-alternatives --list`
-  shell: update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-amd64 --jre-headless --jre
+  shell: |
+    update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+    update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
 
 - name: SBT
   include: sbt.yml


### PR DESCRIPTION
## What does this change?
This modifies the teamcity agent role so that it doesn't use update-java-alternatives, as this fails  with the error below

```
sudo update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-amd64
update-alternatives: error: no alternatives for mozilla-javaplugin.so
update-java-alternatives: plugin alternative does not exist: /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/IcedTeaPlugin.so
```

## How to test
Run an amigo bake on code then cmd+f the build log for `update-alternatives`

## How can we measure success?
Java 8 becomes default  version on teamcity AMIs.
