### PR TITLE
feat: Migrate permissions to trigger AMI deletions

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -80,38 +80,6 @@ Object {
           "Statement": Array [
             Object {
               "Action": Array [
-                "sns:*",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Sub": Array [
-                  "arn:aws:sns:*:*:amigo-\${Stage}-notify",
-                  Object {
-                    "Stage": Object {
-                      "Ref": "Stage",
-                    },
-                  },
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "sns:*",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Sub": Array [
-                  "arn:aws:sns:*:*:amigo-\${Stage}-housekeeping-notify",
-                  Object {
-                    "Stage": Object {
-                      "Ref": "Stage",
-                    },
-                  },
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
                 "s3:GetBucketPolicy",
                 "s3:PutBucketPolicy",
               ],
@@ -243,6 +211,36 @@ Object {
               "Action": "sns:ListTopics",
               "Effect": "Allow",
               "Resource": "*",
+            },
+            Object {
+              "Action": "sns:*",
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:sns:*:*:amigo-",
+                      Object {
+                        "Ref": "Stage",
+                      },
+                      "-notify",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:sns:*:*:amigo-",
+                      Object {
+                        "Ref": "Stage",
+                      },
+                      "-housekeeping-notify",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -76,6 +76,19 @@ export class AmigoStack extends GuStack {
           actions: ["sns:ListTopics"],
           resources: ["*"],
         }),
+
+        /*
+        Permissions to trigger AMI deletion
+        See https://github.com/guardian/amigo/pull/193
+         */
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["sns:*"],
+          resources: [
+            `arn:aws:sns:*:*:amigo-${this.stage}-notify`,
+            `arn:aws:sns:*:*:amigo-${this.stage}-housekeeping-notify`,
+          ],
+        }),
       ],
     });
   }

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -61,15 +61,6 @@ Resources:
       PolicyName: amigo-app
       PolicyDocument:
         Statement:
-        - Effect: Allow
-          Action:
-          - sns:*
-          Resource: !Sub 'arn:aws:sns:*:*:amigo-${Stage}-notify'
-        - Effect: Allow
-          Action:
-          - sns:*
-          Resource: !Sub 'arn:aws:sns:*:*:amigo-${Stage}-housekeeping-notify'
-
         # Allow us to allow other accounts to retrieve the ImageCopier lambda artifact
         - Effect: Allow
           Action:


### PR DESCRIPTION
Builds on #598.

Requires #625.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Migrates the policies that allow writing to SNS topics that trigger AMI deletions.

I've combined two individual polices into one, using an array of resources as the reason for the policies existing are the same.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

The AMI deletion feature should still work!

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We move closer to a CDK only template.