### PR TITLE
[role: `browser-testing`] make version of Chrome and chromedriver configurable (falling back to 'latest')

### DIFF
--- a/roles/browser-testing/README.md
+++ b/roles/browser-testing/README.md
@@ -4,6 +4,8 @@ This feature installs Google Chrome, Chromedriver and the virtual frame buffer, 
 
 The install script does the following:
  - Installs Xvfb
- - Installs the latest version of Google Chrome and associated packages
- - Installs latest Chromedriver version
+ - Installs the version of Google Chrome specified by `chrome_version` (installs latest if blank) and associated packages
+   <br/>_see https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable for available options_
+ - Installs  Chromedriver version specified by `chromedriver_version` (installs latest if blank)
+   <br/>_see version numbers for entries ending in `/chromedriver_linux64.zip` from https://chromedriver.storage.googleapis.com/_
  - Creates and enables an Xvfb service

--- a/roles/browser-testing/tasks/main.yml
+++ b/roles/browser-testing/tasks/main.yml
@@ -2,18 +2,28 @@
 - name: Install Xvfb
   apt: name=xvfb state=latest
 
-- name: Download Chrome
-  get_url: url=https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb dest=/tmp/google-chrome-stable_current_amd64.deb
+- name: Download LATEST Chrome
+  get_url: url=https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb dest=/tmp/google-chrome-stable_amd64.deb
+  when: chrome_version is undefined
+
+- name: Download SPECIFIED version of Chrome
+  get_url: url=https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_{{chrome_version}}_amd64.deb dest=/tmp/google-chrome-stable_amd64.deb
+  when: chrome_version is defined
 
 - name: Install Chrome - ignores errors as expect missing packages
-  shell: dpkg -i /tmp/google-chrome-stable_current_amd64.deb
+  shell: dpkg -i /tmp/google-chrome-stable_amd64.deb
   ignore_errors: yes
 
 - name: Install missing packages for Chrome
   shell: apt-get install -f -y
 
-- name: Download Chromedriver
+- name: Download LATEST Chromedriver
   shell: wget http://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE)/chromedriver_linux64.zip -O /tmp/chromedriver.zip
+  when: chromedriver_version is undefined
+
+- name: Download SPECIFIED version of Chromedriver
+  shell: wget http://chromedriver.storage.googleapis.com/{{chromedriver_version}}/chromedriver_linux64.zip -O /tmp/chromedriver.zip
+  when: chromedriver_version is defined
 
 - name: Unzip Chromedriver
   unarchive: src=/tmp/chromedriver.zip dest=/usr/local/bin/


### PR DESCRIPTION
Currently [guardian/editorial-tools-production-monitoring](https://github.com/guardian/editorial-tools-production-monitoring) breaks with Chrome 92 (see https://trello.com/c/8tvMxMRX/2446-investigate-why-prodmon-breaks-w-the-latest-ami-and-fix for all the things we've tried in order to resolve). As such we had to remove the `ami-cloudformation-parameter` deployment step (see https://github.com/guardian/editorial-tools-production-monitoring/pull/281) so prodmon is not using the latest AMI, as it includes Chrome 92 (because it is 'latest').

## What does this change?
This PR makes the version of Chrome (and chromedriver) configurable (falling back to _latest_ if unspecified), so that we can specify Chrome 91 (which is the company wide version at the moment anyway) until there's a compatible & stable version of selenium available to work work with Chrome 92 (or above).

## How to test
Already tested...

- https://amigo.code.dev-gutools.co.uk/recipes/browser-testing-bionic/bakes/1 (without config, i.e. latest)
![image](https://user-images.githubusercontent.com/19289579/129020031-39247921-4c54-449d-8d28-59b4d5377d02.png)

- https://amigo.code.dev-gutools.co.uk/recipes/browser-testing-bionic/bakes/2 (with config, downloads chrome 91)
![image](https://user-images.githubusercontent.com/19289579/129020122-bd5745df-bba4-4060-abc1-0b275f1f9740.png)
![image](https://user-images.githubusercontent.com/19289579/129020093-522de42b-98a8-4616-961a-abbafccd5273.png)

## How can we measure success?
We can revert https://github.com/guardian/editorial-tools-production-monitoring/pull/281 so at least we have up to date(ish) AMIs (i.e. latest OS etc. security patches) even if we don't have latest Chrome.
