### PR TITLE
feat: Migrate policies that grant access to DynamoDb

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -80,29 +80,6 @@ Object {
           "Statement": Array [
             Object {
               "Action": Array [
-                "dynamodb:ListTables",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            Object {
-              "Action": Array [
-                "dynamodb:*",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Sub": Array [
-                  "arn:aws:dynamodb:*:*:table/amigo-\${Stage}-*",
-                  Object {
-                    "Stage": Object {
-                      "Ref": "Stage",
-                    },
-                  },
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
                 "dynamodb:DescribeTable",
                 "dynamodb:GetItem",
               ],
@@ -244,6 +221,27 @@ Object {
                       ],
                     },
                     "/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "dynamodb:ListTables",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "dynamodb:*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:dynamodb:*:*:table/amigo-",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "-*",
                   ],
                 ],
               },

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -40,6 +40,22 @@ export class AmigoStack extends GuStack {
           actions: ["s3:GetObject"],
           resources: [`${this.dataBucket.bucketArn}/*`],
         }),
+
+        /*
+        AMIgo uses DynamoDb as a data store.
+        The permissions are quite wide, mainly because AMIgo creates tables as well as reading/writing data.
+        See `app/data/Dynamo.scala`
+         */
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["dynamodb:ListTables"],
+          resources: ["*"],
+        }),
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["dynamodb:*"],
+          resources: [`arn:aws:dynamodb:*:*:table/amigo-${this.stage}-*`],
+        }),
       ],
     });
   }

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -63,14 +63,6 @@ Resources:
         Statement:
         - Effect: Allow
           Action:
-          - dynamodb:ListTables
-          Resource: '*'
-        - Effect: Allow
-          Action:
-          - dynamodb:*
-          Resource: !Sub 'arn:aws:dynamodb:*:*:table/amigo-${Stage}-*'
-        - Effect: Allow
-          Action:
           - dynamodb:DescribeTable
           - dynamodb:GetItem
           Resource: arn:aws:dynamodb:*:*:table/config-deploy


### PR DESCRIPTION
Builds on #598.

Requires #622.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Migrates the policies that allow AMIgo to [create DynamoDb tables](https://github.com/guardian/amigo/blob/3496a1ba7d90ff1339e0f297d966a63ed25a4ce3/app/data/Dynamo.scala) from the YAML template into the CDK stack.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Pretty difficult really, as AMIgo doesn't need to create any more tables...

Maybe review the diff in the snapshot test to see if they result in the same permissions?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We move closer to a CDK only template.
