### PR TITLE
revert: "chore: Remove unused teamcity-ivy-cache role" #593

### DIFF
--- a/roles/teamcity-ivy-cache/README.md
+++ b/roles/teamcity-ivy-cache/README.md
@@ -1,0 +1,3 @@
+# Teamcity IVY Cache
+
+This sets up the ivy cache on a teamcity agent and synchronises it.

--- a/roles/teamcity-ivy-cache/README.md
+++ b/roles/teamcity-ivy-cache/README.md
@@ -1,3 +1,6 @@
 # Teamcity IVY Cache
 
 This sets up the ivy cache on a teamcity agent and synchronises it.
+
+It gets reported as unused in "Used by" as it's not directly used by a recipe.
+It is however used by the [`teamcity-agent`](../teamcity-agent/tasks/main.yml) role via `import_role`.

--- a/roles/teamcity-ivy-cache/files/sync-ivy-cache
+++ b/roles/teamcity-ivy-cache/files/sync-ivy-cache
@@ -1,0 +1,4 @@
+*/15 * * * * teamcity aws s3 sync --exclude '*ivydata-*.properties' --storage-class REDUCED_REDUNDANCY /opt/teamcity/.ivy2/cache/ s3://teamcity-ivy-cache/ > /dev/null 2>&1
+5-51/15 * * * * teamcity aws s3 sync --exclude '*ivydata-*.properties' --storage-class REDUCED_REDUNDANCY /opt/teamcity/buildAgent/system/sbt_ivy/cache/ s3://teamcity-ivy-cache/ > /dev/null 2>&1
+# Push sbt deps to S3
+10-56/15 * * * * teamcity aws s3 sync --exclude '*.lock' --storage-class REDUCED_REDUNDANCY /opt/teamcity/.sbt/ s3://teamcity-sbt-cache/ > /dev/null 2>&1

--- a/roles/teamcity-ivy-cache/tasks/main.yml
+++ b/roles/teamcity-ivy-cache/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: teamcity-sbt-cache dir
+  file:
+    path: /opt/teamcity/.sbt
+    state: directory
+- name: teamcity ivy cache
+  file:
+    path: /opt/teamcity/.ivy2/cache
+    state: directory
+- name: teamcity ivy cache
+  file:
+    path: /opt/teamcity/buildAgent/system/sbt_ivy/cache/
+    state: directory
+- name: initial download sbt
+  shell: aws s3 cp s3://teamcity-sbt-cache/ /opt/teamcity/.sbt/ --recursive --quiet
+- name: initial download ivy
+  shell: aws s3 cp s3://teamcity-ivy-cache/ /opt/teamcity/.ivy2/cache/ --recursive --quiet
+- name:  download ivy
+  shell: aws s3 cp s3://teamcity-ivy-cache/ /opt/teamcity/buildAgent/system/sbt_ivy/cache/ --recursive --quiet
+- name: add chron job
+  copy:
+    src: sync-ivy-cache
+    dest: /etc/cron.d/sync-ivy-cache
+- name: chown teamcity to teamcity
+  file:
+    path: /opt/teamcity
+    recurse: true
+    owner: teamcity

--- a/roles/teamcity-ivy-cache/tasks/main.yml
+++ b/roles/teamcity-ivy-cache/tasks/main.yml
@@ -17,7 +17,7 @@
   shell: aws s3 cp s3://teamcity-ivy-cache/ /opt/teamcity/.ivy2/cache/ --recursive --quiet
 - name:  download ivy
   shell: aws s3 cp s3://teamcity-ivy-cache/ /opt/teamcity/buildAgent/system/sbt_ivy/cache/ --recursive --quiet
-- name: add chron job
+- name: set up upload to S3 cron
   copy:
     src: sync-ivy-cache
     dest: /etc/cron.d/sync-ivy-cache


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

As it turns out, the `teamcity-ivy-cache` role _is_ used. The `teamcity-agent` role [imports](https://github.com/guardian/amigo/blob/cabb7d47ae83c6ca87650681b382a41af7434022/roles/teamcity-agent/tasks/main.yml#L77-L79) it. This PR reverts https://github.com/guardian/amigo/pull/593 and updates some documentation for clarity.