### PR TITLE
feat: Add the instanceId as a log marker

### DIFF
--- a/app/services/ELKLogging.scala
+++ b/app/services/ELKLogging.scala
@@ -1,32 +1,36 @@
 package services
 
-import ch.qos.logback.classic.{ AsyncAppender, Logger, LoggerContext }
+import ch.qos.logback.classic.{AsyncAppender, Logger, LoggerContext}
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.Appender
 import ch.qos.logback.core.joran.spi.JoranException
 import ch.qos.logback.core.util.StatusPrinter
 import com.amazonaws.auth.AWSCredentialsProvider
-import com.gu.cm.Identity
+import com.gu.cm.{AwsInstanceImpl, Identity}
 import com.gu.logback.appender.kinesis.KinesisAppender
 import net.logstash.logback.layout.LogstashLayout
-import org.slf4j.{ LoggerFactory, Logger => SLFLogger }
+import org.slf4j.{LoggerFactory, Logger => SLFLogger}
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.Json
 import amigo.BuildInfo
 
 import scala.util.control.NonFatal
 
-class ElkLogging(identity: Identity,
-    loggingStreamName: Option[String],
-    awsCredentialsProvider: AWSCredentialsProvider,
-    applicationLifecycle: ApplicationLifecycle) extends Loggable {
+class ElkLogging(
+  identity: Identity,
+  awsInstance: AwsInstanceImpl,
+  loggingStreamName: Option[String],
+  awsCredentialsProvider: AWSCredentialsProvider,
+  applicationLifecycle: ApplicationLifecycle
+) extends Loggable {
   def getContextTags: Map[String, String] = {
     val effective = Map(
       "app" -> identity.app,
       "stage" -> identity.stage,
       "stack" -> identity.stack,
       "region" -> identity.region,
-      "buildNumber" -> BuildInfo.buildNumber
+      "buildNumber" -> BuildInfo.buildNumber,
+      "instanceId" -> awsInstance.instanceId.getOrElse("unknown")
     )
     log.info(s"Logging with context map: $effective")
     effective


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This will allow us to determine which instance is sending logs, which is of particular use for the YAML -> CDK migration.

There are a lot of whitespace changes in this diff, so it'll be easier to review [w/out them](https://github.com/guardian/amigo/pull/634/files?diff=split&w=1).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy this branch
- Check logs, they should have a new marker

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

This will allow us to determine if the new instances launched in #632 have the correct permissions.

## Images

![image](https://user-images.githubusercontent.com/836140/124265643-e06a3480-db2d-11eb-96eb-82c2de5c4a97.png)
