### PR TITLE
chore: Bump `sbt-riffraff-artifact` to v1.1.17

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.17")
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts Artifact("jdeb", "jar", "jar")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/script/ci
+++ b/script/ci
@@ -8,4 +8,4 @@ set -e
  ./script/ci
 )
 
-sbt clean compile test riffRaffNotifyTeamcity
+sbt clean compile test riffRaffUpload


### PR DESCRIPTION
This version brings some changes for GHA.

Also move from `riffRaffNotifyTeamcity` to `riffRaffUpload`.