### PR TITLE
feat: Expose build info on `/healthcheck`

### DIFF
--- a/app/controllers/RootController.scala
+++ b/app/controllers/RootController.scala
@@ -1,13 +1,14 @@
 package controllers
 
+import amigo.BuildInfo
 import com.gu.googleauth.GoogleAuthConfig
-
+import play.api.libs.json.Json
 import play.api.mvc._
 
 class RootController(val authConfig: GoogleAuthConfig) extends Controller with AuthActions {
 
   def healthcheck = Action {
-    Ok("OK")
+    Ok(Json.parse(BuildInfo.toJson))
   }
 
   def index = AuthAction {

--- a/app/management/BuildInfo.scala
+++ b/app/management/BuildInfo.scala
@@ -1,0 +1,5 @@
+package management
+
+trait BuildInfo {
+  def toJson: String
+}

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,11 @@ lazy val root = (project in file("."))
         BuildInfoKey.constant("buildTime", System.currentTimeMillis),
         BuildInfoKey.constant("gitCommitId", buildInfo.revision)
       )
-    }
+    },
+    buildInfoOptions:= Seq(
+      BuildInfoOption.Traits("management.BuildInfo"),
+      BuildInfoOption.ToJson
+    )
   )
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Xfatal-warnings")

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,9 @@ import akka.actor.FSM.->
 import com.gu.riffraff.artifact.BuildInfo
 import com.typesafe.sbt.packager.archetypes.ServerLoader.Systemd
 
+import java.time.format.DateTimeFormatter
+import java.time.{ZoneId, ZonedDateTime}
+
 name := "amigo"
 version := "1.0-latest"
 scalaVersion := "2.11.8"
@@ -38,12 +41,15 @@ lazy val root = (project in file("."))
     buildInfoPackage := "amigo",
     buildInfoKeys := {
       lazy val buildInfo = BuildInfo(baseDirectory.value)
+
+      // so this next one is constant to avoid it always recompiling on dev machines.
+      // we only really care about build time on teamcity, when a constant based on when
+      // it was loaded is just fine
+      lazy val buildTime: String = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now(ZoneId.of("UTC")))
+
       Seq[BuildInfoKey](
         BuildInfoKey.constant("buildNumber", buildInfo.buildIdentifier),
-        // so this next one is constant to avoid it always recompiling on dev machines.
-        // we only really care about build time on teamcity, when a constant based on when
-        // it was loaded is just fine
-        BuildInfoKey.constant("buildTime", System.currentTimeMillis),
+        BuildInfoKey.constant("buildTime", buildTime),
         BuildInfoKey.constant("gitCommitId", buildInfo.revision)
       )
     },


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The build info has useful information that aides debugging. Specifically the commit hash which helps one determine exactly what version of the app is deployed.

This doesn't impact the AWS healthcheck as the status code remains the same - only the response body changes.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy this branch
- Visit `/healthcheck`
- Witness some lovely JSON

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

![image](https://user-images.githubusercontent.com/836140/124242322-8741d700-db14-11eb-84eb-fe2e11bef857.png)