### PR TITLE
refactor: Use Parameter Store for dist bucket

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -118,11 +118,14 @@ Resources:
           Action:
             - sns:Publish
           Resource: !Ref AnghammaradTopicArn
+
+        # Allow us to allow other accounts to retrieve the ImageCopier lambda artifact
         - Effect: Allow
           Action:
           - s3:GetBucketPolicy
           - s3:PutBucketPolicy
           Resource: !Join [ "", [ "arn:aws:s3::*:", !Ref DistributionBucketName ] ]
+
         - Effect: Allow
           Action:
             - s3:GetObject

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -36,6 +36,10 @@ Parameters:
   AnghammaradTopicArn:
     Type: String
     Description: Anghammarad sns notifications topic arn
+  DistributionBucketName:
+    Description: SSM parameter containing the S3 bucket name holding distribution artifacts
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /account/services/artifact.bucket
 
 Mappings:
   Config:
@@ -67,7 +71,7 @@ Resources:
           Action:
           - s3:GetObject
           Resource:
-          - arn:aws:s3::*:deploy-tools-dist/*
+          - !Join [ "", [ "arn:aws:s3::*:", !Ref DistributionBucketName, "/*" ] ]
       Roles:
       - !Ref 'RootRole'
   AmigoAppPolicy:
@@ -118,7 +122,7 @@ Resources:
           Action:
           - s3:GetBucketPolicy
           - s3:PutBucketPolicy
-          Resource: arn:aws:s3::*:deploy-tools-dist
+          Resource: !Join [ "", [ "arn:aws:s3::*:", !Ref DistributionBucketName ] ]
         - Effect: Allow
           Action:
             - s3:GetObject
@@ -290,7 +294,7 @@ Resources:
           wget -P /tmp https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_arm64/session-manager-plugin.deb
           dpkg -i /tmp/session-manager-plugin.deb
 
-          aws --region eu-west-1 s3 cp s3://deploy-tools-dist/deploy/${Stage}/amigo/amigo_1.0-latest_all.deb /tmp/amigo.deb
+          aws --region eu-west-1 s3 cp s3://${DistributionBucketName}/deploy/${Stage}/amigo/amigo_1.0-latest_all.deb /tmp/amigo.deb
           dpkg -i /tmp/amigo.deb
 
   LoadBalancerSecurityGroup:


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Our current best practice is to retrieve the distribution bucket from Parameter Store.

This change updates the main template, adding a new parameter with a default value of the standard location. It also adds a comment to a somewhat confusing policy for future reference.

This is part of the preparation work to move this stack definition into CDK.

See:
  - https://github.com/guardian/cdk/blob/main/docs/005-default-parameter-store-locations.md