### PR TITLE
Prevent AMIgo from removing TeamCity AMIs

### DIFF
--- a/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
+++ b/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
@@ -26,7 +26,7 @@ object MarkOldUnusedBakesForDeletion {
     // Exclude TeamCity Agent AMIs, which have been incorrectly assumed to be unused in the past. This happens
     // because TeamCity Agents are typically terminated overnight and are not linked to a launch configuration.
     val oldBakesExcludingTeamCityAgents = oldBakes.filterNot { bake =>
-      bake.recipe.id.value == "teamcity-agent"
+      bake.recipe.id.value.startsWith("teamcity-agent")
     }
 
     val recipeUsage = getRecipeUsage(oldBakesExcludingTeamCityAgents)

--- a/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
+++ b/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
@@ -60,8 +60,8 @@ class MarkOldUnusedBakesForDeletionSpec extends FlatSpec with Matchers {
 
   it should "not include TeamCity agent AMIs, even if they are old" in {
     val housekeepingDate = new DateTime(2018, 7, 12, 0, 0, 0, DateTimeZone.UTC)
-    val recipeIds = Set(RecipeId("teamcity-agent"))
-    val oldTeamCityAgent = fixtureBake(fixtureRecipe("teamcity-agent", oldDate), Some(AmiId("ami-1")), oldDate)
+    val recipeIds = Set(RecipeId("teamcity-agent-focal"))
+    val oldTeamCityAgent = fixtureBake(fixtureRecipe("teamcity-agent-focal", oldDate), Some(AmiId("ami-1")), oldDate)
     def getBakesWithTeamCityAgent(recipeId: RecipeId): Iterable[Bake] = Iterable(oldTeamCityAgent)
     val markedBakes = MarkOldUnusedBakesForDeletion.getOldUnusedBakes(recipeIds, housekeepingDate, getBakesWithTeamCityAgent, getEmptyRecipeUsage)
 


### PR DESCRIPTION
Follow-up to https://github.com/guardian/amigo/pull/553, as the TeamCity Agent AMI has changed slightly since that PR was merged.

Obviously this is still a hack, but hopefully it'll keep things stable until [this card](https://trello.com/c/unohWhlM/728-auto-update-teamcity-build-agents-ami) can be worked on.