### PR TITLE
feat: Migrate Packer instance profile policy statement

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -40,7 +40,7 @@ Object {
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "PackerInstanceProfile": Object {
-      "Description": "Instance profile given to instances created by Packer",
+      "Description": "Instance profile given to instances created by Packer. Find this in the PackerUser-PackerRole in IAM",
       "Type": "String",
     },
     "PackerVersion": Object {
@@ -74,30 +74,6 @@ Object {
     },
   },
   "Resources": Object {
-    "AmigoAppPolicy": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "iam:GetInstanceProfile",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Ref": "PackerInstanceProfile",
-              },
-            },
-          ],
-        },
-        "PolicyName": "amigo-app",
-        "Roles": Array [
-          Object {
-            "Ref": "RootRole",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "AmigoDataBucket": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
@@ -240,6 +216,13 @@ Object {
                     },
                   ],
                 ],
+              },
+            },
+            Object {
+              "Action": "iam:GetInstanceProfile",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Ref": "PackerInstanceProfile",
               },
             },
           ],

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -24,9 +24,6 @@ Parameters:
   PackerVersion:
     Description: What version of Packer to install
     Type: String
-  PackerInstanceProfile:
-    Description: Instance profile given to instances created by Packer #find this in the PackerUser-PackerRole in IAM
-    Type: String
   TLSCert:
     Type: String
     Description: ARN of a TLS certificate to install on the load balancer
@@ -55,18 +52,6 @@ Resources:
           Value: deploy
         - Key: Stage
           Value: !Ref 'Stage'
-  AmigoAppPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: amigo-app
-      PolicyDocument:
-        Statement:
-        - Effect: Allow
-          Action:
-            - iam:GetInstanceProfile
-          Resource: !Ref PackerInstanceProfile
-      Roles:
-      - !Ref 'RootRole'
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:


### PR DESCRIPTION
Builds on #598.

Requires #627.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Migrates the Packer SSM policy from the YAML template to the CDK stack.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

If this change isn't correct, I think the result would be an inability to bake any recipe. So, to test, try to bake a recipe?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We move closer to a CDK only template - the YAML defined `AmigoAppPolicy` is completely migrated 🎉 .
