### PR TITLE
Allow AMIgo to remove old TeamCity AMIs

### DIFF
--- a/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
+++ b/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
@@ -23,16 +23,10 @@ object MarkOldUnusedBakesForDeletion {
       duration.getStandardDays > MAX_AGE
     }
 
-    // Exclude TeamCity Agent AMIs, which have been incorrectly assumed to be unused in the past. This happens
-    // because TeamCity Agents are typically terminated overnight and are not linked to a launch configuration.
-    val oldBakesExcludingTeamCityAgents = oldBakes.filterNot { bake =>
-      bake.recipe.id.value.startsWith("teamcity-agent")
-    }
-
-    val recipeUsage = getRecipeUsage(oldBakesExcludingTeamCityAgents)
+    val recipeUsage = getRecipeUsage(oldBakes)
     val usedBakes = recipeUsage.bakeUsage.map(_.bake).distinct.toSet
 
-    oldBakesExcludingTeamCityAgents -- usedBakes
+    oldBakes -- usedBakes
   }
 }
 

--- a/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
+++ b/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
@@ -57,14 +57,4 @@ class MarkOldUnusedBakesForDeletionSpec extends FlatSpec with Matchers {
     markedBakes.size shouldEqual 1
     markedBakes.map(_.bakeId) shouldEqual Set(BakeId(RecipeId("recipe-1"), 1))
   }
-
-  it should "not include TeamCity agent AMIs, even if they are old" in {
-    val housekeepingDate = new DateTime(2018, 7, 12, 0, 0, 0, DateTimeZone.UTC)
-    val recipeIds = Set(RecipeId("teamcity-agent-focal"))
-    val oldTeamCityAgent = fixtureBake(fixtureRecipe("teamcity-agent-focal", oldDate), Some(AmiId("ami-1")), oldDate)
-    def getBakesWithTeamCityAgent(recipeId: RecipeId): Iterable[Bake] = Iterable(oldTeamCityAgent)
-    val markedBakes = MarkOldUnusedBakesForDeletion.getOldUnusedBakes(recipeIds, housekeepingDate, getBakesWithTeamCityAgent, getEmptyRecipeUsage)
-
-    markedBakes.size shouldEqual 0
-  }
 }


### PR DESCRIPTION
## What does this change?

* Now that we have a process for automatically updating TeamCity Agent AMIs (see https://github.com/guardian/deploy-tools-platform/pull/528), we can remove a hack that was added to prevent AMIgo from deleting old TeamCity AMIs (see https://github.com/guardian/amigo/pull/553)

## How to test

* Should be covered by [existing unit tests](https://github.com/guardian/amigo/blob/daee87ab85fbcd9774db21b96ebaa2acf576ee24/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala)

## How can we measure success?

* We no longer retain stale AMIs unnecessarily 

## Have we considered potential risks?

* Yes, there is a risk that TeamCity Agent AMI bakes / the new automated upgrade process will fail. Without this hack it's possible that we will end up in a situation where TeamCity agents cannot be launched. However, I think existing AMIgo/AMIable monitoring should be sufficient to mitigate this risk