### PR TITLE
feat: Move Anghammarad policy into CDK

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -20,9 +20,10 @@ Object {
       "Description": "AMI ID",
       "Type": "String",
     },
-    "AnghammaradTopicArn": Object {
-      "Description": "Anghammarad sns notifications topic arn",
-      "Type": "String",
+    "AnghammaradSnsArn": Object {
+      "Default": "/account/services/anghammarad.topic.arn",
+      "Description": "SSM parameter containing the ARN of the Anghammarad SNS topic",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "DistributionBucketName": Object {
       "Default": "/account/services/artifact.bucket",
@@ -145,15 +146,6 @@ Object {
                     },
                   },
                 ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "sns:Publish",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Ref": "AnghammaradTopicArn",
               },
             },
             Object {
@@ -429,6 +421,52 @@ Object {
           "Version": "2012-10-17",
         },
         "PolicyName": "GetDistributablePolicyAmigoB25A5D2B",
+        "Roles": Array [
+          Object {
+            "Fn::Select": Array [
+              1,
+              Object {
+                "Fn::Split": Array [
+                  "/",
+                  Object {
+                    "Fn::Select": Array [
+                      5,
+                      Object {
+                        "Fn::Split": Array [
+                          ":",
+                          Object {
+                            "Fn::GetAtt": Array [
+                              "RootRole",
+                              "Arn",
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuAnghammaradSenderPolicy674A3874": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Ref": "AnghammaradSnsArn",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuAnghammaradSenderPolicy674A3874",
         "Roles": Array [
           Object {
             "Fn::Select": Array [

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -8,6 +8,7 @@ import { GuDistributionBucketParameter, GuStack } from "@guardian/cdk/lib/constr
 import type { AppIdentity } from "@guardian/cdk/lib/constructs/core/identity";
 import {
   GuAllowPolicy,
+  GuAnghammaradSenderPolicy,
   GuDescribeEC2Policy,
   GuGetDistributablePolicy,
   GuLogShippingPolicy,
@@ -99,5 +100,7 @@ export class AmigoStack extends GuStack {
     }).attachToRole(rootRole);
 
     GuDescribeEC2Policy.getInstance(this).attachToRole(rootRole);
+
+    GuAnghammaradSenderPolicy.getInstance(this).attachToRole(rootRole);
   }
 }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -35,7 +35,7 @@
     "@aws-cdk/aws-s3": "1.107.0",
     "@aws-cdk/cloudformation-include": "1.107.0",
     "@aws-cdk/core": "1.107.0",
-    "@guardian/cdk": "19.1.0",
+    "@guardian/cdk": "19.2.1",
     "source-map-support": "^0.5.16"
   }
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -2299,10 +2299,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@19.1.0":
-  version "19.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-19.1.0.tgz#f2f182cffe070676df4df2fc0d09e8d5f646756c"
-  integrity sha512-8Pvuo8tBe38LzsnRAmWTewxdVTibsuDkz3zzwRd/sovmdwbF9pOxq4Yeow99vEMEnHGJzuEsg9XhPCUbWsYMaw==
+"@guardian/cdk@19.2.1":
+  version "19.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-19.2.1.tgz#c89265fb61c47ec2f70f375740e2899f51758497"
+  integrity sha512-c+5w/wxvx8+1+9DorUWqqh+8VY2iIGgjqnZ9FCTrFbFN/l77W6eyv8tA9Qx1C7uWpPGWG+x3/hwfL8tCK/6gtA==
   dependencies:
     "@aws-cdk/assert" "1.107.0"
     "@aws-cdk/aws-apigateway" "1.107.0"
@@ -2319,7 +2319,7 @@
     "@aws-cdk/aws-rds" "1.107.0"
     "@aws-cdk/aws-s3" "1.107.0"
     "@aws-cdk/core" "1.107.0"
-    aws-sdk "^2.919.0"
+    aws-sdk "^2.929.0"
     execa "^5.1.1"
     git-url-parse "^11.4.4"
     read-pkg-up "7.0.1"
@@ -3016,10 +3016,25 @@ aws-cdk@1.107.0:
     yaml "1.10.2"
     yargs "^16.2.0"
 
-aws-sdk@^2.848.0, aws-sdk@^2.919.0:
+aws-sdk@^2.848.0:
   version "2.930.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.930.0.tgz#f98871a790ffdbfae5439e50db99f6d4635afe19"
   integrity sha512-g8fPOy7Skh2Pqpz2SaDI+M9re2rjTWBQUirAMgtUD/6I/Lf6CR1Q0amsjtQU8WqRQH06kNGwuLtc8Tt6wAux3Q==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
+aws-sdk@^2.929.0:
+  version "2.932.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.932.0.tgz#43da32ab6de58a0eac6c7976feb6c9879fe09e7c"
+  integrity sha512-U6MWUtFD0npWa+ReVEgm0fCIM0fMOYahFp14GLv8fC+BWOTvh5Iwt/gF8NrLomx42bBjA1Abaw6yhmiaSJDQHQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -30,9 +30,6 @@ Parameters:
   TLSCert:
     Type: String
     Description: ARN of a TLS certificate to install on the load balancer
-  AnghammaradTopicArn:
-    Type: String
-    Description: Anghammarad sns notifications topic arn
   DistributionBucketName:
     Description: SSM parameter containing the S3 bucket name holding distribution artifacts
     Type: AWS::SSM::Parameter::Value<String>
@@ -96,10 +93,6 @@ Resources:
           Action:
           - sns:*
           Resource: !Sub 'arn:aws:sns:*:*:amigo-${Stage}-housekeeping-notify'
-        - Effect: Allow
-          Action:
-            - sns:Publish
-          Resource: !Ref AnghammaradTopicArn
 
         # Allow us to allow other accounts to retrieve the ImageCopier lambda artifact
         - Effect: Allow


### PR DESCRIPTION
Builds on #598.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This change moves the Anghammarad permissions into the CDK defined stack.

The permissions get created as a policy in its own right, rather than statements on a generic "amigo-app" policy.

This results in a LOC increase to the resulting CFN template. That is, we're increasing the chance of reaching the CFN template limit!

This stack is pretty small, we should adjust strategy only when needed.

The change set includes changes to `cdk/package.json` and `cdk/yarn.lock` because `@guardian/cdk` has been updated to get the new construct (see https://github.com/guardian/cdk/pull/626).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

We only [talk to Anghammarad](https://github.com/guardian/amigo/search?q=%22Anghammarad.notify%22) on bake failure at the moment.

I've tested this by creating a bake in CODE that installs an invalid package (filebeat version X.Y.Z). We've successfully received the notification (screenshot below) 🎉 .

Thanks for the suggestion @jacobwinch !

![image](https://user-images.githubusercontent.com/836140/123071781-dac56e00-d40c-11eb-9ace-66b53d9e7e6e.png)


## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We move closer to a CDK only template.