### PR TITLE
feat: Define EC2 policies with GuCDK construct

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -109,21 +109,6 @@ Object {
               "Resource": "arn:aws:dynamodb:*:*:table/config-deploy",
             },
             Object {
-              "Action": "ec2:DescribeTags",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            Object {
-              "Action": "autoscaling:DescribeAutoScalingGroups",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            Object {
-              "Action": "autoscaling:DescribeAutoScalingInstances",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            Object {
               "Action": Array [
                 "sns:ListTopics",
               ],
@@ -366,6 +351,55 @@ Object {
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "DescribeEC2PolicyFF5F9295": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": Array [
+          Object {
+            "Fn::Select": Array [
+              1,
+              Object {
+                "Fn::Split": Array [
+                  "/",
+                  Object {
+                    "Fn::Select": Array [
+                      5,
+                      Object {
+                        "Fn::Split": Array [
+                          ":",
+                          Object {
+                            "Fn::GetAtt": Array [
+                              "RootRole",
+                              "Arn",
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "GetDistributablePolicyAmigoB25A5D2B": Object {
       "Properties": Object {

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -8,6 +8,7 @@ import { GuDistributionBucketParameter, GuStack } from "@guardian/cdk/lib/constr
 import type { AppIdentity } from "@guardian/cdk/lib/constructs/core/identity";
 import {
   GuAllowPolicy,
+  GuDescribeEC2Policy,
   GuGetDistributablePolicy,
   GuLogShippingPolicy,
   GuSSMRunCommandPolicy,
@@ -96,5 +97,7 @@ export class AmigoStack extends GuStack {
         "iam:PassRole",
       ],
     }).attachToRole(rootRole);
+
+    GuDescribeEC2Policy.getInstance(this).attachToRole(rootRole);
   }
 }

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -85,15 +85,6 @@ Resources:
           - dynamodb:GetItem
           Resource: arn:aws:dynamodb:*:*:table/config-deploy
         - Effect: Allow
-          Action: ec2:DescribeTags
-          Resource: '*'
-        - Effect: Allow
-          Action: autoscaling:DescribeAutoScalingGroups
-          Resource: '*'
-        - Effect: Allow
-          Action: autoscaling:DescribeAutoScalingInstances
-          Resource: '*'
-        - Effect: Allow
           Action:
           - sns:ListTopics
           Resource: '*'


### PR DESCRIPTION
Builds on #598.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

An app's identity is defined by the App, Stack and Stage tags.

This change uses the `GuDescribeEC2Policy` construct to allow an app to know it's identity, replacing the YAML definition.

In using the construct, we're also creating the policy as a resource in its own right. This is preferred as it follows the single responsibility principle.

The `GuDescribeEC2Policy` construct grants the following permissions on `"*"`:
  - autoscaling:DescribeAutoScalingInstances
  - autoscaling:DescribeAutoScalingGroups
  - ec2:DescribeTags
  - ec2:DescribeInstances

That is, there is an additional `ec2:DescribeInstances` permission being granted.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

I think we can test this by observing log lines as it looks like the logs' [identity based markers](https://github.com/guardian/amigo/blob/ccd7aba578bd302a6a042f1f621e337054f1e6c6/app/services/ELKLogging.scala#L24-L30) originate from [tag look ups](https://github.com/guardian/amigo/blob/ccd7aba578bd302a6a042f1f621e337054f1e6c6/app/components/AppComponents.scala#L71); success is the markers in the log lines continue to be populated.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We move closer to a CDK only template and follow best practice of single responsibility resources.