### PR TITLE
feat: Use GuCDK's log shipping policy construct

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -33,9 +33,10 @@ Object {
       "Description": "EC2 instance type",
       "Type": "String",
     },
-    "KinesisStreamName": Object {
-      "Description": "The name (NOT arn) of the Kinesis stream that logs should be shipped to",
-      "Type": "String",
+    "LoggingStreamName": Object {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "PackerInstanceProfile": Object {
       "Description": "Instance profile given to instances created by Packer",
@@ -366,6 +367,71 @@ Object {
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
     },
+    "GuLogShippingPolicy981BFE5A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:kinesis:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    Object {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": Array [
+          Object {
+            "Fn::Select": Array [
+              1,
+              Object {
+                "Fn::Split": Array [
+                  "/",
+                  Object {
+                    "Fn::Select": Array [
+                      5,
+                      Object {
+                        "Fn::Split": Array [
+                          ":",
+                          Object {
+                            "Fn::GetAtt": Array [
+                              "RootRole",
+                              "Arn",
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "InstanceProfile": Object {
       "Properties": Object {
         "Path": "/",
@@ -536,33 +602,6 @@ dpkg -i /tmp/amigo.deb
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
-    },
-    "LogShippingPolicy": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "kinesis:Describe*",
-                "kinesis:Put*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Sub": "arn:aws:kinesis:\${AWS::Region}:\${AWS::AccountId}:stream/\${KinesisStreamName}",
-                },
-              ],
-            },
-          ],
-        },
-        "PolicyName": "log-shipping-policy",
-        "Roles": Array [
-          Object {
-            "Ref": "RootRole",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "PackerPolicy": Object {
       "Properties": Object {

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -5,7 +5,7 @@ import { CfnInclude } from "@aws-cdk/cloudformation-include";
 import type { App } from "@aws-cdk/core";
 import type { GuStackProps, GuStageParameter } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
-import { GuSSMRunCommandPolicy } from "@guardian/cdk/lib/constructs/iam";
+import { GuLogShippingPolicy, GuSSMRunCommandPolicy } from "@guardian/cdk/lib/constructs/iam";
 
 const yamlTemplateFilePath = path.join(__dirname, "../../cloudformation.yaml");
 
@@ -38,5 +38,7 @@ export class AmigoStack extends GuStack {
       })
     );
     ssmPolicy.attachToRole(rootRole);
+
+    GuLogShippingPolicy.getInstance(this).attachToRole(rootRole);
   }
 }

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -30,9 +30,6 @@ Parameters:
   TLSCert:
     Type: String
     Description: ARN of a TLS certificate to install on the load balancer
-  KinesisStreamName:
-    Type: String
-    Description: The name (NOT arn) of the Kinesis stream that logs should be shipped to
   AnghammaradTopicArn:
     Type: String
     Description: Anghammarad sns notifications topic arn
@@ -144,21 +141,6 @@ Resources:
           Resource: !Ref PackerInstanceProfile
       Roles:
       - !Ref 'RootRole'
-
-  LogShippingPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: log-shipping-policy
-      PolicyDocument:
-        Statement:
-        - Effect: Allow
-          Action:
-          - kinesis:Describe*
-          - kinesis:Put*
-          Resource:
-          - !Sub arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStreamName}
-      Roles:
-      - !Ref RootRole
 
   PackerPolicy:
     Type: AWS::IAM::Policy


### PR DESCRIPTION
Follows #600.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This change replaces the YAML defined log shipping policy with the GuCDK's `GuLogShippingPolicy` construct.

`GuLogShippingPolicy` also brings a Parameter Store driven parameter into the stack, which replaces `KinesisStreamName`.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Perform a full deploy of this branch
- Witness logs continuing to be shipped into Central ELK

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We move closer to a CDK only template.