### PR TITLE
Add a cdk role with tag discovery as a starter for 10

### DIFF
--- a/app/packer/PackerRunner.scala
+++ b/app/packer/PackerRunner.scala
@@ -28,7 +28,12 @@ class PackerRunner(maxInstances: Int) extends Loggable {
     val sourceAmi = bake.recipe.baseImage.amiId.value
     val amiMetadata = amiMetadataLookup.lookupMetadataFor(sourceAmi).right.getOrElse(throw new IllegalStateException(s"Unable to identify the architecture for $sourceAmi"))
 
-    val playbookYaml = PlaybookGenerator.generatePlaybook(bake.recipe, ansibleVars + ("arch" -> amiMetadata.architecture))
+    val playbookYaml = PlaybookGenerator.generatePlaybook(bake.recipe,
+      ansibleVars ++ Map(
+        "arch" -> amiMetadata.architecture,
+        "deb_arch" -> amiMetadata.debArchitecture
+      )
+    )
     val playbookFile = Files.createTempFile(s"amigo-ansible-${bake.recipe.id.value}", ".yml")
     Files.write(playbookFile, playbookYaml.getBytes(StandardCharsets.UTF_8)) // TODO error handling
 

--- a/app/services/AmiMetadataLookup.scala
+++ b/app/services/AmiMetadataLookup.scala
@@ -6,9 +6,13 @@ import com.amazonaws.services.ec2.model.{ DescribeImagesRequest, Image }
 
 import scala.collection.JavaConverters._;
 
-case class AmiMetadata(architecture: String)
+case class AmiMetadata(architecture: String, debArchitecture: String)
 
 class AmiMetadataLookup(ec2Client: AmazonEC2) {
+  val archToDebArch = Map(
+    "x86_64" -> "amd64"
+  )
+
   def lookupMetadataFor(ami: String): Either[String, AmiMetadata] = {
     for {
       result <- Either.catchNonFatal {
@@ -16,8 +20,9 @@ class AmiMetadataLookup(ec2Client: AmazonEC2) {
       }.leftMap[String](_ => "Call to describe images failed")
       imageDescription <- result.getImages.asScala.headOption.fold[Either[String, Image]](Left(s"No ami with ID $ami found"))(i => Right(i))
       architecture = imageDescription.getArchitecture
+      debArchitecture = archToDebArch.getOrElse(architecture, architecture)
     } yield {
-      AmiMetadata(architecture)
+      AmiMetadata(architecture, debArchitecture)
     }
 
   }

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val root = (project in file("."))
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Xfatal-warnings")
 
 val jacksonVersion = "2.7.1"
-val awsVersion = "1.11.263"
+val awsVersion = "1.11.1017"
 val circeVersion = "0.9.0"
 libraryDependencies ++= Seq(
   ws,

--- a/roles/cdk-base/README.md
+++ b/roles/cdk-base/README.md
@@ -1,0 +1,7 @@
+CDK base config
+===============
+
+This role includes boot tasks that the Guardian's EC2 CDK patterns and best practices rely on.
+
+Initially this will be fetching and writing tags and configuration to `/etc/config`.
+

--- a/roles/cdk-base/tasks/main.yml
+++ b/roles/cdk-base/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Download a package from an S3 bucket
+  command: /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}instance-tag-discovery-{{ deb_arch }}_1.0-1.deb /tmp/instance-tag-discovery.deb
+  when:
+    - ansible_os_family == "Debian"
+
+- name: Install cloudwatch agent
+  apt:
+    deb: /tmp/instance-tag-discovery.deb


### PR DESCRIPTION
## What does this change?
With the CDK work we want to usher in a new way of working with infrastructure. One of the experiments is migrate identity discovery and configuration to local disk. Whether the compute is EC2, ECS or Lambda - identity and config will live in one or possibly two well known locations.

This role bakes in the [instance-tag-discovery](https://github.com/guardian/instance-tag-discovery) tool that runs automatically at instance launch that fetches the tags from the related ASG or directly from the instance if there is not an ASG. They are written both as JSON and Java properties into `/etc/config/tags.json` and `/etc/config/tags.properties` respectively.

The package uses cloud-init's per-instance script folder to execute at instance launch.

Have confirmed that this works when IDMSv2 is required.

## How to test
Add the role to a suitable recipe. Check that the files mentioned above exist after launch.

## How can we measure success?
Ultimately: less code for discovering application identity.