### PR TITLE
Tweaks to ssh reserve space

### DIFF
--- a/roles/ssh-reserve-disk-space/tasks/main.yml
+++ b/roles/ssh-reserve-disk-space/tasks/main.yml
@@ -50,4 +50,4 @@
     path: /var/lib/amazon/ssm
     owner: root
     group: root
-    mode: '0700'
+    mode: '0750'

--- a/roles/ssh-reserve-disk-space/tasks/main.yml
+++ b/roles/ssh-reserve-disk-space/tasks/main.yml
@@ -4,7 +4,7 @@
     path: /var/lib/reserved-disk
     state: directory
 
-- name: Reserve 10MB for ssh config
+- name: Reserve 50MB for ssh config
   command: "dd if=/dev/zero of=/var/lib/reserved-disk/ubuntu-ssh.img bs=1024 count=50k"
   args:
     creates: "/var/lib/reserved-disk/ubuntu-ssh.img"
@@ -28,7 +28,7 @@
     group: ubuntu
     mode: '0700'
 
-- name: Reserve 10MB for ssm
+- name: Reserve 50MB for ssm
   command: "dd if=/dev/zero of=/var/lib/reserved-disk/ssm.img bs=1024 count=50k"
   args:
     creates: "/var/lib/reserved-disk/ssm.img"

--- a/roles/ssh-reserve-disk-space/tasks/main.yml
+++ b/roles/ssh-reserve-disk-space/tasks/main.yml
@@ -12,12 +12,12 @@
 - name: Create ext2 filesystem
   filesystem:
     fstype: ext2
-    dev: /home/ubuntu/ssh.img
+    dev: /var/lib/reserved-disk/ubuntu-ssh.img
     
 - name: Mount ssh config in homedir
   mount:
     path: /home/ubuntu/.ssh
-    src: /home/ubuntu/ssh.img
+    src: /var/lib/reserved-disk/ubuntu-ssh.img
     fstype: ext2
     state: mounted
 
@@ -36,12 +36,12 @@
 - name: Create ext2 filesystem
   filesystem:
     fstype: ext2
-    dev: /root/ssm.img
+    dev: /var/lib/reserved-disk/ssm.img
 
 - name: Mount ssm
   mount:
     path: /var/lib/amazon/ssm
-    src: /root/ssm.img
+    src: /var/lib/reserved-disk/ssm.img
     fstype: ext2
     state: mounted
 

--- a/roles/ssh-reserve-disk-space/tasks/main.yml
+++ b/roles/ssh-reserve-disk-space/tasks/main.yml
@@ -5,7 +5,7 @@
     state: directory
 
 - name: Reserve 10MB for ssh config
-  command: "dd if=/dev/zero of=/var/lib/reserved-disk/ubuntu-ssh.img bs=1024 count=10k"
+  command: "dd if=/dev/zero of=/var/lib/reserved-disk/ubuntu-ssh.img bs=1024 count=50k"
   args:
     creates: "/var/lib/reserved-disk/ubuntu-ssh.img"
 
@@ -29,7 +29,7 @@
     mode: '0700'
 
 - name: Reserve 10MB for ssm
-  command: "dd if=/dev/zero of=/var/lib/reserved-disk/ssm.img bs=1024 count=10k"
+  command: "dd if=/dev/zero of=/var/lib/reserved-disk/ssm.img bs=1024 count=50k"
   args:
     creates: "/var/lib/reserved-disk/ssm.img"
 

--- a/roles/ssh-reserve-disk-space/tasks/main.yml
+++ b/roles/ssh-reserve-disk-space/tasks/main.yml
@@ -1,8 +1,13 @@
 ---
+- name: Creates directory
+  file:
+    path: /var/lib/reserved-disk
+    state: directory
+
 - name: Reserve 10MB for ssh config
-  command: "dd if=/dev/zero of=/home/ubuntu/ssh.img bs=1024 count=10k"
+  command: "dd if=/dev/zero of=/var/lib/reserved-disk/ubuntu-ssh.img bs=1024 count=10k"
   args:
-    creates: "/home/ubuntu/ssh.img"
+    creates: "/var/lib/reserved-disk/ubuntu-ssh.img"
 
 - name: Create ext2 filesystem
   filesystem:
@@ -24,9 +29,9 @@
     mode: '0700'
 
 - name: Reserve 10MB for ssm
-  command: "dd if=/dev/zero of=/root/ssm.img bs=1024 count=10k"
+  command: "dd if=/dev/zero of=/var/lib/reserved-disk/ssm.img bs=1024 count=10k"
   args:
-    creates: "/root/ssm.img"
+    creates: "/var/lib/reserved-disk/ssm.img"
 
 - name: Create ext2 filesystem
   filesystem:


### PR DESCRIPTION
## What does this change?

This changes 3 things
1. moves image files to `/var/lib/reserved-disk`
2. Reserves 50mb instead of 10mb
3. Retains `/var/lib/amazon/ssm`'s original permissions, which are `drwxr-x---`

## How to test

- [x] Create an AMI with this role
- [x]  Create an instance of this AMI
- [x]  Use ssm ssh to get onto the instance
- [x]  Run `fallocate -l $(($(df . --output=avail | tail -1) * 1024)) filler` to fill the root partition
- [x]  Try to use ssm ssh again from another local terminal. It should work
