### PR TITLE
feat: Add `diff` script to easily compare against AWS

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -11,6 +11,7 @@ find useful scripts within the [`script`](./script) directory for common tasks.
 - `./script/start` to run the Jest unit tests in watch mode
 - `./script/lint` to lint the code using ESLint
 - `./script/test` to lint, run tests and generate templates of the CDK stacks
+- `./script/diff [--prod]` to show the difference between the CDK template and the stack in AWS
 
 There are also some other commands defined in `package.json`, including:
 

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,9 +1,12 @@
 import { App } from "@aws-cdk/core";
 import { AmigoStack } from "../lib/amigo";
 
+const stackName = process.env.GU_CDK_STACK_NAME;
+
 const app = new App();
 
 new AmigoStack(app, "AMIgo", {
   stack: "deploy",
   migratedFromCloudFormation: true,
+  stackName,
 });

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write \"{lib,bin}/**/*.ts\"",
     "cdk": "cdk",
     "lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
-    "synth": "cdk synth --path-metadata false --version-reporting false"
+    "synth": "cdk synth --path-metadata false --version-reporting false",
+    "diff": "cdk diff --path-metadata false --version-reporting false"
   },
   "devDependencies": {
     "@aws-cdk/assert": "1.107.0",

--- a/cdk/script/diff
+++ b/cdk/script/diff
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+STACK_NAME=amigo-CODE
+PROFILE=deployTools
+
+for arg in "$@"; do
+  if [ "$arg" == "--prod" ]; then
+    STACK_NAME=amigo-PROD
+    shift
+  fi
+done
+
+checkCredentials() {
+  STATUS=$(aws sts get-caller-identity --profile ${PROFILE} 2>&1 || true)
+
+  if [[ ${STATUS} =~ (ExpiredToken) ]]; then
+    echo "Credentials for profile '${PROFILE}' have expired. Fetch new credentials."
+    exit 1
+  elif [[ ${STATUS} =~ ("could not be found") ]]; then
+    echo "Credentials for profile '${PROFILE}' are missing. Fetch credentials."
+    exit 1
+  fi
+}
+
+checkCredentials
+
+export GU_CDK_STACK_NAME=${STACK_NAME}
+export AWS_PROFILE=${PROFILE}
+
+yarn diff


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The `cdk diff` command will compare a CDK stack against one running in AWS.

By default, `cdk` will use the `id` argument as the AWS stack name. That is, by default `cdk` will try to compare against the AWS stack "AMIgo".

This change creates a script that will read the stack name from an envvar instead, wrapping it all up in a new script for ease.

You can run `./script/diff` to compare against the CODE stack in AWS, or `./script/diff --prod` to compare against the PROD stack in AWS.

The script will also check your credentials as `cdk` seems to just hang if your credentials are invalid.

<details>
<summary>Example output</summary>

```console
➜ ./script/diff
yarn run v1.22.10
warning package.json: No license field
$ cdk diff --path-metadata false --version-reporting false
Stack AMIgo (amigo-CODE)
There were no differences
✨  Done in 3.62s.
```

</details>

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Checkout this branch
- Run `./script/diff` and observe the output

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Local development is that much easier.