### PR TITLE
feat: Migrate policy for ImageCopier

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -80,24 +80,6 @@ Object {
           "Statement": Array [
             Object {
               "Action": Array [
-                "s3:GetBucketPolicy",
-                "s3:PutBucketPolicy",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:aws:s3::*:",
-                    Object {
-                      "Ref": "DistributionBucketName",
-                    },
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
                 "iam:GetInstanceProfile",
               ],
               "Effect": "Allow",
@@ -241,6 +223,24 @@ Object {
                   ],
                 },
               ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucketPolicy",
+                "s3:PutBucketPolicy",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3::*:",
+                    Object {
+                      "Ref": "DistributionBucketName",
+                    },
+                  ],
+                ],
+              },
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -89,6 +89,15 @@ export class AmigoStack extends GuStack {
             `arn:aws:sns:*:*:amigo-${this.stage}-housekeeping-notify`,
           ],
         }),
+
+        /*
+        Allow us to allow other accounts to retrieve the ImageCopier lambda artifact
+         */
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["s3:GetBucketPolicy", "s3:PutBucketPolicy"],
+          resources: [`arn:aws:s3::*:${GuDistributionBucketParameter.getInstance(this).valueAsString}`],
+        }),
       ],
     });
   }

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -61,13 +61,6 @@ Resources:
       PolicyName: amigo-app
       PolicyDocument:
         Statement:
-        # Allow us to allow other accounts to retrieve the ImageCopier lambda artifact
-        - Effect: Allow
-          Action:
-          - s3:GetBucketPolicy
-          - s3:PutBucketPolicy
-          Resource: !Join [ "", [ "arn:aws:s3::*:", !Ref DistributionBucketName ] ]
-
         - Effect: Allow
           Action:
             - iam:GetInstanceProfile


### PR DESCRIPTION
Builds on #598.

Requires #626.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

I don't fully understand the implementation of the image copier feature! In this change I'm (somewhat blindly) moving the policy from the YAML template into the CDK stack. It should be a no-op.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

As mentioned above, I don't really understand this feature to conclusively say. Help wanted!

We can see from the snapshot diff, however, that the only change is where the policy gets defined. That is, I'm confident this is a no-op.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We move closer to a CDK only template.