### PR TITLE
Remove renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ],
-  "masterIssue": true
-}


### PR DESCRIPTION
We are no longer trialling renovate so let's remove it. This is a follow up from https://github.com/guardian/amigo/pull/609 which missedd out this file