### PR TITLE
refactor: Do not download from S3 unnecessarily

### DIFF
--- a/roles/teamcity-ivy-cache/tasks/main.yml
+++ b/roles/teamcity-ivy-cache/tasks/main.yml
@@ -15,8 +15,8 @@
   shell: aws s3 cp s3://teamcity-sbt-cache/ /opt/teamcity/.sbt/ --recursive --quiet
 - name: initial download ivy
   shell: aws s3 cp s3://teamcity-ivy-cache/ /opt/teamcity/.ivy2/cache/ --recursive --quiet
-- name:  download ivy
-  shell: aws s3 cp s3://teamcity-ivy-cache/ /opt/teamcity/buildAgent/system/sbt_ivy/cache/ --recursive --quiet
+- name: setup ivy cache for agents
+  shell: cp -r /opt/teamcity/.ivy2/cache/ /opt/teamcity/buildAgent/system/sbt_ivy/cache/
 - name: add chron job
   copy:
     src: sync-ivy-cache


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We're currently downloading the same content from S3 into two locations.

This change removes the second download, replacing it with a local disk copy command. This results in less network IO and a faster AMI bake. Logs from previous bakes suggest it takes ~3 minutes to perform the S3 download.

It should also mean a reduction in S3 spend, however looking at the billing dashboard, the savings will be marginal as current spend is in the $10s.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy to CODE
- Bake a recipe that uses the `teamcity-ivy-cache` role, it should complete successfully

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A shorter bake time?

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

Here's the last three months spend on S3. This change won't save massive amounts of money.

![image](https://user-images.githubusercontent.com/836140/122200376-e48e2500-ce92-11eb-9663-14c36fc024a8.png)