### PR TITLE
Add libgtk3 dependency to puppeteer role & upgrade puppeteer

### DIFF
--- a/roles/puppeteer/tasks/main.yml
+++ b/roles/puppeteer/tasks/main.yml
@@ -6,11 +6,12 @@
       'npm', # we need this to *install* Puppeteer
       'nodejs', # we need this to *run* Puppeteer
       'chromium-browser', # we used to use this to get all the X11 libraries required by Puppeteer's bundled copy of Chrome, but as of September 2020 need to specify libxss1 (see below)
-      'libxss1' # required by Puppeteer as detailed https://github.com/guardian/ophan/issues/3932
+      'libxss1', # required by Puppeteer as detailed https://github.com/guardian/ophan/issues/3932
+      'libgtk-3-0' # also required by Puppeteer
     ]
 
 - name: Install "puppeteer" node.js package so that it is available to any program on the system
   npm:
     name: puppeteer
-    version: '1.9.0'
+    version: '10.2.0'
     path: / # Hack based on https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders - blame Alex


### PR DESCRIPTION
We observed that Time Machine stopped working, and went to find some
errors in the logs.

We saw this error:

```
java.lang.RuntimeException: External process failed with error output: (node:9347) UnhandledPromiseRejectionWarning: Error: Failed to launch chrome! /node_modules/puppeteer/.local-chromium/linux-594312/chrome-linux/chrome: error while loading shared libraries: libgtk-3.so.0: cannot open shared object file: No such file or directory TROUBLESHOOTING: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md at onClose (/node_modules/puppeteer/lib/Launcher.js:339:14) at Interface.helper.addEventListener
```

Which prompted us to see if updating the version of libgtk-3-0 by ssh-ing
directly onto the time machine box would get time machine up and running
again. It did! So we'll need to update libgtk-3-0 as a puppeteer dependency.

We were also curious if Time Machine would still work with a puppeteer update, so
we updated puppeteer with npm on the Time Machine box in prod after updating libgtk-3-0
and this works, so we also bump the puppeteer version here.

Co-authored-by: Simone Smith  <simone.smith@guardian.co.uk>

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
- adds libgtk-3-0 as a dependency for puppeteer, so that we will get the latest version of puppeteer
- bumps the version of puppeteer to 10.2.0
## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

We tested this by upgrading puppeteer on directly on the box
`sudo npm install puppeteer` 
and validating that we got the new version
![image](https://user-images.githubusercontent.com/3072877/130623469-edbbd7c0-02a4-4b60-b8b1-149832f1622f.png)

And then upgrading libgtk-3-0
`sudo apt install libgtk-3-0`

Then we were able to see if the box would come back in service, and that Time Machine would start taking screenshots again. This was to see that these upgrades would fix the problem as expected. 

Post merge we should do the same checks:
1. Deploy amigo
2. Rebake the time machine recipe
3. Redeploy time machine with the latest bake
4. Check that the box has successfully come up, and that time machine is taking screenshots again


## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Time machine should be running and taking screenshots as it normally does after a redeploy. 

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Yes. Only time machine uses the puppeteer role currently, and this is a fix to get time machine working again. 


More detail here:
https://github.com/guardian/ophan/issues/3932#issuecomment-904571290
