### PR TITLE
chore: Update `sbt-riffraff-artifact` plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.8")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts Artifact("jdeb", "jar", "jar")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

I noticed that the `buildNumber` marker in the logs is currently `unknown`.

The value of this comes from [`sbt-riffraff-artifact`](https://github.com/guardian/sbt-riffraff-artifact). I'm not sure when, so bumping it to the latest.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy to CODE
- Observe logs in Central ELK

OR

- See images below

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Our log lines are more accurate.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

### Before
![image](https://user-images.githubusercontent.com/836140/122768083-2952fb00-d29b-11eb-9e32-8851b8b72869.png)

### After
![image](https://user-images.githubusercontent.com/836140/122767980-14766780-d29b-11eb-8d7b-75f00cd0a6ab.png)
