### PR TITLE
feat: Define `SSMRunCommandPolicy` in the CDK stack

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -714,7 +714,7 @@ dpkg -i /tmp/amigo.deb
       },
       "Type": "AWS::IAM::Role",
     },
-    "SSMRunCommandPolicy": Object {
+    "SSMRunCommandPolicy244E1613": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -730,22 +730,52 @@ dpkg -i /tmp/amigo.deb
                 "ssm:ListInstanceAssociations",
                 "ssm:DescribeInstanceProperties",
                 "ssm:DescribeDocumentParameters",
-                "ssm:StartSession",
                 "ssmmessages:CreateControlChannel",
                 "ssmmessages:CreateDataChannel",
                 "ssmmessages:OpenControlChannel",
                 "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "ssm:StartSession",
                 "ssm:TerminateSession",
               ],
               "Effect": "Allow",
               "Resource": "*",
             },
           ],
+          "Version": "2012-10-17",
         },
         "PolicyName": "ssm-run-command-policy",
         "Roles": Array [
           Object {
-            "Ref": "RootRole",
+            "Fn::Select": Array [
+              1,
+              Object {
+                "Fn::Split": Array [
+                  "/",
+                  Object {
+                    "Fn::Select": Array [
+                      5,
+                      Object {
+                        "Fn::Split": Array [
+                          ":",
+                          Object {
+                            "Fn::GetAtt": Array [
+                              "RootRole",
+                              "Arn",
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
           },
         ],
       },

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -1,8 +1,11 @@
 import path from "path";
+import type { CfnRole } from "@aws-cdk/aws-iam";
+import { Effect, PolicyStatement, Role } from "@aws-cdk/aws-iam";
 import { CfnInclude } from "@aws-cdk/cloudformation-include";
 import type { App } from "@aws-cdk/core";
 import type { GuStackProps, GuStageParameter } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
+import { GuSSMRunCommandPolicy } from "@guardian/cdk/lib/constructs/iam";
 
 const yamlTemplateFilePath = path.join(__dirname, "../../cloudformation.yaml");
 
@@ -10,11 +13,30 @@ export class AmigoStack extends GuStack {
   constructor(scope: App, id: string, props: GuStackProps) {
     super(scope, id, props);
 
-    new CfnInclude(this, "YamlTemplate", {
+    const yamlDefinedStack = new CfnInclude(this, "YamlTemplate", {
       templateFile: yamlTemplateFilePath,
       parameters: {
         Stage: this.getParam<GuStageParameter>("Stage"), // TODO `GuStageParameter` could be a singleton to simplify this
       },
     });
+
+    // See https://docs.aws.amazon.com/cdk/latest/guide/use_cfn_template.html#use_cfn_template_cfninclude_access
+    const cfnRootRole = yamlDefinedStack.getResource("RootRole") as CfnRole;
+    const rootRole = Role.fromRoleArn(this, "RootRole", cfnRootRole.attrArn);
+
+    const ssmPolicy = GuSSMRunCommandPolicy.getInstance(this);
+
+    // TODO Can GuSSMRunCommandPolicy expose its default `PolicyStatement` to easily add actions to it?
+    ssmPolicy.addStatements(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        resources: ["*"],
+
+        // required to allow Packer to run SSM commands
+        // see https://github.com/guardian/amigo/pull/526 and https://github.com/guardian/amigo/pull/538
+        actions: ["ssm:StartSession", "ssm:TerminateSession"],
+      })
+    );
+    ssmPolicy.attachToRole(rootRole);
   }
 }

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -145,35 +145,6 @@ Resources:
       Roles:
       - !Ref 'RootRole'
 
-  SSMRunCommandPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: ssm-run-command-policy
-      PolicyDocument:
-        Statement:
-        # minimal policy to allow running commands via ssm
-        - Effect: Allow
-          Resource: "*"
-          Action:
-          - ec2messages:AcknowledgeMessage
-          - ec2messages:DeleteMessage
-          - ec2messages:FailMessage
-          - ec2messages:GetEndpoint
-          - ec2messages:GetMessages
-          - ec2messages:SendReply
-          - ssm:UpdateInstanceInformation
-          - ssm:ListInstanceAssociations
-          - ssm:DescribeInstanceProperties
-          - ssm:DescribeDocumentParameters
-          - ssm:StartSession
-          - ssmmessages:CreateControlChannel
-          - ssmmessages:CreateDataChannel
-          - ssmmessages:OpenControlChannel
-          - ssmmessages:OpenDataChannel
-          - ssm:TerminateSession
-      Roles:
-      - !Ref RootRole
-
   LogShippingPolicy:
     Type: AWS::IAM::Policy
     Properties:


### PR DESCRIPTION
Builds on https://github.com/guardian/amigo/pull/598.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Moving the `SSMRunCommandPolicy` resource into the CDK stack.

This is chosen because it's fairly easy to test if it works: if successful, we can continue to connect to an instance using ssm-scala.

AMIgo's stack defines two additional actions over the standard `GuSSMRunCommandPolicy`:
  1. ssm:StartSession
  2. ssm:TerminateSession

Slightly annoyingly, `GuSSMRunCommandPolicy` is a singleton and doesn't accept additional input. Therefore, we have to add these actions into a new statement on the policy.

`GuSSMRunCommandPolicy`'s `Roles` array is kinda hilarious (see snapshot test change). The good news is it's done by AWS CDK magic, so should work!

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Perform a full deploy of this branch on CODE
- Attempt to connect to one of the instances (`ssm ssh -t amigo,CODE -p deployTools --newest -x`) and witness it succeed

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We move closer to a CDK only template.