### PR TITLE
retrieve kong deb from capi s3

### DIFF
--- a/roles/kong/tasks/main.yml
+++ b/roles/kong/tasks/main.yml
@@ -14,7 +14,7 @@
   user: name={{kong_user}} system=yes
 
 - name: Download Kong package
-  get_url: url=https://bintray.com/kong/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{kong_version}}.bionic.all.deb dest=/tmp/kong-{{kong_version}}.deb
+  get_url: url=https://content-api-dist.s3.eu-west-1.amazonaws.com/kong/mirrored/kong-community-edition-{{kong_version}}.bionic.all.deb dest=/tmp/kong-{{kong_version}}.deb
 
 - name: Install Kong package
   command: dpkg -i /tmp/kong-{{kong_version}}.deb


### PR DESCRIPTION
## What does this change?
The Kong distribution for v 0.14.0 is no longer available, so this change is providing it from our own s3 bucket

## How to test
Run the Kong AMI build 

