### PR TITLE
Add AMI ID label to wazuh agent role.

### DIFF
--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -78,6 +78,7 @@
 
         REGION=$(curl -s -H "X-aws-ec2-metadata-token: `curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`" http://169.254.169.254/latest/meta-data/placement/availability-zone |  sed 's/.$//')
         INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: `curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`" http://169.254.169.254/latest/meta-data/instance-id)
+        AMI_ID=$(curl -s -H "X-aws-ec2-metadata-token: `curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`" http://169.254.169.254/latest/meta-data/ami-id)
 
         ASG_NAME=$(aws autoscaling describe-auto-scaling-instances --region "$REGION" --instance-ids "$INSTANCE_ID" --output text --query "AutoScalingInstances[0].AutoScalingGroupName" || true)
 
@@ -109,6 +110,7 @@
             <label key="aws.stack">$STACK</label>
             <label key="aws.stage">$STAGE</label>
             <label key="aws.instanceId">$INSTANCE_ID</label>
+            <label key="aws.amiId">$AMI_ID</label>
           </labels>
         </ossec_config>
       EOF


### PR DESCRIPTION
## What does this change?
This sets up the wazuh agent role so that when registering an agent with the wazuh server it includes the AMI ID as a [wazuh label](https://documentation.wazuh.com/current/user-manual/capabilities/labels.html)

## How to test
- [x] Deploy this change to AMIgo CODE, bake an AMI and verify that the bake completes. 
- [ ] Then deploy to AMIgo PROD, bake an AMI and redeploy an app using that AMI. 
- [ ] Verify that the app boots succesfully, registers with wazuh and that the AMI ID appears in the wazuh console.

## How can we measure success?
We will be able to aggregate vulnerabilities by ami id

## Have we considered potential risks?
My bash could be dodgy and break the wazuh agent role script 😱  but it's all copy pasted so 🤞🏻 
