### PR TITLE
Revert "Add AMI ID label to wazuh agent role."

### DIFF
--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -78,7 +78,6 @@
 
         REGION=$(curl -s -H "X-aws-ec2-metadata-token: `curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`" http://169.254.169.254/latest/meta-data/placement/availability-zone |  sed 's/.$//')
         INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: `curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`" http://169.254.169.254/latest/meta-data/instance-id)
-        AMI_ID=$(curl -s -H "X-aws-ec2-metadata-token: `curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`" http://169.254.169.254/latest/meta-data/ami-id)
 
         ASG_NAME=$(aws autoscaling describe-auto-scaling-instances --region "$REGION" --instance-ids "$INSTANCE_ID" --output text --query "AutoScalingInstances[0].AutoScalingGroupName" || true)
 
@@ -110,7 +109,6 @@
             <label key="aws.stack">$STACK</label>
             <label key="aws.stage">$STAGE</label>
             <label key="aws.instanceId">$INSTANCE_ID</label>
-            <label key="aws.amiId">$AMI_ID</label>
           </labels>
         </ossec_config>
       EOF


### PR DESCRIPTION
Reverts guardian/amigo#587

This worked in CODE and on a single test instance, but in our services (I tried amiable and amigo) the aws cli calls now fail with a memory allocation error.

```
$  aws autoscaling describe-auto-scaling-instances
 [SSL] malloc failure (_ssl.c:2805)
``` 

Very strange! Here's the full log output for reference

```
Jun 07 15:40:53 authenticate-with-wazuh-manager.sh[910]: + '[' -f /var/ossec/etc/authd.pass ']'
Jun 07 15:40:53 authenticate-with-wazuh-manager.sh[910]: + MANAGER_ADDRESS=xxxx
Jun 07 15:40:53 authenticate-with-wazuh-manager.sh[910]: ++ sed 's/.$//'
Jun 07 15:40:53 authenticate-with-wazuh-manager.sh[910]: +++ curl -s -X PUT http://169.254.169.254/latest/api/token -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600'
Jun 07 15:40:53 authenticate-with-wazuh-manager.sh[910]: ++ curl -s -H 'X-aws-ec2-metadata-token: AQAEALzkzbisnf_SnB2bST4GVCgCXTdWYnadhwjgT_fw4wm9RqgLkg==' http://169.254.169.254/latest/meta-data/placement/availability-zone
Jun 07 15:40:53 authenticate-with-wazuh-manager.sh[910]: + REGION=xxxx
Jun 07 15:40:53 authenticate-with-wazuh-manager.sh[910]: +++ curl -s -X PUT http://169.254.169.254/latest/api/token -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600'
Jun 07 15:40:53 authenticate-with-wazuh-manager.sh[910]: ++ curl -s -H 'X-aws-ec2-metadata-token: AQAEALzkzbhAlVAo3YU5ZAVyFg2IDxLsznWEd79ryaI65IdJsCyJ6g==' http://169.254.169.254/latest/meta-data/instance-id
Jun 07 15:40:53 authenticate-with-wazuh-manager.sh[910]: + INSTANCE_ID=i-xxxxxx
Jun 07 15:40:53 authenticate-with-wazuh-manager.sh[910]: +++ curl -s -X PUT http://169.254.169.254/latest/api/token -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600'
Jun 07 15:40:53 authenticate-with-wazuh-manager.sh[910]: ++ curl -s -H 'X-aws-ec2-metadata-token: AQAEALzkzbgvDye919BkNict_qnl9UNLoZ12B6YMcPlqgLXSUco76g==' http://169.254.169.254/latest/meta-data/ami-id
Jun 07 15:40:53 authenticate-with-wazuh-manager.sh[910]: + AMI_ID=ami-xxxxx
Jun 07 15:40:53 authenticate-with-wazuh-manager.sh[910]: ++ aws autoscaling describe-auto-scaling-instances --region eu-west-1 --instance-ids i-03771d3fa69e7ee4f --output text --query 'AutoScalingInstances[0].AutoScalingGroupName'
Jun 07 15:40:55 authenticate-with-wazuh-manager.sh[910]: [SSL] malloc failure (_ssl.c:2805)
Jun 07 15:40:55 authenticate-with-wazuh-manager.sh[910]: ++ true
Jun 07 15:40:55 authenticate-with-wazuh-manager.sh[910]: + ASG_NAME=
Jun 07 15:40:55 authenticate-with-wazuh-manager.sh[910]: + ARGS='describe-auto-scaling-groups --region eu-west-1 --auto-scaling-group-name  --output text'
Jun 07 15:40:55 authenticate-with-wazuh-manager.sh[910]: ++ aws autoscaling describe-auto-scaling-groups --region eu-west-1 --auto-scaling-group-name --output text --query 'AutoScalingGroups[0].Tags[?Key == '\''App'\''].Value'
Jun 07 15:40:55 authenticate-with-wazuh-manager.sh[910]: [SSL] malloc failure (_ssl.c:2805)
Jun 07 15:40:55 authenticate-with-wazuh-manager.sh[910]: ++ true
Jun 07 15:40:55 authenticate-with-wazuh-manager.sh[910]: + APP=
Jun 07 15:40:55 authenticate-with-wazuh-manager.sh[910]: ++ aws autoscaling describe-auto-scaling-groups --region eu-west-1 --auto-scaling-group-name --output text --query 'AutoScalingGroups[0].Tags[?Key == '\''Stack'\''].Value'
Jun 07 15:40:56 authenticate-with-wazuh-manager.sh[910]: [SSL] malloc failure (_ssl.c:2805)
Jun 07 15:40:56 authenticate-with-wazuh-manager.sh[910]: ++ true
Jun 07 15:40:56 authenticate-with-wazuh-manager.sh[910]: + STACK=
Jun 07 15:40:56 authenticate-with-wazuh-manager.sh[910]: ++ aws autoscaling describe-auto-scaling-groups --region eu-west-1 --auto-scaling-group-name --output text --query 'AutoScalingGroups[0].Tags[?Key == '\''Stage'\''].Value'
Jun 07 15:40:56 authenticate-with-wazuh-manager.sh[910]: [SSL] malloc failure (_ssl.c:2805)
Jun 07 15:40:56 authenticate-with-wazuh-manager.sh[910]: ++ true
Jun 07 15:40:56 authenticate-with-wazuh-manager.sh[910]: + STAGE=
Jun 07 15:40:56 authenticate-with-wazuh-manager.sh[910]: + '[' -z '' ']'
Jun 07 15:40:56 authenticate-with-wazuh-manager.sh[910]: + echo 'Failed to fetch ASG tags, fetching instance tags instead'
Jun 07 15:40:56 authenticate-with-wazuh-manager.sh[910]: Failed to fetch ASG tags, fetching instance tags instead
Jun 07 15:40:56 authenticate-with-wazuh-manager.sh[910]: + FILTERS='Name=resource-id,Values=i-xxxxxx Name=resource-type,Values=instance'
Jun 07 15:40:56 authenticate-with-wazuh-manager.sh[910]: + OPTIONS='--query Tags[].Value --output text --region eu-west-1'
Jun 07 15:40:56 authenticate-with-wazuh-manager.sh[910]: ++ aws ec2 describe-tags --filters Name=resource-id,Values=i-xxxxx Name=resource-type,Values=instance Name=key,Values=App --query 'Tags[].Value' --output text --region eu-west-1
Jun 07 15:40:57 authenticate-with-wazuh-manager.sh[910]: [SSL] malloc failure (_ssl.c:2805)
Jun 07 15:40:57 authenticate-with-wazuh-manager.sh[910]: ++ true
Jun 07 15:40:57 authenticate-with-wazuh-manager.sh[910]: + APP=
Jun 07 15:40:57 authenticate-with-wazuh-manager.sh[910]: ++ aws ec2 describe-tags --filters Name=resource-id,Values=i-xxxxx Name=resource-type,Values=instance Name=key,Values=Stack --query 'Tags[].Value' --output text --region eu-west-1
Jun 07 15:40:57 authenticate-with-wazuh-manager.sh[910]: [SSL] malloc failure (_ssl.c:2805)
Jun 07 15:40:58 authenticate-with-wazuh-manager.sh[910]: ++ true
Jun 07 15:40:58 authenticate-with-wazuh-manager.sh[910]: + STACK=
Jun 07 15:40:58 authenticate-with-wazuh-manager.sh[910]: ++ aws ec2 describe-tags --filters Name=resource-id,Values=i-xxxxxx Name=resource-type,Values=instance Name=key,Values=Stage --query 'Tags[].Value' --output text --region eu-west-1
Jun 07 15:40:58 authenticate-with-wazuh-manager.sh[910]: [SSL] malloc failure (_ssl.c:2805)
Jun 07 15:40:58 authenticate-with-wazuh-manager.sh[910]: ++ true
Jun 07 15:40:58 authenticate-with-wazuh-manager.sh[910]: + STAGE=
Jun 07 15:40:58 authenticate-with-wazuh-manager.sh[910]: + cp /var/ossec/etc/ossec.conf /var/ossec/etc/ossec.conf.bak
Jun 07 15:40:58 authenticate-with-wazuh-manager.sh[910]: + sed -i s/MANAGER_IP/manager.wazuh.gutools.co.uk/ /var/ossec/etc/ossec.conf
Jun 07 15:40:58 authenticate-with-wazuh-manager.sh[910]: + sed -i 's/<protocol>udp<\/protocol>/<protocol>tcp<\/protocol>/' /var/ossec/etc/ossec.conf
Jun 07 15:40:58 authenticate-with-wazuh-manager.sh[910]: + cat
Jun 07 15:40:58 authenticate-with-wazuh-manager.sh[910]: + /var/ossec/bin/agent-auth -m manager.wazuh.gutools.co.uk -A ---i-xxxxxx

```