### PR TITLE
Notify upon bake failure

### DIFF
--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -152,7 +152,9 @@ class AppComponents(context: Context)
 
   val amigoUrl: String = configuration.getString("amigo.url").getOrElse(s"https://${identity.app}.gutools.co.uk")
   val anghammaradNotificationTopic: Option[String] = configuration.getString("anghammarad.sns.topicArn")
-  val notificationConfig: Option[NotificationConfig] = anghammaradNotificationTopic.map(t => NotificationConfig(amigoUrl, t, anghammaradSNSClient))
+  val notificationConfig: Option[NotificationConfig] = anghammaradNotificationTopic.map{ t =>
+    NotificationConfig(amigoUrl, t, anghammaradSNSClient, identity.stage)
+  }
 
   configuration.getString("aws.distributionBucket").foreach { bucketName =>
     LambdaDistributionBucket.updateBucketPolicy(s3Client, bucketName, identity.stage, accountNumbers)

--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -13,7 +13,7 @@ import com.amazonaws.services.ec2.{ AmazonEC2, AmazonEC2ClientBuilder }
 import com.amazonaws.services.s3.{ AmazonS3, AmazonS3ClientBuilder }
 import com.amazonaws.services.securitytoken.{ AWSSecurityTokenService, AWSSecurityTokenServiceClientBuilder }
 import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest
-import com.amazonaws.services.sns.AmazonSNSClientBuilder
+import com.amazonaws.services.sns.{ AmazonSNS, AmazonSNSAsync, AmazonSNSAsyncClientBuilder, AmazonSNSClientBuilder }
 import com.gu.cm.{ ConfigurationLoader, Identity, LocalApplication }
 import com.gu.googleauth.GoogleAuthConfig
 import controllers._
@@ -21,6 +21,7 @@ import data.{ Dynamo, Recipes }
 import event.{ ActorSystemWrapper, BakeEvent, Behaviours }
 import housekeeping._
 import housekeeping.utils.{ BakesRepo, PackerEC2Client }
+import models.NotificationConfig
 import notification.{ AmiCreatedNotifier, LambdaDistributionBucket, NotificationSender, SNS }
 import org.joda.time.Duration
 import org.quartz.Scheduler
@@ -143,6 +144,16 @@ class AppComponents(context: Context)
     .withClientConfiguration(clientConfiguration)
     .build()
 
+  val anghammaradSNSClient: AmazonSNSAsync = AmazonSNSAsyncClientBuilder.standard
+    .withRegion(region)
+    .withCredentials(awsCreds)
+    .withClientConfiguration(clientConfiguration)
+    .build()
+
+  val amigoUrl: String = configuration.getString("amigo.url").getOrElse(s"https://${identity.app}.gutools.co.uk")
+  val anghammaradNotificationTopic: Option[String] = configuration.getString("anghammarad.sns.topicArn")
+  val notificationConfig: Option[NotificationConfig] = anghammaradNotificationTopic.map(t => NotificationConfig(amigoUrl, t, anghammaradSNSClient))
+
   configuration.getString("aws.distributionBucket").foreach { bucketName =>
     LambdaDistributionBucket.updateBucketPolicy(s3Client, bucketName, identity.stage, accountNumbers)
   }
@@ -153,7 +164,7 @@ class AppComponents(context: Context)
     val eventListeners = Map(
       "channelSender" -> Props(Behaviours.sendToChannel(eventsChannel)),
       "logWriter" -> Props(Behaviours.writeToLog),
-      "dynamoWriter" -> Props(Behaviours.writeToDynamo)
+      "dynamoWriter" -> Props(Behaviours.persistBakeEvent(notificationConfig))
     )
     ActorSystem[BakeEvent]("EventBus", Props(Behaviours.guardian(eventListeners)))
   }
@@ -198,7 +209,7 @@ class AppComponents(context: Context)
   log.info("Registering all scheduled bakes with the scheduler")
   bakeScheduler.initialise(Recipes.list())
 
