### PR TITLE
fix: Fix `teamcity-agent` role

### DIFF
--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -74,9 +74,6 @@
   become_user: teamcity
   args:
     executable: /bin/bash
-- name: add caches
-  import_role:
-    name: teamcity-ivy-cache
 - name: chown teamcity to teamcity
   file:
     path: /opt/teamcity


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

As it turns out, the role deleted in #593 _is_ used, it just doesn't get reported in the "Used by" tab.

This change updates the `teamcity-agent` role to remove the dependency as I think the [`teamcityagent.service` file](https://github.com/guardian/amigo/blob/cabb7d47ae83c6ca87650681b382a41af7434022/roles/teamcity-agent/files/teamcityagent.service#L9-L11) performs the same steps that `teamcity-ivy-cache` did (downloading files from S3).