### PR TITLE
Revert PR #640

### DIFF
--- a/roles/python3.7-pip-virtualenv/README.md
+++ b/roles/python3.7-pip-virtualenv/README.md
@@ -1,3 +1,0 @@
-# python3.7-pip-virtualenv
-
-Installs Python 3.7, pip for Python 3 and Python virtual environment.

--- a/roles/python3.7-pip-virtualenv/meta/main.yml
+++ b/roles/python3.7-pip-virtualenv/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - apt

--- a/roles/python3.7-pip-virtualenv/tasks/main.yml
+++ b/roles/python3.7-pip-virtualenv/tasks/main.yml
@@ -1,6 +1,0 @@
----
-- name: install pip, python 3.7 and virtualenv
-  apt:
-    name: ['python3-pip', 'python3.7', 'virtualenv']
-    update_cache: yes
-    state: latest


### PR DESCRIPTION
## What does this change?
Remove bespoke apt package installation role (`python3.7-pip-virtualenv`) as the same can be achieved with the [`packages` role](https://amigo.gutools.co.uk/roles#packages) as per conversation: https://chat.google.com/room/AAAAag0I08g/m7WVe37Wqls
