### PR TITLE
Add role that installs Python3.7 and virtual environment

### DIFF
--- a/roles/python3.7-pip-virtualenv/README.md
+++ b/roles/python3.7-pip-virtualenv/README.md
@@ -1,0 +1,3 @@
+# python3.7-pip-virtualenv
+
+Installs Python 3.7, pip for Python 3 and Python virtual environment.

--- a/roles/python3.7-pip-virtualenv/meta/main.yml
+++ b/roles/python3.7-pip-virtualenv/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - apt

--- a/roles/python3.7-pip-virtualenv/tasks/main.yml
+++ b/roles/python3.7-pip-virtualenv/tasks/main.yml
@@ -1,16 +1,6 @@
 ---
-- name: install pip
+- name: install pip, python 3.7 and virtualenv
   apt:
-    name: ['python3-pip']
-    update_cache: yes
-    state: latest
-- name: install python3.7
-  apt:
-    name: ['python3.7']
-    update_cache: yes
-    state: latest
-- name: install virtualenv
-  apt:
-    name: ['virtualenv']
+    name: ['python3-pip', 'python3.7', 'virtualenv']
     update_cache: yes
     state: latest

--- a/roles/python3.7-pip-virtualenv/tasks/main.yml
+++ b/roles/python3.7-pip-virtualenv/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: install pip
+  apt:
+    name: ['python3-pip']
+    update_cache: yes
+    state: latest
+- name: install python3.7
+  apt:
+    name: ['python3.7']
+    update_cache: yes
+    state: latest
+- name: install virtualenv
+  apt:
+    name: ['virtualenv']
+    update_cache: yes
+    state: latest


### PR DESCRIPTION
## What does this change?
Adds an ansible role that installs:
- `python3.7`
- `pip3`
- `virtualenv` for Python 3

Installs Python 3.7 as a longer support option compared to the system Python 3.6 (EOL: [27 Jun 2023 vs. 23 Dec 2021](https://endoflife.date/python)).
I am open to replace it with Python 3.8 as an even longer support option.

## Testing
- [x] Tested ansible role as set out in `README.md` (including manual check that all 3 installed packages run on the provisioned Vagrant box)


## Have we considered potential risks?
This role does **not** overwrite the Python 3.6 version installed via `apt-get install python3`, hence it will not conflict with any of the other Python 3 roles in this repo (`pip3`, `pip3-packages`).
The following symlink will remain intact:
`/usr/bin/python3` --> `/usr/bin/python3.6`




