### PR TITLE
feat: Migrate configuration access policy

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -80,14 +80,6 @@ Object {
           "Statement": Array [
             Object {
               "Action": Array [
-                "dynamodb:DescribeTable",
-                "dynamodb:GetItem",
-              ],
-              "Effect": "Allow",
-              "Resource": "arn:aws:dynamodb:*:*:table/config-deploy",
-            },
-            Object {
-              "Action": Array [
                 "sns:ListTopics",
               ],
               "Effect": "Allow",
@@ -245,6 +237,14 @@ Object {
                   ],
                 ],
               },
+            },
+            Object {
+              "Action": Array [
+                "dynamodb:DescribeTable",
+                "dynamodb:GetItem",
+              ],
+              "Effect": "Allow",
+              "Resource": "arn:aws:dynamodb:*:*:table/config-deploy",
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -56,6 +56,16 @@ export class AmigoStack extends GuStack {
           actions: ["dynamodb:*"],
           resources: [`arn:aws:dynamodb:*:*:table/amigo-${this.stage}-*`],
         }),
+
+        /*
+        Permissions to obtain configuration via configuration-magic
+        See https://github.com/guardian/configuration-magic/blob/master/core/src/main/scala/com/gu/cm/DynamoDbConfigurationSource.scala
+         */
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["dynamodb:DescribeTable", "dynamodb:GetItem"],
+          resources: ["arn:aws:dynamodb:*:*:table/config-deploy"],
+        }),
       ],
     });
   }

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -63,11 +63,6 @@ Resources:
         Statement:
         - Effect: Allow
           Action:
-          - dynamodb:DescribeTable
-          - dynamodb:GetItem
-          Resource: arn:aws:dynamodb:*:*:table/config-deploy
-        - Effect: Allow
-          Action:
           - sns:ListTopics
           Resource: '*'
         - Effect: Allow


### PR DESCRIPTION
Builds on #598.

Requires #623.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Migrates the policy that allows access to configuration in DynamoDb.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Deploy this branch to CODE, it should succeed as app will not start if it cannot fetch config.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We move closer to a CDK only template.