### PR TITLE
Hotfix wazuh

### DIFF
--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -79,6 +79,8 @@
         REGION=$(curl -s -H "X-aws-ec2-metadata-token: `curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`" http://169.254.169.254/latest/meta-data/placement/availability-zone |  sed 's/.$//')
         INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: `curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`" http://169.254.169.254/latest/meta-data/instance-id)
 
+        # force /dev/random to initialise before calling the aws cli (workaround for a regression in Linux/5.4.0-1049-aws)
+        dd bs=32 count=1 if=/dev/random of=/dev/null
         ASG_NAME=$(aws autoscaling describe-auto-scaling-instances --region "$REGION" --instance-ids "$INSTANCE_ID" --output text --query "AutoScalingInstances[0].AutoScalingGroupName" || true)
 
         ARGS="describe-auto-scaling-groups --region "$REGION" --auto-scaling-group-name "$ASG_NAME" --output text"


### PR DESCRIPTION
## What does this change?

This is a hotfix for the issue highlighted in #588. Turns out the revert didn't fix the issue, so it wasn't the original PR that introduced it. The cause for the issue is related to these package changes

![AMIgo](https://user-images.githubusercontent.com/1672034/121227732-d1bc9480-c883-11eb-9ee9-c248b29f5261.png)

Here's the full output with `--debug` flag, where we can see the aws command fails on its attempt to make an https request

```
++ aws autoscaling describe-auto-scaling-instances --debug --region eu-west-1 --instance-ids i-xxxxxxx --output text --query 'AutoScalingInstances[0].AutoScalingGroupName'
2021-06-08 13:20:44,352 - MainThread - awscli.clidriver - DEBUG - CLI version: aws-cli/1.19.12 Python/3.6.9 Linux/5.4.0-1049-aws botocore/1.20.12
2021-06-08 13:20:44,352 - MainThread - awscli.clidriver - DEBUG - Arguments entered to CLI: ['autoscaling', 'describe-auto-scaling-instances', '--debug', '--region', 'eu-west-1', '--instance-ids
2021-06-08 13:20:44,352 - MainThread - botocore.hooks - DEBUG - Event session-initialized: calling handler <function add_scalar_parsers at 0xffffb9eaa268>
2021-06-08 13:20:44,353 - MainThread - botocore.hooks - DEBUG - Event session-initialized: calling handler <function register_uri_param_handler at 0xffffba329620>
2021-06-08 13:20:44,354 - MainThread - botocore.hooks - DEBUG - Event session-initialized: calling handler <function inject_assume_role_provider_cache at 0xffffba302bf8>
2021-06-08 13:20:44,357 - MainThread - awscli.clidriver - DEBUG - Exception caught in main()
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/awscli/clidriver.py", line 213, in main
    self._emit_session_event(parsed_args)
  File "/usr/local/lib/python3.6/dist-packages/awscli/clidriver.py", line 253, in _emit_session_event
    parsed_args=parsed_args)
  File "/usr/local/lib/python3.6/dist-packages/botocore/session.py", line 677, in emit
    return self._events.emit(event_name, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/botocore/hooks.py", line 356, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/botocore/hooks.py", line 228, in emit
    return self._emit(event_name, kwargs)
  File "/usr/local/lib/python3.6/dist-packages/botocore/hooks.py", line 211, in _emit
    response = handler(**kwargs)
  File "/usr/local/lib/python3.6/dist-packages/awscli/customizations/assumerole.py", line 19, in inject_assume_role_provider_cache
    cred_chain = session.get_component('credential_provider')
  File "/usr/local/lib/python3.6/dist-packages/botocore/session.py", line 685, in get_component
    return self._components.get_component(name)
  File "/usr/local/lib/python3.6/dist-packages/botocore/session.py", line 924, in get_component
    self._components[name] = factory()
  File "/usr/local/lib/python3.6/dist-packages/botocore/session.py", line 152, in _create_credential_resolver
    self, region_name=self._last_client_region_used
  File "/usr/local/lib/python3.6/dist-packages/botocore/credentials.py", line 78, in create_credential_resolver
    container_provider = ContainerProvider()
  File "/usr/local/lib/python3.6/dist-packages/botocore/credentials.py", line 1824, in __init__
    fetcher = ContainerMetadataFetcher()
  File "/usr/local/lib/python3.6/dist-packages/botocore/utils.py", line 2059, in __init__
    timeout=self.TIMEOUT_SECONDS
  File "/usr/local/lib/python3.6/dist-packages/botocore/httpsession.py", line 194, in __init__
    self._manager = PoolManager(**self._get_pool_manager_kwargs())
  File "/usr/local/lib/python3.6/dist-packages/botocore/httpsession.py", line 213, in _get_pool_manager_kwargs
    'ssl_context': self._get_ssl_context(),
  File "/usr/local/lib/python3.6/dist-packages/botocore/httpsession.py", line 222, in _get_ssl_context
    return create_urllib3_context()
  File "/usr/local/lib/python3.6/dist-packages/botocore/httpsession.py", line 61, in create_urllib3_context
    context = SSLContext(ssl_version or ssl.PROTOCOL_SSLv23)
  File "/usr/lib/python3.6/ssl.py", line 391, in __new__
    self = _SSLContext.__new__(cls, protocol)
ssl.SSLError: [SSL] malloc failure (_ssl.c:2805)
2021-06-08 13:20:44,372 - MainThread - awscli.clidriver - DEBUG - Exiting with rc 255
[SSL] malloc failure (_ssl.c:2805)
```

My working theory is that this is a bizarre side effect of a regression introduced in linux aws version 5.4.0-1049

The changelog for that new package is [in launchpad](https://launchpad.net/ubuntu/+source/linux-aws-5.4/5.4.0-1049.51~18.04.1), with more information on why they messed up with the random generator in [a bug report](https://bugs.launchpad.net/ubuntu/+source/linux-aws/+bug/1927692).

In short - I believe an attempt by amazon to fix a problem with their second generation gravition instance's ability to generate random numbers has backfired. It's made`/dev/random` not be immediately available upon boot, which makes aws cli's https requests fail with an openssl malloc error (how a random number generator failure causes a malloc failure can be seen on [this openssl issue](https://github.com/openssl/openssl/issues/10015), which is similar but not the same).

This patch works around the problem by manually accessing `/dev/random` before using the aws cli. In the new linux version calling `/dev/random` is a blocking call that will only returns when a random number if available. This means the script will only execute the aws cli call when `dev/random` is ready, which succeeds.

## How to test
This is very painful to test because the initialisation problem only happens on boot, and I could not reproduce it when I booted a CODE ami bake in a test instance.

So this might be a case of merging it, baking a new deploy tools image, and redeploying either amiable or amigo CODE or something like that
