### PR TITLE
feat: Move the data bucket into the GuCDK stack

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -5,12 +5,12 @@ Object {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "AMIgo, an AMI bakery",
   "Mappings": Object {
-    "Config": Object {
+    "stagemapping": Object {
       "CODE": Object {
-        "LowerCaseName": "code",
+        "DataBucketName": "amigo-data-code",
       },
       "PROD": Object {
-        "LowerCaseName": "prod",
+        "DataBucketName": "amigo-data-prod",
       },
     },
   },
@@ -168,17 +168,6 @@ Object {
             },
             Object {
               "Action": Array [
-                "s3:GetObject",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Sub": "arn:aws:s3:::\${AmigoDataBucket}/*",
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
                 "iam:GetInstanceProfile",
               ],
               "Effect": "Allow",
@@ -201,19 +190,12 @@ Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "BucketName": Object {
-          "Fn::Sub": Array [
-            "amigo-data-\${LowerCaseStage}",
+          "Fn::FindInMap": Array [
+            "stagemapping",
             Object {
-              "LowerCaseStage": Object {
-                "Fn::FindInMap": Array [
-                  "Config",
-                  Object {
-                    "Ref": "Stage",
-                  },
-                  "LowerCaseName",
-                ],
-              },
+              "Ref": "Stage",
             },
+            "DataBucketName",
           ],
         },
         "Tags": Array [
@@ -242,6 +224,64 @@ Object {
         ],
       },
       "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "AppPolicyF941AEC5": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "AmigoDataBucket",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "app-policy",
+        "Roles": Array [
+          Object {
+            "Fn::Select": Array [
+              1,
+              Object {
+                "Fn::Split": Array [
+                  "/",
+                  Object {
+                    "Fn::Select": Array [
+                      5,
+                      Object {
+                        "Fn::Split": Array [
+                          ":",
+                          Object {
+                            "Fn::GetAtt": Array [
+                              "RootRole",
+                              "Arn",
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "ApplicationSecurityGroup": Object {
       "Properties": Object {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -36,7 +36,7 @@
     "@aws-cdk/aws-s3": "1.107.0",
     "@aws-cdk/cloudformation-include": "1.107.0",
     "@aws-cdk/core": "1.107.0",
-    "@guardian/cdk": "19.2.1",
+    "@guardian/cdk": "19.3.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -2299,10 +2299,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@19.2.1":
-  version "19.2.1"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-19.2.1.tgz#c89265fb61c47ec2f70f375740e2899f51758497"
-  integrity sha512-c+5w/wxvx8+1+9DorUWqqh+8VY2iIGgjqnZ9FCTrFbFN/l77W6eyv8tA9Qx1C7uWpPGWG+x3/hwfL8tCK/6gtA==
+"@guardian/cdk@19.3.0":
+  version "19.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-19.3.0.tgz#03d124e5a1922643075b6288267cc1b6a1a32644"
+  integrity sha512-QtUCnche0VhzPw4oU9W/VlZs0tiXESoxGyu6GnEyltg54UPr9JXpnN553u/z4k9NFPnak/Qo2S7bOLpR/ami+Q==
   dependencies:
     "@aws-cdk/assert" "1.107.0"
     "@aws-cdk/aws-apigateway" "1.107.0"
@@ -2319,7 +2319,7 @@
     "@aws-cdk/aws-rds" "1.107.0"
     "@aws-cdk/aws-s3" "1.107.0"
     "@aws-cdk/core" "1.107.0"
-    aws-sdk "^2.929.0"
+    aws-sdk "^2.932.0"
     execa "^5.1.1"
     git-url-parse "^11.4.4"
     read-pkg-up "7.0.1"
@@ -3031,10 +3031,10 @@ aws-sdk@^2.848.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
-aws-sdk@^2.929.0:
-  version "2.932.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.932.0.tgz#43da32ab6de58a0eac6c7976feb6c9879fe09e7c"
-  integrity sha512-U6MWUtFD0npWa+ReVEgm0fCIM0fMOYahFp14GLv8fC+BWOTvh5Iwt/gF8NrLomx42bBjA1Abaw6yhmiaSJDQHQ==
+aws-sdk@^2.932.0:
+  version "2.933.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.933.0.tgz#42f2cab2ebb63291ce6e764510e8bfa997847256"
+  integrity sha512-WJBQSE3zdX5YbzTa5+k45hzUAL5EPyiZJAnzCV6TIkPEYPMY215q8iloBATqbntbvAyWC4j2Rto6+RYmki1MOQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -35,13 +35,6 @@ Parameters:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /account/services/artifact.bucket
 
-Mappings:
-  Config:
-    CODE:
-      LowerCaseName: code
-    PROD:
-      LowerCaseName: prod
-
 Resources:
   RootRole:
     Type: AWS::IAM::Role
@@ -101,11 +94,6 @@ Resources:
           - s3:PutBucketPolicy
           Resource: !Join [ "", [ "arn:aws:s3::*:", !Ref DistributionBucketName ] ]
 
-        - Effect: Allow
-          Action:
-            - s3:GetObject
-          Resource:
-            - !Sub 'arn:aws:s3:::${AmigoDataBucket}/*'
         - Effect: Allow
           Action:
             - iam:GetInstanceProfile
@@ -227,21 +215,6 @@ Resources:
         FromPort: '9000'
         ToPort: '9000'
         SourceSecurityGroupId: !Ref 'LoadBalancerSecurityGroup'
-      Tags:
-        - Key: App
-          Value: amigo
-        - Key: Stack
-          Value: deploy
-        - Key: Stage
-          Value: !Ref 'Stage'
-  AmigoDataBucket:
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Retain
-    Properties:
-      BucketName:
-        Fn::Sub:
-          - amigo-data-${LowerCaseStage}
-          - LowerCaseStage: !FindInMap [ Config, Ref: Stage, LowerCaseName ]
       Tags:
         - Key: App
           Value: amigo


### PR DESCRIPTION
Builds on #598.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Migrates the `AmigoDataBucket` resource into the GuCDK version of the stack.

In order to do this, we need to also move any resource that references `AmigoDataBucket`. There's only one resource `AmigoAppPolicy`.

Whilst we could migrate `AmigoAppPolicy` in this change too, it's preferable not to as the change set is pretty big and difficult to reason about.

I couldn't work out how to mutate a YAML defined resource from within CDK, so instead an additional policy is being added. I plan to migrate the remaining policies defined in `AmigoAppPolicy` to it in the next PR.

One thing to note is the bucket name is "changing" from a `Fn::Sub` to a mapping lookup, it still resolves to the same value. This causes `cdk diff` (via [`./script/diff`](https://github.com/guardian/amigo/pull/621)) to suggest this is a replacement operation:

```console
[~] AWS::S3::Bucket AmigoDataBucket AmigoDataBucket replace
 ├─ [~] BucketName (requires replacement)
 │   ├─ [+] Added: .Fn::FindInMap
 │   └─ [-] Removed: .Fn::Sub
```

However it really isn't, as seen in the JSON change set below - there are only `AWS::IAM::Policy` changes. (Technically, the `gu:cdk:version` tag also updates as the library version has been bumped, however I applied that separately as it's a no-op).

<details>
<summary>Change set JSON from CODE</summary>

```json
[
  {
    "resourceChange": {
      "logicalResourceId": "AmigoAppPolicy",
      "action": "Modify",
      "physicalResourceId": "amigo-Amig-1E4GKDN7I64ZN",
      "resourceType": "AWS::IAM::Policy",
      "replacement": "False",
      "moduleInfo": null,
      "details": [
        {
          "target": {
            "name": "PolicyDocument",
            "requiresRecreation": "Never",
            "attribute": "Properties"
          },
          "causingEntity": null,
          "evaluation": "Static",
          "changeSource": "DirectModification"
        }
      ],
      "changeSetId": null,
      "scope": [
        "Properties"
      ]
    },
    "hookInvocationCount": null,
    "type": "Resource"
  },
  {
    "resourceChange": {
      "logicalResourceId": "AppPolicyF941AEC5",
      "action": "Add",
      "physicalResourceId": null,
      "resourceType": "AWS::IAM::Policy",
      "replacement": null,
      "moduleInfo": null,
      "details": [],
      "changeSetId": null,
      "scope": []
    },
    "hookInvocationCount": null,
    "type": "Resource"
  }
]
```
</details>

I think `cdk` simply follows the [Cloudformation spec](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-name):

> BucketName 
> Update requires: Replacement

Lastly `@guardian/cdk` gets updated to [19.3.0](https://github.com/guardian/cdk/releases/tag/v19.3.0) to get the new `GuS3Bucket` construct (https://github.com/guardian/cdk/pull/635).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Deploy this branch to CODE, we should still be able to list the packages installed during a bake.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We move closer to a CDK only template.