-  val bakesRepo = new BakesRepo
+  val bakesRepo = new BakesRepo(notificationConfig)
   val packerEC2Client = new PackerEC2Client(ec2Client, identity.stage)
 
   val houseKeepingJobs = List(
@@ -219,7 +230,18 @@ class AppComponents(context: Context)
   val housekeepingController = new HousekeepingController(googleAuthConfig)
   val roleController = new RoleController(googleAuthConfig)
   val recipeController = new RecipeController(bakeScheduler, prismAgents, googleAuthConfig, messagesApi, debugAvailable)
-  val bakeController = new BakeController(identity.stage, eventsSource, prismAgents, googleAuthConfig, messagesApi, ansibleVariables, debugAvailable, amiMetadataLookup, amigoDataBucket, s3Client, packerRunner)
+  val bakeController = new BakeController(
+    identity.stage,
+    eventsSource,
+    prismAgents,
+    googleAuthConfig,
+    messagesApi,
+    ansibleVariables,
+    debugAvailable,
+    amiMetadataLookup,
+    amigoDataBucket,
+    s3Client,
+    packerRunner)
   val authController = new Auth(googleAuthConfig)(wsClient)
   val assets = new controllers.Assets(httpErrorHandler)
   lazy val router: Router = new Routes(

--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -152,7 +152,7 @@ class AppComponents(context: Context)
 
   val amigoUrl: String = configuration.getString("amigo.url").getOrElse(s"https://${identity.app}.gutools.co.uk")
   val anghammaradNotificationTopic: Option[String] = configuration.getString("anghammarad.sns.topicArn")
-  val notificationConfig: Option[NotificationConfig] = anghammaradNotificationTopic.map{ t =>
+  val notificationConfig: Option[NotificationConfig] = anghammaradNotificationTopic.map { t =>
     NotificationConfig(amigoUrl, t, anghammaradSNSClient, identity.stage)
   }
 

--- a/app/controllers/BakeController.scala
+++ b/app/controllers/BakeController.scala
@@ -29,7 +29,7 @@ class BakeController(
   packerRunner: PackerRunner)(implicit dynamo: Dynamo, packerConfig: PackerConfig, eventBus: EventBus)
     extends Controller with AuthActions with I18nSupport with Loggable {
 
-  def startBaking(recipeId: RecipeId, debug: Boolean) = AuthAction { request =>
+  def startBaking(recipeId: RecipeId, debug: Boolean): Action[AnyContent] = AuthAction { request =>
     Recipes.findById(recipeId).fold[Result](NotFound) { recipe =>
       Recipes.incrementAndGetBuildNumber(recipe.id) match {
         case Some(buildNumber) =>

--- a/app/event/Behaviours.scala
+++ b/app/event/Behaviours.scala
@@ -59,7 +59,7 @@ object Behaviours extends Loggable {
     case AmiCreated(bakeId, amiId) => Bakes.updateAmiId(bakeId, amiId)
     case PackerProcessExited(bakeId, exitCode) =>
       val status = if (exitCode == 0) BakeStatus.Complete else BakeStatus.Failed
-      Bake.updateStatus(bakeId, status, notificationConfig)
+      Bake.updateStatusAndNotifyFailure(bakeId, status, notificationConfig)
   }
 
 }

--- a/app/housekeeping/utils/BakesRepo.scala
+++ b/app/housekeeping/utils/BakesRepo.scala
@@ -1,11 +1,13 @@
 package housekeeping.utils
 
 import data.{ Bakes, Dynamo }
-import models.{ Bake, BakeId, BakeStatus }
+import models.{ Bake, BakeId, BakeStatus, NotificationConfig }
+
+import scala.concurrent.ExecutionContext
 
 // Wrapper around dynamo access.
 // Injecting this functionality as a class facilitates unit testing.
-class BakesRepo(implicit dynamo: Dynamo) {
+class BakesRepo(notificationConfig: Option[NotificationConfig])(implicit dynamo: Dynamo, exec: ExecutionContext) {
 
   def getBakes: List[Bake.DbModel] = Bakes.scanForAll()
 
@@ -14,7 +16,7 @@ class BakesRepo(implicit dynamo: Dynamo) {
     // Therefore, look up the bake first and check its status.
     Bakes.findById(bakeId.recipeId, bakeId.buildNumber).foreach { bake =>
       if (bake.status == BakeStatus.Running) {
-        Bakes.updateStatus(bakeId, BakeStatus.TimedOut)
+        Bake.updateStatus(bakeId, BakeStatus.TimedOut, notificationConfig)
       }
     }
   }

--- a/app/housekeeping/utils/BakesRepo.scala
+++ b/app/housekeeping/utils/BakesRepo.scala
@@ -16,7 +16,7 @@ class BakesRepo(notificationConfig: Option[NotificationConfig])(implicit dynamo:
     // Therefore, look up the bake first and check its status.
     Bakes.findById(bakeId.recipeId, bakeId.buildNumber).foreach { bake =>
       if (bake.status == BakeStatus.Running) {
-        Bake.updateStatus(bakeId, BakeStatus.TimedOut, notificationConfig)
+        Bake.updateStatusAndNotifyFailure(bakeId, BakeStatus.TimedOut, notificationConfig)
       }
     }
   }

--- a/app/models/Bake.scala
+++ b/app/models/Bake.scala
@@ -37,7 +37,7 @@ object Bake {
   def db2domain(dbModel: DbModel, recipe: Recipe): Bake =
     transform[Bake.DbModel, Bake](dbModel, "recipe" -> recipe, "deleted" -> dbModel.deleted.getOrElse(false))
 
-  def updateStatus(bakeId: BakeId, status: BakeStatus, notificationConfig: Option[NotificationConfig])(implicit dynamo: Dynamo, exec: ExecutionContext): Unit = {
+  def updateStatusAndNotifyFailure(bakeId: BakeId, status: BakeStatus, notificationConfig: Option[NotificationConfig])(implicit dynamo: Dynamo, exec: ExecutionContext): Unit = {
     if (status == BakeStatus.Failed || status == BakeStatus.TimedOut) {
       BakeFailedNotifier.notifyBakeFailed(bakeId, status, notificationConfig)
     }

--- a/app/models/NotificationConfig.scala
+++ b/app/models/NotificationConfig.scala
@@ -1,0 +1,5 @@
+package models
+
+import com.amazonaws.services.sns.AmazonSNSAsync
+
+case class NotificationConfig(baseUrl: String, snsTopicArn: String, snsClient: AmazonSNSAsync)

--- a/app/models/NotificationConfig.scala
+++ b/app/models/NotificationConfig.scala
@@ -2,4 +2,4 @@ package models
 
 import com.amazonaws.services.sns.AmazonSNSAsync
 
-case class NotificationConfig(baseUrl: String, snsTopicArn: String, snsClient: AmazonSNSAsync)
+case class NotificationConfig(baseUrl: String, snsTopicArn: String, snsClient: AmazonSNSAsync, amigoStage: String)

--- a/app/notification/BakeFailedNotifier.scala
+++ b/app/notification/BakeFailedNotifier.scala
@@ -20,10 +20,10 @@ object BakeFailedNotifier extends Loggable {
     val targets = bake.recipe.encryptFor.map(m => AwsAccount(m.accountNumber))
     val statusString = bakeStatus.toString.toLowerCase()
     val actions = List(
-      Action(s"View recipe ${bake.recipe} in AMIgo", s"$config.baseUrl/recipes/${bake.recipe.id}"),
-      Action(s"Check bake log for ${bake.bakeId}", s"$config.baseUrl/recipes/${bake.recipe.id}/bakes/${bake.buildNumber}")
+      Action(s"View recipe ${bake.recipe.id} in AMIgo", s"${config.baseUrl}/recipes/${bake.recipe.id}"),
+      Action(s"Check bake log for ${bake.bakeId}", s"${config.baseUrl}/recipes/${bake.recipe.id}/bakes/${bake.buildNumber}")
     )
-    val stageString = if (config.amigoStage != "PROD") s"(stage ${config.amigoStage})" else ""
+    val stageString = if (config.amigoStage != "PROD") s"(AMIgo ${config.amigoStage})" else ""
     if (targets.nonEmpty) {
       Some(
         Notification(

--- a/app/notification/BakeFailedNotifier.scala
+++ b/app/notification/BakeFailedNotifier.scala
@@ -46,11 +46,11 @@ object BakeFailedNotifier extends Loggable {
   }
 
   def logFailure(configAvailable: Boolean, bakeId: BakeId): Unit = {
-      if (configAvailable) {
-        log.info(s"Failed to fetch bake ${bakeId} from DB. Bake failed notification not sent.")
-      } else {
-        log.info(s"Missing notification config - notification for bake failure ${bakeId} not sent")
-      }
+    if (configAvailable) {
+      log.info(s"Failed to fetch bake ${bakeId} from DB. Bake failed notification not sent.")
+    } else {
+      log.info(s"Missing notification config - notification for bake failure ${bakeId} not sent")
+    }
   }
 
   def notifyBakeFailed(bakeId: BakeId, bakeStatus: BakeStatus, notificationConfig: Option[NotificationConfig])(implicit exec: ExecutionContext, dynamo: Dynamo): Unit = {

--- a/app/notification/BakeFailedNotifier.scala
+++ b/app/notification/BakeFailedNotifier.scala
@@ -45,14 +45,12 @@ object BakeFailedNotifier extends Loggable {
     }
   }
 
-  def logFailure(notificationSuccess: Boolean, configAvailable: Boolean, bakeId: BakeId): Unit = {
-    if (!notificationSuccess) {
+  def logFailure(configAvailable: Boolean, bakeId: BakeId): Unit = {
       if (configAvailable) {
         log.info(s"Failed to fetch bake ${bakeId} from DB. Bake failed notification not sent.")
       } else {
         log.info(s"Missing notification config - notification for bake failure ${bakeId} not sent")
       }
-    }
   }
 
   def notifyBakeFailed(bakeId: BakeId, bakeStatus: BakeStatus, notificationConfig: Option[NotificationConfig])(implicit exec: ExecutionContext, dynamo: Dynamo): Unit = {
@@ -68,6 +66,6 @@ object BakeFailedNotifier extends Loggable {
           log.error(s"Failed to send notification about recipe ${bake.recipe.id} bake failure", exception)
       }
     }
-    logFailure(notificationResult.isEmpty, notificationConfig.isEmpty, bakeId)
+    if (notificationResult.isEmpty) logFailure(notificationConfig.isEmpty, bakeId)
   }
 }

--- a/app/notification/BakeFailedNotifier.scala
+++ b/app/notification/BakeFailedNotifier.scala
@@ -1,0 +1,70 @@
+package notification
+
+import com.gu.anghammarad.Anghammarad
+import com.gu.anghammarad.models.{ Action, AwsAccount, Email, Notification, Preferred }
+import data.{ Bakes, Dynamo }
+import models.{ Bake, BakeId, BakeStatus, NotificationConfig }
+import services.Loggable
+
+import scala.concurrent.ExecutionContext
+import scala.util.{ Failure, Success }
+
+object BakeFailedNotifier extends Loggable {
+  private val channel: Preferred = Preferred(Email)
+
+  /**
+   * Generates an anghammarad notification. The targets of the notification are generated based off the accounts to which
+   * an encrypted copy has been requested. If no encrypted copies have been requested return None
+   */
+  def makeNotification(bake: Bake, bakeStatus: BakeStatus, baseUrl: String): Option[Notification] = {
+    val targets = bake.recipe.encryptFor.map(m => AwsAccount(m.accountNumber))
+    val statusString = bakeStatus.toString.toLowerCase()
+    val actions = List(
+      Action("View recipe", s"$baseUrl/recipes/${bake.recipe.id}"),
+      Action("Check bake log", s"$baseUrl/recipes/${bake.recipe.id}/bakes/${bake.buildNumber}")
+    )
+    if (targets.nonEmpty) {
+      Some(
+        Notification(
+          s"AMIgo bake ${bake.bakeId} $statusString",
+          s"""
+             |Unfortunately a bake on ${bake.recipe.id} has $statusString. Sometimes failures happen due to AMIgo memory errors
+             |and can be fixed simply by re-running the bake and changing the schedule to a less busy time.
+             |""".stripMargin,
+          actions,
+          targets,
+          channel,
+          "AMIgo")
+      )
+    } else {
+      log.info(s"No anghammarad targets available for bake ${bake.recipe.id},${bake.buildNumber} - likely no encrypted copies have been requested for the recipe.")
+      None
+    }
+  }
+
+  def logFailure(notificationSuccess: Boolean, configAvailable: Boolean, bakeId: BakeId): Unit = {
+    if (!notificationSuccess) {
+      if (configAvailable) {
+        log.info(s"Failed to fetch bake ${bakeId} from DB. Bake failed notification not sent.")
+      } else {
+        log.info(s"Missing notification config - notification for bake failure ${bakeId} not sent")
+      }
+    }
+  }
+
+  def notifyBakeFailed(bakeId: BakeId, bakeStatus: BakeStatus, notificationConfig: Option[NotificationConfig])(implicit exec: ExecutionContext, dynamo: Dynamo): Unit = {
+    val notificationResult = for {
+      config <- notificationConfig
+      bake <- Bakes.findById(bakeId.recipeId, bakeId.buildNumber)
+      notification <- makeNotification(bake, bakeStatus, config.baseUrl)
+    } yield {
+      Anghammarad.notify(notification, config.snsTopicArn, config.snsClient).onComplete {
+        case Success(value) =>
+          log.info(s"Sent notification to anghammarard about recipe ${bake.recipe.id} bake failure. Status: $value")
+        case Failure(exception) =>
+          log.error(s"Failed to send notification about recipe ${bake.recipe.id} bake failure", exception)
+      }
+    }
+    logFailure(notificationResult.isEmpty, notificationConfig.isEmpty, bakeId)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,8 @@ libraryDependencies ++= Seq(
   "com.gu" % "kinesis-logback-appender" % "1.4.2",
   "org.scalatest" %% "scalatest" % "2.2.6" % Test,
   "org.mockito" % "mockito-core" % "2.7.19" % Test,
-  "fun.mike" % "diff-match-patch" % "0.0.2"
+  "fun.mike" % "diff-match-patch" % "0.0.2",
+  "com.gu" % "anghammarad-client_2.11" % "1.1.3"
 )
 routesGenerator := InjectedRoutesGenerator
 routesImport += "models._"

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -33,6 +33,9 @@ Parameters:
   KinesisStreamName:
     Type: String
     Description: The name (NOT arn) of the Kinesis stream that logs should be shipped to
+  AnghammaradTopicArn:
+    Type: String
+    Description: Anghammarad sns notifications topic arn
 
 Mappings:
   Config:
@@ -107,6 +110,10 @@ Resources:
           Action:
           - sns:*
           Resource: !Sub 'arn:aws:sns:*:*:amigo-${Stage}-housekeeping-notify'
+        - Effect: Allow
+          Action:
+            - sns:Publish
+          Resource: !Ref AnghammaradTopicArn
         - Effect: Allow
           Action:
           - s3:GetBucketPolicy


### PR DESCRIPTION
## What does this change?
This PR wires AMIgo up to [Anghammarad](https://github.com/guardian/anghammarad) so that it can send email notifications when a bake fails. Right now this feature relies on the 'request encrypted copy'  feature to identify who owns a recipe - it will only send notifications to the owners of AWS accounts to which an encrypted copy has been requested.

For example, in the screenshot below failure notifications woul be sent to account  095

<img width="327" alt="Screenshot 2021-05-14 at 14 56 42" src="https://user-images.githubusercontent.com/3606555/118281356-06c40a00-b4c5-11eb-8e2f-eca3f949dea3.png">

## How to test
Tested on CODE. This is a backend only change. An example of the output notification can be seen below:

<img width="542" alt="Screenshot 2021-05-14 at 15 04 06" src="https://user-images.githubusercontent.com/3606555/118281933-a6819800-b4c5-11eb-85c4-809d60d74248.png">

