### PR TITLE
Downgrade puppeteer version back to 1.9.0

### DIFF
--- a/roles/puppeteer/tasks/main.yml
+++ b/roles/puppeteer/tasks/main.yml
@@ -13,5 +13,5 @@
 - name: Install "puppeteer" node.js package so that it is available to any program on the system
   npm:
     name: puppeteer
-    version: '10.2.0'
+    version: '1.9.0'
     path: / # Hack based on https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders - blame Alex


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Decouples Puppeteer upgrade from the libgtk-3-0 upgrade that was in this PR: https://github.com/guardian/amigo/pull/644 

libgtk-3-0 was needed to get Time Machine working again. We were hoping to upgrade Puppeteer too while we were there, but that seems to be a bit more involved and should probably be decoupled from the libgtk-3-0 upgrade. We tried manually updating libgtk-3-0 and puppeteer before shipping https://github.com/guardian/amigo/pull/644 - process described here https://github.com/guardian/ophan/issues/3932#issuecomment-904571290 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Post merge we should do the same checks:

- [ ] Deploy amigo. 
- [ ] Rebake the time machine recipe. 
- [ ] Redeploy time machine with the latest bake. 
- [ ] Check that the box has successfully come up, and that time machine is taking screenshots again

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Time machine works again. 

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Yes, only we use the puppeteer role currently. 
