### PR TITLE
feat: Migrate policy for encrypted bakes sns

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -80,13 +80,6 @@ Object {
           "Statement": Array [
             Object {
               "Action": Array [
-                "sns:ListTopics",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            Object {
-              "Action": Array [
                 "sns:*",
               ],
               "Effect": "Allow",
@@ -245,6 +238,11 @@ Object {
               ],
               "Effect": "Allow",
               "Resource": "arn:aws:dynamodb:*:*:table/config-deploy",
+            },
+            Object {
+              "Action": "sns:ListTopics",
+              "Effect": "Allow",
+              "Resource": "*",
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -66,6 +66,16 @@ export class AmigoStack extends GuStack {
           actions: ["dynamodb:DescribeTable", "dynamodb:GetItem"],
           resources: ["arn:aws:dynamodb:*:*:table/config-deploy"],
         }),
+
+        /*
+        Permissions to support encrypted bakes
+        See https://github.com/guardian/amigo/pull/164
+         */
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["sns:ListTopics"],
+          resources: ["*"],
+        }),
       ],
     });
   }

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -63,10 +63,6 @@ Resources:
         Statement:
         - Effect: Allow
           Action:
-          - sns:ListTopics
-          Resource: '*'
-        - Effect: Allow
-          Action:
           - sns:*
           Resource: !Sub 'arn:aws:sns:*:*:amigo-${Stage}-notify'
         - Effect: Allow


### PR DESCRIPTION
Builds on #598.

Requires #624.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Migrate the policies to support encrypted bakes from the YAML template into the CDK stack. I suspect `*` is too broad, however not changing it to keep as close to a no-op as possible.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

The encrypted bakes feature should still work!

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We move closer to a CDK only template.
