### PR TITLE
Show unused recipes separately

### DIFF
--- a/app/controllers/BaseImageController.scala
+++ b/app/controllers/BaseImageController.scala
@@ -24,8 +24,9 @@ class BaseImageController(
   def showBaseImage(id: BaseImageId) = AuthAction { implicit request =>
     BaseImages.findById(id).fold[Result](NotFound) { image =>
       val usedByRecipes = Recipes.findByBaseImage(id)
-      val usages: Map[Recipe, RecipeUsage] = RecipeUsage.forAll(usedByRecipes, findBakes = recipeId => Bakes.list(recipeId))(prismAgents)
-      Ok(views.html.showBaseImage(image, Roles.list, usedByRecipes.toSeq, Forms.cloneBaseImage, usages))
+      val usages: Map[Recipe, RecipeUsage] = RecipeUsage.getUsagesMap(usedByRecipes)(prismAgents, dynamo)
+      val (usedRecipes, unusedRecipes) = usedByRecipes.partition(r => RecipeUsage.hasUsage(r, usages))
+      Ok(views.html.showBaseImage(image, Roles.list, usedRecipes.toSeq, unusedRecipes.toSeq, Forms.cloneBaseImage, usages))
     }
   }
 

--- a/app/controllers/RecipeController.scala
+++ b/app/controllers/RecipeController.scala
@@ -26,8 +26,9 @@ class RecipeController(
 
   def listRecipes = AuthAction {
     val recipes: Iterable[Recipe] = Recipes.list()
-    val usages: Map[Recipe, RecipeUsage] = RecipeUsage.forAll(recipes, findBakes = recipeId => Bakes.list(recipeId))(prismAgents)
-    Ok(views.html.recipes(recipes, usages))
+    val usages: Map[Recipe, RecipeUsage] = RecipeUsage.getUsagesMap(recipes)(prismAgents, dynamo)
+    val (usedRecipes, unusedRecipes) = recipes.partition(r => RecipeUsage.hasUsage(r, usages))
+    Ok(views.html.recipes(usedRecipes, unusedRecipes, usages))
   }
 
   def showRecipe(id: RecipeId) = AuthAction { implicit request =>

--- a/app/prism/RecipeUsage.scala
+++ b/app/prism/RecipeUsage.scala
@@ -76,8 +76,16 @@ object RecipeUsage {
     recipes.map(r => r -> apply(findBakes(r.id))).toMap
   }
 
-  def getUsages(recipes: Iterable[Recipe])(implicit prismAgents: PrismAgents, dynamo: Dynamo) = {
+  def getUsagesMap(recipes: Iterable[Recipe])(implicit prismAgents: PrismAgents, dynamo: Dynamo): Map[Recipe, RecipeUsage] = {
+    forAll(recipes, findBakes = recipeId => Bakes.list(recipeId))(prismAgents)
+  }
+
+  def getUsages(recipes: Iterable[Recipe])(implicit prismAgents: PrismAgents, dynamo: Dynamo): Iterable[RecipeUsage] = {
     recipes.map(r => RecipeUsage(Bakes.list(r.id)))
+  }
+
+  def hasUsage(recipe: Recipe, usages: Map[Recipe, RecipeUsage]): Boolean = {
+    usages.get(recipe).exists(u => u.launchConfigurations.nonEmpty || u.instances.nonEmpty)
   }
 
 }

--- a/app/views/fragments/recipeTable.scala.html
+++ b/app/views/fragments/recipeTable.scala.html
@@ -1,0 +1,28 @@
+@(
+    title: String,
+    recipes: Iterable[Recipe],
+    usages: Map[Recipe, prism.RecipeUsage]
+)
+<h3>@title</h3>
+@if(recipes.isEmpty) {
+    <p>No @title.toLowerCase()</p>
+} else {
+    <table class="table table-striped">
+        <thead>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Usage</th>
+            <th>Status</th>
+        </thead>
+        <tbody>
+        @for(recipe <- recipes.toList.sortBy(_.id.value.toLowerCase)) {
+            <tr class="@BaseImage.eolStatusClass(recipe.baseImage)">
+                <td class="has-block-link"><a href="@routes.RecipeController.showRecipe(recipe.id)" class="block-link">@recipe.id</a></td>
+                <td class="has-block-link"><a href="@routes.RecipeController.showRecipe(recipe.id)" class="block-link">@recipe.description</a></td>
+                @fragments.usagesColumn(recipe, usages)
+                <td>@fragments.eolStatus(recipe.baseImage) </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}

--- a/app/views/fragments/usedByTable.scala.html
+++ b/app/views/fragments/usedByTable.scala.html
@@ -1,0 +1,15 @@
+@(title: String, recipes: Seq[Recipe], usages: Map[Recipe, prism.RecipeUsage])
+
+<h3>@title</h3>
+@if(recipes.isEmpty) {
+    <p>No @title.toLowerCase() for this image</p>
+} else {
+    <table class="table">
+    @recipes.map { recipe =>
+        <tr>
+            <td><a href="@routes.RecipeController.showRecipe(recipe.id)">@recipe.id</a></td>
+            @fragments.usagesColumn(recipe, usages)
+        </tr>
+    }
+    </table>
+}

--- a/app/views/recipes.scala.html
+++ b/app/views/recipes.scala.html
@@ -1,5 +1,6 @@
 @(
-        recipes: Iterable[Recipe],
+        usedRecipes: Iterable[Recipe],
+        unusedRecipes: Iterable[Recipe],
         usages: Map[Recipe, prism.RecipeUsage]
 )
 @simpleLayout("AMIgo"){
@@ -15,23 +16,7 @@
 
   <p>Click on a row for more details.</p>
 
-  <table class="table table-striped">
-    <thead>
-      <th>Name</th>
-      <th>Description</th>
-      <th>Usage</th>
-      <th>Status</th>
-    </thead>
-    <tbody>
-    @for(recipe <- recipes.toList.sortBy(_.id.value.toLowerCase)) {
-      <tr class="@BaseImage.eolStatusClass(recipe.baseImage)">
-        <td class="has-block-link"><a href="@routes.RecipeController.showRecipe(recipe.id)" class="block-link">@recipe.id</a></td>
-        <td class="has-block-link"><a href="@routes.RecipeController.showRecipe(recipe.id)" class="block-link">@recipe.description</a></td>
-        @fragments.usagesColumn(recipe, usages)
-        <td>@fragments.eolStatus(recipe.baseImage) </td>
-      </tr>
-    }
-    </tbody>
-  </table>
+  @fragments.recipeTable("Recipes in use", usedRecipes, usages)
+  @fragments.recipeTable("Unused recipes", unusedRecipes, usages)
 
 }

--- a/app/views/showBaseImage.scala.html
+++ b/app/views/showBaseImage.scala.html
@@ -1,5 +1,5 @@
 @import data.Roles
-@(image: BaseImage, allRoles: Seq[RoleSummary], usedByRecipes: Seq[Recipe], cloneForm: Form[_], usages: Map[Recipe, prism.RecipeUsage])(implicit flash: Flash, messages: play.api.i18n.Messages)
+@(image: BaseImage, allRoles: Seq[RoleSummary], usedRecipes: Seq[Recipe], unusedRecipes: Seq[Recipe], cloneForm: Form[_], usages: Map[Recipe, prism.RecipeUsage])(implicit flash: Flash, messages: play.api.i18n.Messages)
 
 @implicitFieldConstructor = @{ b3.inline.fieldConstructor }
 
@@ -54,18 +54,12 @@
     <div class="panel-heading">Used by</div>
     <div class="panel-body">
 
-      @if(usedByRecipes.isEmpty) {
+      @if(usedRecipes.isEmpty && unusedRecipes.isEmpty) {
         This base image is not used by any recipe
       } else {
         This base image is used by the following recipes:
-        <table class="table">
-        @usedByRecipes.map { recipe =>
-          <tr>
-            <td><a href="@routes.RecipeController.showRecipe(recipe.id)">@recipe.id</a></td>
-            @fragments.usagesColumn(recipe, usages)
-          </tr>
-        }
-        </table>
+        @fragments.usedByTable("Recipes with active instances/launch configurations", usedRecipes, usages)
+        @fragments.usedByTable("Unused recipes", unusedRecipes, usages)
       }
     </div>
   </div>

--- a/test/prism/RecipeUsageSpec.scala
+++ b/test/prism/RecipeUsageSpec.scala
@@ -16,6 +16,9 @@ class RecipeUsageSpec extends FlatSpec with Matchers with MockitoSugar {
   def fixtureRecipeWithSize(id: String, size: Int): Recipe = Recipe(RecipeId(id), None, fixtureBaseImage(s"base-image-$id"), Some(100), List(), "Test", DateTime.now, "Test", DateTime.now, None, Nil)
   def fixtureBake(recipe: Recipe, amiId: Option[AmiId]): Bake = Bake(recipe, 1, amiId.map(_ => BakeStatus.Complete).getOrElse(BakeStatus.Failed), amiId, "Test", DateTime.now, false)
 
+  val emptyUsage: RecipeUsage = RecipeUsage(Seq(), Seq(), Seq())
+  val nonEmptyusage: RecipeUsage = RecipeUsage(Seq(Instance("weatherwax", AmiId("a-tuin"), AWSAccount("Gaspode", "carrot"))), Seq(), Seq())
+
   "RecipeUsage" should "find for each recipes where they are being used" in {
     val amiId1 = AmiId("1")
     val amiId2 = AmiId("2")
@@ -82,6 +85,19 @@ class RecipeUsageSpec extends FlatSpec with Matchers with MockitoSugar {
     recipe3Usages.instances shouldBe Seq.empty
     recipe3Usages.launchConfigurations shouldBe Seq.empty
     recipe3Usages.bakeUsage shouldBe Seq.empty
+  }
+
+  "hasUsage" should "return true if a recipe is used" in {
+    val recipe1 = fixtureRecipe("recipe1")
+    val recipe2 = fixtureRecipe("recipe2")
+    val usages = Map(
+      recipe1 -> emptyUsage,
+      recipe2 -> nonEmptyusage
+    )
+
+    RecipeUsage.hasUsage(recipe1, usages) shouldBe false
+    RecipeUsage.hasUsage(recipe2, usages) shouldBe true
+
   }
 
 }


### PR DESCRIPTION
## What does this change?
This changes the recipes and baseimageussage lists so that they have 2 sections - one for recipes in use (with an active instance or launch configuration), and one for unused recipes.

As part of this work I added a new `getUsagesMap` function which simplifies somewhat the calls  to RecipesUsage from the Recipes/BaseImage controllers.

This should make it easier to see which end of life recipes we need to worry about, and also easier to clean out unused recipes.

## How to test
I've tested this on CODE - it should just be a UI change. See screenshots below


### Recipes view
<img width="1215" alt="Screenshot 2021-04-29 at 12 32 42" src="https://user-images.githubusercontent.com/3606555/116544440-09c8d300-a8e7-11eb-83d2-3cbaf6a82319.png">

### Base image view
<img width="1002" alt="Screenshot 2021-04-29 at 11 41 29" src="https://user-images.githubusercontent.com/3606555/116544373-f3bb1280-a8e6-11eb-95b4-95b0c3519127.png">

