### PR TITLE
fix: Remove redundant port 80 load balancer access

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -634,11 +634,6 @@ dpkg -i /tmp/amigo.deb
         "Listeners": Array [
           Object {
             "InstancePort": "9000",
-            "LoadBalancerPort": "80",
-            "Protocol": "HTTP",
-          },
-          Object {
-            "InstancePort": "9000",
             "LoadBalancerPort": "443",
             "Protocol": "HTTPS",
             "SSLCertificateId": Object {
@@ -694,12 +689,6 @@ dpkg -i /tmp/amigo.deb
           },
         ],
         "SecurityGroupIngress": Array [
-          Object {
-            "CidrIp": "77.91.248.0/21",
-            "FromPort": 80,
-            "IpProtocol": "tcp",
-            "ToPort": 80,
-          },
           Object {
             "CidrIp": "77.91.248.0/21",
             "FromPort": 443,

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -127,9 +127,6 @@ Resources:
       Subnets: !Ref 'PublicSubnets'
       CrossZone: true
       Listeners:
-      - Protocol: HTTP
-        LoadBalancerPort: '80'
-        InstancePort: '9000'
       - Protocol: HTTPS
         LoadBalancerPort: '443'
         InstancePort: '9000'
@@ -200,10 +197,6 @@ Resources:
         80
       VpcId: !Ref 'VPC'
       SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: '80'
-        ToPort: '80'
-        CidrIp: 77.91.248.0/21
       - IpProtocol: tcp
         FromPort: '443'
         ToPort: '443'


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We have the HSTS header set for the CODE and PROD domains.

The HSTS header results in user agents always using HTTPS (443).

Not all user agents observe the HSTS header (e.g. curl), however:
  - We only use AMIgo via the browser, which does observe HSTS
  - AMIgo can still be accessed over HTTPS (443)

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Fairly simply - the app should still be accessible after deploying this branch.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A smaller CFN stack.
