### PR TITLE
feat: Move to GuCDK's policy to get the artifact 

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -367,6 +367,65 @@ Object {
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
     },
+    "GetDistributablePolicyAmigoB25A5D2B": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/deploy/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/amigo/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyAmigoB25A5D2B",
+        "Roles": Array [
+          Object {
+            "Fn::Select": Array [
+              1,
+              Object {
+                "Fn::Split": Array [
+                  "/",
+                  Object {
+                    "Fn::Select": Array [
+                      5,
+                      Object {
+                        "Fn::Split": Array [
+                          ":",
+                          Object {
+                            "Fn::GetAtt": Array [
+                              "RootRole",
+                              "Arn",
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "GuLogShippingPolicy981BFE5A": Object {
       "Properties": Object {
         "PolicyDocument": Object {
@@ -477,6 +536,9 @@ aws --region eu-west-1 s3 cp s3://\${DistributionBucketName}/deploy/\${Stage}/am
 dpkg -i /tmp/amigo.deb
 ",
               Object {
+                "DistributionBucketName": Object {
+                  "Ref": "DistributionBucketName",
+                },
                 "Stage": Object {
                   "Ref": "Stage",
                 },
@@ -815,41 +877,6 @@ dpkg -i /tmp/amigo.deb
                 ],
               },
             ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "UserDataPolicy": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "s3:GetObject",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:aws:s3::*:",
-                      Object {
-                        "Ref": "DistributionBucketName",
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-        "PolicyName": "download-artifacts-from-s3",
-        "Roles": Array [
-          Object {
-            "Ref": "RootRole",
           },
         ],
       },

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -20,6 +20,9 @@ export class AmigoStack extends GuStack {
 
     const yamlDefinedStack = new CfnInclude(this, "YamlTemplate", {
       templateFile: yamlTemplateFilePath,
+
+      // These override like-named parameters in the YAML template.
+      // TODO remove the parameter from the YAML template once each resource that uses it has been CDK-ified.
       parameters: {
         Stage: this.getParam<GuStageParameter>("Stage"), // TODO `GuStageParameter` could be a singleton to simplify this
         DistributionBucketName: GuDistributionBucketParameter.getInstance(this).valueAsString,

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -65,19 +65,6 @@ Resources:
           Value: deploy
         - Key: Stage
           Value: !Ref 'Stage'
-  UserDataPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: download-artifacts-from-s3
-      PolicyDocument:
-        Statement:
-        - Effect: Allow
-          Action:
-          - s3:GetObject
-          Resource:
-          - !Join [ "", [ "arn:aws:s3::*:", !Ref DistributionBucketName, "/*" ] ]
-      Roles:
-      - !Ref 'RootRole'
   AmigoAppPolicy:
     Type: AWS::IAM::Policy
     Properties:


### PR DESCRIPTION
Builds on #598.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Replace the YAML resource that allows the instance to download the artifact from S3 with a GuCDK construct.

This has a secondary benefit where we follow the principle of least privilege as GuCDK [tightly scopes](https://github.com/guardian/cdk/pull/259) the `s3:GetObject` permission.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Perform a full deploy of this branch. If you can, then we can still get the correct files from S3 🎉 .

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We move closer to a CDK only template and have tighter access policies.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

The AMIgo application code might require access to the bucket on a path different from `bucket/stack/stage/app/*`. I can't see anything obvious to this effect though, so it should be ok.