### PR TITLE
feat: Migrate `PackerSecurityGroup` into CDK stack

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -826,18 +826,20 @@ dpkg -i /tmp/amigo.deb
       "Properties": Object {
         "GroupDescription": "Security group for instances created by Packer",
         "GroupName": Object {
-          "Fn::Sub": Array [
-            "amigo-packer-\${Stage}",
-            Object {
-              "Stage": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "amigo-packer-",
+              Object {
                 "Ref": "Stage",
               },
-            },
+            ],
           ],
         },
         "SecurityGroupEgress": Array [
           Object {
             "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound TCP",
             "FromPort": 0,
             "IpProtocol": "tcp",
             "ToPort": 65535,

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -175,21 +175,3 @@ Resources:
           Value: deploy
         - Key: Stage
           Value: !Ref 'Stage'
-  PackerSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupName: !Sub 'amigo-packer-${Stage}'
-      GroupDescription: Security group for instances created by Packer
-      VpcId: !Ref VpcId
-      SecurityGroupEgress:
-        - IpProtocol: tcp
-          FromPort: 0
-          ToPort: 65535
-          CidrIp: 0.0.0.0/0
-      Tags:
-        - Key: App
-          Value: amigo
-        - Key: Stack
-          Value: deploy
-        - Key: Stage
-          Value: !Ref 'Stage'


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This change moves the YAML defined `PackerSecurityGroup` into the CDK stack. There is ultimately one change being made, the `AWS::EC2::SecurityGroup Egress` gets a description. The [docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-rule.html#cfn-ec2-security-group-rule-description) state this isn't a replacement operation 🎉 .

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Deploy and bake - the bake should start.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Moving closer to a CDK only defined stack.