### PR TITLE
chore: Adopt VpcId stack parameter into CDK stack

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -68,9 +68,10 @@ Object {
       "Description": "ARN of a TLS certificate to install on the load balancer",
       "Type": "String",
     },
-    "VPC": Object {
+    "VpcId": Object {
+      "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within",
-      "Type": "AWS::EC2::VPC::Id",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
     },
   },
   "Resources": Object {
@@ -304,7 +305,7 @@ Object {
           },
         ],
         "VpcId": Object {
-          "Ref": "VPC",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
@@ -738,7 +739,7 @@ dpkg -i /tmp/amigo.deb
           },
         ],
         "VpcId": Object {
-          "Ref": "VPC",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
@@ -867,7 +868,7 @@ dpkg -i /tmp/amigo.deb
           },
         ],
         "VpcId": Object {
-          "Ref": "VPC",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -6,7 +6,12 @@ import { CfnInclude } from "@aws-cdk/cloudformation-include";
 import type { App } from "@aws-cdk/core";
 import { Stage } from "@guardian/cdk/lib/constants";
 import type { GuStackProps, GuStageParameter } from "@guardian/cdk/lib/constructs/core";
-import { GuDistributionBucketParameter, GuStack, GuStringParameter } from "@guardian/cdk/lib/constructs/core";
+import {
+  GuDistributionBucketParameter,
+  GuStack,
+  GuStringParameter,
+  GuVpcParameter,
+} from "@guardian/cdk/lib/constructs/core";
 import { AppIdentity } from "@guardian/cdk/lib/constructs/core/identity";
 import {
   GuAllowPolicy,
@@ -144,6 +149,7 @@ export class AmigoStack extends GuStack {
       parameters: {
         Stage: this.getParam<GuStageParameter>("Stage"), // TODO `GuStageParameter` could be a singleton to simplify this
         DistributionBucketName: GuDistributionBucketParameter.getInstance(this).valueAsString,
+        VpcId: GuVpcParameter.getInstance(this).valueAsString,
       },
     });
 

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -36,7 +36,7 @@
     "@aws-cdk/aws-s3": "1.110.1",
     "@aws-cdk/cloudformation-include": "1.110.1",
     "@aws-cdk/core": "1.110.1",
-    "@guardian/cdk": "20.0.1",
+    "@guardian/cdk": "21.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -2323,10 +2323,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@20.0.1":
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-20.0.1.tgz#07d5d8419c934cf39b4cdf659ea19cf478e07e64"
-  integrity sha512-bCMCha1JdEiIS9FKN+aBTust365LTGc6fnQFEHS5mrmV47e5vIH2E87ZBVXUjG7hglYL1UuLtzqWTbDg//PorA==
+"@guardian/cdk@21.0.0":
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-21.0.0.tgz#724b9c666d5dc7d5111e04a4d1b955bb3cc0551e"
+  integrity sha512-TB/lQpbmGY6VHhcEVfnsAQjMXU6+Xng0Y+YTwh8s/nskVBbv/duqabVItMRxPUNWrUOOIo+mpwDrsBf4rve1zg==
   dependencies:
     "@aws-cdk/assert" "1.110.1"
     "@aws-cdk/aws-apigateway" "1.110.1"
@@ -2343,9 +2343,9 @@
     "@aws-cdk/aws-rds" "1.110.1"
     "@aws-cdk/aws-s3" "1.110.1"
     "@aws-cdk/core" "1.110.1"
-    aws-sdk "^2.933.0"
+    aws-sdk "^2.936.0"
     execa "^5.1.1"
-    git-url-parse "^11.4.4"
+    git-url-parse "^11.5.0"
     read-pkg-up "7.0.1"
 
 "@guardian/eslint-config-typescript@^0.6.0":
@@ -3071,7 +3071,7 @@ aws-sdk@^2.848.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
-aws-sdk@^2.933.0:
+aws-sdk@^2.936.0:
   version "2.937.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.937.0.tgz#6dce5f72343c89bf06672403af3135397eba0fe7"
   integrity sha512-Ko5fATHxfHWMVJjS5/7eNEeIZ0Sja3B5f7ZvdyGmyRdUv7JVeppkNmc6cK5jFt/qGxVOK2OZnY/vE6D/INwGiQ==
@@ -4173,10 +4173,10 @@ git-up@^4.0.0:
     is-ssh "^1.3.0"
     parse-url "^5.0.0"
 
-git-url-parse@^11.4.4:
-  version "11.4.4"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.4.4.tgz#5d747debc2469c17bc385719f7d0427802d83d77"
-  integrity sha512-Y4o9o7vQngQDIU9IjyCmRJBin5iYjI5u9ZITnddRZpD7dcCFQj2sL2XuMNbLRE4b4B/4ENPsp2Q8P44fjAZ0Pw==
+git-url-parse@^11.5.0:
+  version "11.5.0"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.5.0.tgz#acaaf65239cb1536185b19165a24bbc754b3f764"
+  integrity sha512-TZYSMDeM37r71Lqg1mbnMlOqlHd7BSij9qN7XwTkRqSAYFMihGLGhfHwgqQob3GUhEneKnV4nskN9rbQw2KGxA==
   dependencies:
     git-up "^4.0.0"
 

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -5,9 +5,10 @@ Parameters:
     Description: Stage name
     Type: String
     Default: PROD
-  VPC:
+  VpcId:
     Description: Virtual Private Cloud to run EC2 instances within
-    Type: AWS::EC2::VPC::Id
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>
+    Default: /account/vpc/primary/id
   PublicSubnets:
     Description: Subnets to run load balancer within
     Type: List<AWS::EC2::Subnet::Id>
@@ -135,7 +136,7 @@ Resources:
     Properties:
       GroupDescription: Guardian IP range has access to the load balancer on port
         80
-      VpcId: !Ref 'VPC'
+      VpcId: !Ref VpcId
       SecurityGroupIngress:
       - IpProtocol: tcp
         FromPort: '443'
@@ -157,7 +158,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: SSH and HTTP
-      VpcId: !Ref 'VPC'
+      VpcId: !Ref VpcId
       SecurityGroupIngress:
       - IpProtocol: tcp
         FromPort: '9000'
@@ -179,7 +180,7 @@ Resources:
     Properties:
       GroupName: !Sub 'amigo-packer-${Stage}'
       GroupDescription: Security group for instances created by Packer
-      VpcId: !Ref 'VPC'
+      VpcId: !Ref VpcId
       SecurityGroupEgress:
         - IpProtocol: tcp
           FromPort: 0


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adopting the VpcId stack parameter into the CDK stack allows us to start moving the YAML defined resources that reference this parameter in the CDK stack (for example the [`PackerSecurityGroup`](https://github.com/guardian/amigo/blob/158729df183d1d1bd284a9e74e0f24ad1dff027f/cloudformation.yaml#L177-L194)).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Deploy the app, it should still work!

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Unblocking us from moving more YAML defined resources into CDK.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

As we're moving from a direct parameter to a SSM parameter, we need to be sure the values are the same. I've just checked this and they are.
