### PR TITLE
Update @guardian/cdk to 26.2.1

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -44,11 +44,6 @@ Object {
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "InstanceTypeAmigo": Object {
-      "Default": "t3.small",
-      "Description": "EC2 Instance Type for the app amigo",
-      "Type": "String",
-    },
     "LoggingStreamName": Object {
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
@@ -343,9 +338,7 @@ Object {
         "ImageId": Object {
           "Ref": "AMIAmigo",
         },
-        "InstanceType": Object {
-          "Ref": "InstanceTypeAmigo",
-        },
+        "InstanceType": "t4g.small",
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [
@@ -1083,11 +1076,11 @@ dpkg -i /tmp/amigo.deb",
     },
     "TargetGroupAmigoB9501F07": Object {
       "Properties": Object {
-        "HealthCheckIntervalSeconds": 30,
+        "HealthCheckIntervalSeconds": 10,
         "HealthCheckPath": "/healthcheck",
         "HealthCheckProtocol": "HTTP",
-        "HealthCheckTimeoutSeconds": 10,
-        "HealthyThresholdCount": 2,
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
         "Port": 9000,
         "Protocol": "HTTP",
         "Tags": Array [
@@ -1114,8 +1107,14 @@ dpkg -i /tmp/amigo.deb",
             },
           },
         ],
+        "TargetGroupAttributes": Array [
+          Object {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+        ],
         "TargetType": "instance",
-        "UnhealthyThresholdCount": 5,
+        "UnhealthyThresholdCount": 2,
         "VpcId": Object {
           "Ref": "VpcId",
         },

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -1,4 +1,4 @@
-import { Peer, Port } from "@aws-cdk/aws-ec2";
+import { InstanceClass, InstanceSize, InstanceType, Peer, Port } from "@aws-cdk/aws-ec2";
 import { Effect, Policy, PolicyStatement } from "@aws-cdk/aws-iam";
 import type { Bucket } from "@aws-cdk/aws-s3";
 import type { App } from "@aws-cdk/core";
@@ -232,6 +232,7 @@ export class AmigoStack extends GuStack {
 
     new GuPlayApp(this, {
       ...AmigoStack.app,
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
       userData: [
         "#!/bin/bash -ev",
         `wget -P /tmp https://releases.hashicorp.com/packer/${packerVersion}/packer_1.6.6_linux_arm64.zip`,

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -16,11 +16,11 @@
     "diff": "cdk diff --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.110.1",
+    "@aws-cdk/assert": "1.122.0",
     "@guardian/eslint-config-typescript": "^0.6.0",
     "@types/jest": "^26.0.20",
     "@types/node": "15.12.5",
-    "aws-cdk": "1.110.1",
+    "aws-cdk": "1.122.0",
     "eslint": "^7.29.0",
     "jest": "^27.0.6",
     "prettier": "^2.3.2",
@@ -29,13 +29,13 @@
     "typescript": "~4.3.5"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "1.110.1",
-    "@aws-cdk/aws-events-targets": "1.110.1",
-    "@aws-cdk/aws-iam": "1.110.1",
-    "@aws-cdk/aws-lambda": "1.110.1",
-    "@aws-cdk/aws-s3": "1.110.1",
-    "@aws-cdk/core": "1.110.1",
-    "@guardian/cdk": "21.0.0",
+    "@aws-cdk/aws-ec2": "1.122.0",
+    "@aws-cdk/aws-events-targets": "1.122.0",
+    "@aws-cdk/aws-iam": "1.122.0",
+    "@aws-cdk/aws-lambda": "1.122.0",
+    "@aws-cdk/aws-s3": "1.122.0",
+    "@aws-cdk/core": "1.122.0",
+    "@guardian/cdk": "26.2.1",
     "source-map-support": "^0.5.16"
   }
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -2,709 +2,768 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/assert@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.110.1.tgz#1f03c0f008e9e41bb2a6eb62599dc2245a06695c"
-  integrity sha512-GdLgThJrOZ4VsvnuJu+uYtbbx884m0jFavy4NgWc7KSE+Vn4X51VtO4Ju02el/pMSgS7MLgbGQXLYuFAlt3ITA==
+"@aws-cdk/assert@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.122.0.tgz#30a78c0784aff0ec57239a862c8d266f9f9ffd10"
+  integrity sha512-hgmN7Owmsk9F7rGsvD4LjhY7YukgMpKWNvbXHxsTSluoP2LF7MRwTcYu2bf/DAkYuY7tK1X8k0G4jeEZAie4ZQ==
   dependencies:
-    "@aws-cdk/cloudformation-diff" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/cloudformation-diff" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/assets@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.110.1.tgz#e3578c8926e07cfb44c9b02e095b2e1d0c6c8068"
-  integrity sha512-aPJvTQeSkkvS7TjtQmMU1zRRSfhMqgZs9lZGUKv6wc/zeMS1t89ntzvuDCZmpUBP3tZbx0lexLqOAvBgD+FdSQ==
+"@aws-cdk/assets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.122.0.tgz#58c1a34ce4ae59fdf33a9d4dc2f384c1850acae5"
+  integrity sha512-jNY/nXEWtoIONZnXfRr22i8PVp2JPDai4hofzu2/vnwZuJF+a+BlEI3yWzXaQMZ7ZNMnT0KSXwkaSque+1xr3g==
   dependencies:
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-apigateway@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.110.1.tgz#36a7a6c26651d59942c30a2e0ba2ca65a4af3ad1"
-  integrity sha512-KQQdNIFPD2/hHeGSu6bbbhxW6Dt+GhLWX42TWVQpktBfA36hptYxf7QhX+gjhlthKhjbJSvEMYLG4ZDn9/nVqg==
+"@aws-cdk/aws-apigateway@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.122.0.tgz#5f2a1e3f5b7fedc951bbd4e25117d0954f4cfdfe"
+  integrity sha512-rJlocumxO+9uvEMrLc0iUxcq0jfn/+ckvJX76TsRr7ptXO8ydfEfwBcZjNtX0ypDOv6QShZH6KbqiZimgp/GbA==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.110.1"
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-cognito" "1.110.1"
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/aws-logs" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/aws-s3-assets" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/aws-certificatemanager" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-cognito" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-applicationautoscaling@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.110.1.tgz#1604cba645454bfb76900f2a73caee422928408e"
-  integrity sha512-tg+JhgShqwRBAP2fZ9mXRbleQQxfT8UsciKbNSX6C7RAzJTD2Esoz384bOHmOdn9B8zgfpBXyx8erkrr1ZMEjg==
+"@aws-cdk/aws-applicationautoscaling@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.122.0.tgz#25330a0185cf9df77499677b528b260ca6db441d"
+  integrity sha512-iLXCGgQPfkL/bSIbtJXN5VlEqLyK/mnu+y8TtSsZ6ls0o3et1vHSZoVZvbtmlXdP/F+MF40rSwKqVrU1cMb70A==
   dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.110.1"
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-autoscaling-common" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-autoscaling-common@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.110.1.tgz#e4889f0b792a1ecfc44bd50b9e6ded5aa30ead0b"
-  integrity sha512-l2IEuiNGbnJWL5CJ/+676N6Oz1wPNc9lReNnHakznT6rZQ6rIFiQ0b6xu7AMH+CtAKXcdhCyv/4nrXhlUjsROQ==
+"@aws-cdk/aws-autoscaling-common@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.122.0.tgz#fb001f5b85b927063dc5dd4c28c4534127cae251"
+  integrity sha512-vTkBJGOHKr16S+4XOhkqvHfzapSKVJ+eHe599B2imhC5n3hui/ly6jc0aUGXT8r2yIUqGYuqVJLVW0OlHZRjBQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-autoscaling-hooktargets@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.110.1.tgz#a90badbb3a1278d4386ad8068b06dbd719353f0f"
-  integrity sha512-PBicW8tmvzh6YyYrIdQfqkWT65SfIqnGvKYG5mYS8qY1CBjArve6gDUJ0Wg1Pq0GoZ41e1+JdvHirlG7xh+k8w==
+"@aws-cdk/aws-autoscaling-hooktargets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.122.0.tgz#33e2615b75a013d3d2f043bb7211aef8d1dffac1"
+  integrity sha512-4oDw8zveuEMUmOYZQ96cAVVw8o9tM1BEN1Jb+Yul+GVw2xJPzHMxbDn3IKvIqu+dL/9dabK0fq5Tpve74RHb1A==
   dependencies:
-    "@aws-cdk/aws-autoscaling" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/aws-sns" "1.110.1"
-    "@aws-cdk/aws-sns-subscriptions" "1.110.1"
-    "@aws-cdk/aws-sqs" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-autoscaling" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sns-subscriptions" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-autoscaling@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.110.1.tgz#4dbdfb971efef3001d604fc2966c7df80a5b3792"
-  integrity sha512-fHjEaYJ0+gjSLNU49nm2qOAvsyFGNa/rVceH/FFjdZoquasnoa1Zms5fyTpin/o68lHvpcxozplDTt4txanCpA==
+"@aws-cdk/aws-autoscaling@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.122.0.tgz#d4c8f5b02306c3371279ab601dbd6b2ad7b8d4ae"
+  integrity sha512-K/DNeCMxRNhtksOW6JIVDcng8FSnGQHV6ScTnYTUeJGOJpNgwF/pB+nW3Bmw4w/QNyt5lN9DnHs6NIYZjTDMCw==
   dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.110.1"
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-elasticloadbalancing" "1.110.1"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-sns" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-autoscaling-common" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancing" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-certificatemanager@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.110.1.tgz#d689521aadeeba95d32e322f62aac0f44e5e039a"
-  integrity sha512-LppbCL/KIKDlefIRXV2vpkoNwUFW2+b6nYMHDnL54eWn2T3vNkiGPcNh79q5DnoD6o2OJGEHorlbud86STIP9A==
+"@aws-cdk/aws-certificatemanager@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.122.0.tgz#f2eec2a41a48998667e5d5578047a4f1d9e60e9e"
+  integrity sha512-ULrOt7JJWBisQz9ImjXQT/lSvOHobNqBGLP8nXTltlIktPO1oqdtcqJGYq0+XXXRz99xmw6O9K5raDpAc/eKIQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/aws-route53" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-route53" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudformation@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.110.1.tgz#ca17aa35eac169b48d4e8f6d5d8a669509d94e73"
-  integrity sha512-lX+UG8jXd490J+UzDiFj35FGA6niATwgVjioCutdtwFDEDqf7xGA09+Eueh/55TinL4tOB0vwsxnsMc9b2J/qg==
+"@aws-cdk/aws-cloudformation@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.122.0.tgz#b077151c001571188688678c86e3053ae64b52a1"
+  integrity sha512-ohI6cKwqd7YuibyvBGn9I0V8hf0MU1uHQvNRBy3teMMXOVwUrJbGKeeA5uBppAlJFmGanUpgiScEOJW9FvKW7Q==
   dependencies:
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/aws-sns" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudfront@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.110.1.tgz#2c67c7c6eaa3fafd93606f1309322dd288ed154d"
-  integrity sha512-rpNjXM2iL3FQjaI7glqo9KkoqZtywlXrSWkuR0Chve//DGcqD3l/+S466eRYJFQ3CyId/jTYYP9HbFsCnnsHOg==
+"@aws-cdk/aws-cloudfront@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.122.0.tgz#2e8ce364e725d24652a2d200bfb6c28c131810a9"
+  integrity sha512-JpX2ad/EEGLUuW9guOxDChBdIzWHFG/tx6XKBO0XKgoZ/4Yqvz8CLtA0lSet5hLbly11TmKHZcCm/FoqjUj1Jw==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.110.1"
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/aws-ssm" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-certificatemanager" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-ssm" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudwatch-actions@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch-actions/-/aws-cloudwatch-actions-1.110.1.tgz#adbecf92f7bd366bc6ce9ff439bea806ebf4a3c1"
-  integrity sha512-ilpMlpT+O4YS1qY9tImjkQfcpqqc/RnLMyRWr4hU2PHk/5SkVTwckSS8vX0U6+E2yKC0ih7N9hcTBVJYHcbEZA==
+"@aws-cdk/aws-cloudwatch-actions@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch-actions/-/aws-cloudwatch-actions-1.122.0.tgz#dc9a53dd8fae83bc4f88143a9ddc238da3712526"
+  integrity sha512-QDipB9lZY2P9rnn51oaIriVASdfIF3Ymh5JizpThthFxDubCtkJul0jUbbp3ZM6kQ4ILS9X7tlAD7waNvmh5hQ==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.110.1"
-    "@aws-cdk/aws-autoscaling" "1.110.1"
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-sns" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-applicationautoscaling" "1.122.0"
+    "@aws-cdk/aws-autoscaling" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudwatch@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.110.1.tgz#732c04bc0949d6e2a4db5e697cbd722726b83eed"
-  integrity sha512-zrkKkdrvZw5uImMb7iFVkThJHCnRFxKrm+evbVCtVhSXrcS9tHYG65mTGSc0DkwPoVyfJZHLTzOWQnE6sVi9MA==
+"@aws-cdk/aws-cloudwatch@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.122.0.tgz#25724ce559e423f498247b8821fa1564a0f94edb"
+  integrity sha512-K7kFyc5MlWTBTxQrNg32DZWGJoYXTKxjc/5i5HJBPYPNOeG+joK+3fFiG9seBmea4O3xYMHg7vbuZxcvM7AbSA==
   dependencies:
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-codebuild@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codebuild/-/aws-codebuild-1.110.1.tgz#5e805dc6482b430812e9ab6531a5b1db7570aa45"
-  integrity sha512-jxt5hrMTblXTr5QBggYLZn4dKFwxrnhxbNb5HGL00c0zu4Ua7Atogh7NfCDWr78BcGpLrjjIMTae6U2bKJDAFw==
+"@aws-cdk/aws-codebuild@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codebuild/-/aws-codebuild-1.122.0.tgz#5f8fabb9fc3ecb0359b5c26f6254b3bbb821338c"
+  integrity sha512-Wa73Y02E7LNCHAm76KnJJEikC8HuX8symoVlR9YhZnqFhG3CbynpCgzlNZIhObiUaU2u5L9r8WT3hyYK/QfN8Q==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-codecommit" "1.110.1"
-    "@aws-cdk/aws-codestarnotifications" "1.110.1"
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-ecr" "1.110.1"
-    "@aws-cdk/aws-ecr-assets" "1.110.1"
-    "@aws-cdk/aws-events" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/aws-logs" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/aws-s3-assets" "1.110.1"
-    "@aws-cdk/aws-secretsmanager" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/region-info" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-codecommit" "1.122.0"
+    "@aws-cdk/aws-codestarnotifications" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-ecr-assets" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/aws-secretsmanager" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
     yaml "1.10.2"
 
-"@aws-cdk/aws-codecommit@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codecommit/-/aws-codecommit-1.110.1.tgz#801cdf6e51c71f54136e8b4ac0168cebeca38e9e"
-  integrity sha512-xbB/Y2xrZs1PmHmP4V561/Dy7aHzJC9on4mQp1WScnRjWT138d1wEdv4wdhK8xeG6geRb9nvkkhjS1GYEyUN/Q==
+"@aws-cdk/aws-codecommit@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codecommit/-/aws-codecommit-1.122.0.tgz#60da47c1465eec26d209b8ef908712c9f0b56ed1"
+  integrity sha512-vAMNkNZ5YRI/kgAX+sm3g7E0yLWHAhCFLHnTdBPTtefDxwYudP/csdKBiVOHWh+beB4pJugVLn7jPxwyB2Jc5Q==
   dependencies:
-    "@aws-cdk/aws-events" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-codestarnotifications" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-codeguruprofiler@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.110.1.tgz#f650e2fc7a34a1ddeb6d8d96b35f1f1f326fd6ce"
-  integrity sha512-11liIxSsa9Y4YgC7hWapK/ArpKfrkf6cVCLNSgQnCmHM6UZDp3wFNOPeVLEu6PMft+l3Yvmy8F1+NgA6T4Vh2g==
+"@aws-cdk/aws-codeguruprofiler@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.122.0.tgz#59770d5c7dfffb8abd156a75cef2df8a3f1a6fda"
+  integrity sha512-gwMtyzr2EjvmOuzIPSM2ooUscmGZnhh/B2Zvjrl28/4UAH6EM2kOGdnZtbzFOzUqT5XqsttVfKycPFNYQscmJQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-codepipeline@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.110.1.tgz#93650b84b2775877708d12aff97e1a6b721fb926"
-  integrity sha512-6y22/gjidZ0OAbHCOnK+izWBNu0aLenwgGcmIZkkSaJ9To6JDqf1MxdCsKlxxehBjKQ/lc047XKbu+VE2UZUcQ==
+"@aws-cdk/aws-codepipeline@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.122.0.tgz#49c08fe31c2b0fb36c0c62c09b32641ecac792c1"
+  integrity sha512-oLF58W3e3e32DICIFg+d+Qf5bM1wXA8TXYtNdUVDXKPCgt7Lyd+aqxlYATFrCSAhjrdjoy2Vj21x9WF8tLRzZA==
   dependencies:
-    "@aws-cdk/aws-codestarnotifications" "1.110.1"
-    "@aws-cdk/aws-events" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-codestarnotifications" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-codestarnotifications@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.110.1.tgz#49692d9289801d83070ebd9b99ef1b3f7a650090"
-  integrity sha512-LmU61x3OK/UhEEpBcP+oKU6ePqzAtdiUk++xkUNhje4FkdM7OR1laMiskZN5MR4MCFKKgQV7KKNeppPH49c4kg==
+"@aws-cdk/aws-codestarnotifications@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.122.0.tgz#92049ba8eb6a54a61210506ae6dd0f3af6a83be7"
+  integrity sha512-STdYT94spdxtaODanwW5M0W6V9kaJ9szpPQubYXTKnpKxZ6UCKANKMj+Fqp/zJxlXQqnuaHuMtol0nA/Xt2bfg==
   dependencies:
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cognito@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cognito/-/aws-cognito-1.110.1.tgz#8feb7aec536b319da0383fa2b011ddbba8287689"
-  integrity sha512-J7MzpzwN1tUDCTpsHP03qXfUM+MbNuJ/IYz/wWg3fP2RdXKfcGDKVdSl27gEnsCaiC6cmQLzStRWW6ki2x87ow==
+"@aws-cdk/aws-cognito@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cognito/-/aws-cognito-1.122.0.tgz#a18d1274cbb0d240e365c7edc23b8c1fad1ecf13"
+  integrity sha512-eFdW890ZLaN5c7qQ0/RqQB2Ufta3aQC5tnJzGdkEb9JQfoM/fSL0s+jmpriUHUaD0wok9la34gPq7iKq55B29g==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/custom-resources" "1.110.1"
+    "@aws-cdk/aws-certificatemanager" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
     constructs "^3.3.69"
     punycode "^2.1.1"
 
-"@aws-cdk/aws-dynamodb@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.110.1.tgz#ad8ad6b69a3a044557bddcc01d844f5ab8d4b4b3"
-  integrity sha512-DJ26oXT8Ib7N/ylWyWeZF6QHdqvjMyzcz3dcHZacEQZGqj0aBOVXQtmcZAb+qDBNsg81eKJE4E/3Qsy1YT2qJA==
+"@aws-cdk/aws-dynamodb@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.122.0.tgz#d2402d1cae815910c6a89682dc4ae8978779eec7"
+  integrity sha512-zsEMFxKMxVoa3vyOP4zWD09rXaGKXbAHXhtjhY8MeupDE42ZrspZLybMHycElCVwq8JQjcq0G0oBzOodR6NnPw==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.110.1"
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kinesis" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/custom-resources" "1.110.1"
+    "@aws-cdk/aws-applicationautoscaling" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kinesis" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ec2@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.110.1.tgz#c97bf65f9659ee5101761c9c2748a5786aebfbd4"
-  integrity sha512-lVkWfoVBEXotdhXbYH+DxlVLGVjasBu4rD2FxgjZJe2E+w9atJVgaMUmSuLcVgwLEOVlnYpQ+ffNu+AR/KSziw==
+"@aws-cdk/aws-ec2@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.122.0.tgz#31b2280629404a829eb639e8e373221613a1aded"
+  integrity sha512-bKJGgd3KruFeOyP/5Fc/Ufr4BHB9+xVpXVGqCeKEInkq0f4ttWhHbfKRJdYEUBEF0xwDQEj7RM6EgaV0fdfb9g==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/aws-logs" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/aws-s3-assets" "1.110.1"
-    "@aws-cdk/aws-ssm" "1.110.1"
-    "@aws-cdk/cloud-assembly-schema" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
-    "@aws-cdk/region-info" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/aws-ssm" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ecr-assets@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.110.1.tgz#ff74319577db8723e46da6b4a4f39c56c5299ec7"
-  integrity sha512-lQJU/BGrnzYKGi+mWALtGPk4jliaVeErlZKi4JXLQi58tr8wzRWjUATqasRh8sU7R/UXmNfmBgN2TL3jwf/57g==
+"@aws-cdk/aws-ecr-assets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.122.0.tgz#6483e869202c272f83e37b7c5003a5b1d4d14813"
+  integrity sha512-BFYCNsUs/1Dlh41bXmFmq41RpNatqm/KHfIWA0eFNIAuG/IqOga9LF71zCBiqv4gfNmfGQg19Sq2BojGQwisVA==
   dependencies:
-    "@aws-cdk/assets" "1.110.1"
-    "@aws-cdk/aws-ecr" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/assets" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
     minimatch "^3.0.4"
 
-"@aws-cdk/aws-ecr@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr/-/aws-ecr-1.110.1.tgz#9ad40ef09eaf85cac437b1f5de43bd6217248f9e"
-  integrity sha512-m9OHq/0I2V3hDf6O4hwENgk0s0pj0OSxTQK0FuI4iahPt7ALBmIgH3uw7zNtuE6lx2DC7Ge2N3PAl6i9YjXohA==
+"@aws-cdk/aws-ecr@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr/-/aws-ecr-1.122.0.tgz#a86a52e32d74cd48dc96f7b7613b7151213ea8e6"
+  integrity sha512-FxM7Q/6VHquOdfWrKQArzs/91fxvZFwT/FkPIrEm+X10/voOFI6S6xRXaOlr2UVn6dji6J6DssY7YBvJq1ciOQ==
   dependencies:
-    "@aws-cdk/aws-events" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ecs@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecs/-/aws-ecs-1.110.1.tgz#55df6247489996c55aeb162d81b6992c0b5325ba"
-  integrity sha512-bPVpesIXMkzLkYPPUSPDsWj3Op8BME/0le1g+RKB1OZIjkO8et6x6Znrn6mKkFS0FwHsgKqWoSRvKmjponNlTw==
+"@aws-cdk/aws-ecs@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecs/-/aws-ecs-1.122.0.tgz#6d7e4c34a4e28881bb94e9f43762653c9fbff208"
+  integrity sha512-SdgRi3TsAOGigVga1HRiTsMlbkC5nosmQJ1P67rF2IcXdhoToKLFrXSLskFsO50JjmK6781efhW6xZYvvTlQ/A==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.110.1"
-    "@aws-cdk/aws-autoscaling" "1.110.1"
-    "@aws-cdk/aws-autoscaling-hooktargets" "1.110.1"
-    "@aws-cdk/aws-certificatemanager" "1.110.1"
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-ecr" "1.110.1"
-    "@aws-cdk/aws-ecr-assets" "1.110.1"
-    "@aws-cdk/aws-elasticloadbalancing" "1.110.1"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/aws-logs" "1.110.1"
-    "@aws-cdk/aws-route53" "1.110.1"
-    "@aws-cdk/aws-route53-targets" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/aws-s3-assets" "1.110.1"
-    "@aws-cdk/aws-secretsmanager" "1.110.1"
-    "@aws-cdk/aws-servicediscovery" "1.110.1"
-    "@aws-cdk/aws-sns" "1.110.1"
-    "@aws-cdk/aws-sqs" "1.110.1"
-    "@aws-cdk/aws-ssm" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/aws-applicationautoscaling" "1.122.0"
+    "@aws-cdk/aws-autoscaling" "1.122.0"
+    "@aws-cdk/aws-autoscaling-hooktargets" "1.122.0"
+    "@aws-cdk/aws-certificatemanager" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-ecr-assets" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancing" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-route53" "1.122.0"
+    "@aws-cdk/aws-route53-targets" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/aws-secretsmanager" "1.122.0"
+    "@aws-cdk/aws-servicediscovery" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/aws-ssm" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-efs@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-efs/-/aws-efs-1.110.1.tgz#9419ffc9346bc094d5d83e3c727ae44147fb7ed2"
-  integrity sha512-Ly7Acu/ibLpWR+5vxiFzJggIgFG3k7ik7eufpp1bhMMRMRSChiZdabdlVMEsdP9CcK5p66KnyMisHuUqZ+3Hag==
+"@aws-cdk/aws-efs@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-efs/-/aws-efs-1.122.0.tgz#b0fba574ccc35f4c6989828f2234c88b8e8e6566"
+  integrity sha512-CFvqAVv2BX31j+tGxM2a8CaTbf2QqMoeegORRJzipykeX+wCPu/5nYA7jWOXlCLYZ2MnLRHaAZzzVtLRvgNSWw==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/cloud-assembly-schema" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-elasticloadbalancing@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.110.1.tgz#b0733f9ddcc71e3c4e5001d0d7520e017c86ce6f"
-  integrity sha512-4n7mPXeZQlVF1DXVR4nv9jrHjUUfeVYqRmLlrqGE17uR1wyDraEGz9x7BGA/KpaJ59HpXKdpbtF/XtL5CHRpOw==
+"@aws-cdk/aws-eks@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-eks/-/aws-eks-1.122.0.tgz#25113b3d6ad4804224cf95310f1bb5b1a082501c"
+  integrity sha512-/T876MGxQD6D9o4C6wlHoZjqYxnxU0Iw7O1fKzp4tW0A+F3ykLwls9QcYDxZlIfSEFzLhNKSKFBp8Lrfx0hHxQ==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-autoscaling" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-ssm" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
+    "@aws-cdk/lambda-layer-awscli" "1.122.0"
+    "@aws-cdk/lambda-layer-kubectl" "1.122.0"
+    constructs "^3.3.69"
+    yaml "1.10.2"
+
+"@aws-cdk/aws-elasticloadbalancing@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.122.0.tgz#b96ca26fae657fe1ad3d4fc86bdabe17b11176f7"
+  integrity sha512-LdGcPIp60QLP0SGfgQlJ4N05NT7SCjwzZ3n194+bKlEs/SZ/3KdyCMg4yGKbg9MxcvOV3ADBO7JEy1oEc/b8Sg==
+  dependencies:
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-elasticloadbalancingv2@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.110.1.tgz#b576856497473d3b7f99e41a24230078fa75f1c1"
-  integrity sha512-ufVqQec/Z4lBXiA8W09g/5KuxTXUehcFYiwK+6ICDEtTEB0iJfejuNM9TNLEfnRuiVhR3x4j3dQOmw99eq858Q==
+"@aws-cdk/aws-elasticloadbalancingv2@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.122.0.tgz#3fa95a24c303c44ebc7bb2c15a3289f6197a8c53"
+  integrity sha512-WilvbbVtulDBI1QV2uqd7vlCUKvjjDR6t+WvbaB6iNHyGLcuRF8Gs7aOiIkTbZorkzL68GrKlXmu/oj9dolVHw==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.110.1"
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/cloud-assembly-schema" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
-    "@aws-cdk/region-info" "1.110.1"
+    "@aws-cdk/aws-certificatemanager" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-events-targets@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events-targets/-/aws-events-targets-1.110.1.tgz#f407dd67bbb8d74c5ef00e6272cbe18ba5b7147c"
-  integrity sha512-71sYjOJv3bSaYdoTikLfyugwL9r/UOk5LXwt8kVTIj+5Eko5bRWShx6gTjjb/Y4u6Ln4sW51RGMUgYnINJcFxA==
+"@aws-cdk/aws-events-targets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events-targets/-/aws-events-targets-1.122.0.tgz#7757e1e97b94e4c0274fa8b209555efeda823851"
+  integrity sha512-tgBZBQWzt2ePhoVjbpRHnAmCnpJEgjuEn6bAyjpGT6ucjzuL+l3gJDDbth2c3B74eJQB9N5FQ+RXq3coTaqiew==
   dependencies:
-    "@aws-cdk/aws-apigateway" "1.110.1"
-    "@aws-cdk/aws-codebuild" "1.110.1"
-    "@aws-cdk/aws-codepipeline" "1.110.1"
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-ecs" "1.110.1"
-    "@aws-cdk/aws-events" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kinesis" "1.110.1"
-    "@aws-cdk/aws-kinesisfirehose" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/aws-logs" "1.110.1"
-    "@aws-cdk/aws-sns" "1.110.1"
-    "@aws-cdk/aws-sns-subscriptions" "1.110.1"
-    "@aws-cdk/aws-sqs" "1.110.1"
-    "@aws-cdk/aws-stepfunctions" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/custom-resources" "1.110.1"
+    "@aws-cdk/aws-apigateway" "1.122.0"
+    "@aws-cdk/aws-codebuild" "1.122.0"
+    "@aws-cdk/aws-codepipeline" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecs" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kinesis" "1.122.0"
+    "@aws-cdk/aws-kinesisfirehose" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sns-subscriptions" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/aws-stepfunctions" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-events@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.110.1.tgz#0286bc4720fd73fa7ca6fdfec6519c9b4ab38ed8"
-  integrity sha512-e8jqWZUUqOowvUtbWB4NO+zsiVQBEMbqMobnYFhKFtVXnM5y0jz1ulzvkqhm/w6uEHoCIDwKM4/PPQv8YtwXyA==
+"@aws-cdk/aws-events@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.122.0.tgz#c128fc8b9fd65e82128dcf095b3f25a250c62b8a"
+  integrity sha512-Nc6flYv4Z0P6yK0rIhuUnjsOVEucgv0WdV7va3WzPzp8B253ea0XdLfpSJxGArKAH6qcmCJmd07ls+N2omzFBg==
   dependencies:
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-globalaccelerator@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.110.1.tgz#cc6eb6e7a379f408da0a8acb587ead3bb6e6b056"
-  integrity sha512-luFx83BBDbI5yY7CZPPmO7INnFxu1qMJNrLlzYmF1qceEK5FFtxwBq6NeoyEDXGwjoFrNFo21vYfFz8VGvOlkw==
+"@aws-cdk/aws-globalaccelerator@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.122.0.tgz#42da4ba7998919be7b681a4c36f2c44d9482b4c4"
+  integrity sha512-9fwf7nR91bKce7u0aIS7OdVVJ52KC98OfhVO7cTTGS8YHjEnHZIpmNvNWgA3KMinpsMuqiIRIWJrhj2GREis6g==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/custom-resources" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-iam@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.110.1.tgz#3916fb431194afaeef551acd4bb7386e40149670"
-  integrity sha512-qwhVd1ZUeIIMAUqfZjSB5OfVxe0vr9b+eUW/znuL5QjkSMeVORJW5/OEbI2id1OdnncTczyqo9GSJSIX1ISkcg==
+"@aws-cdk/aws-iam@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.122.0.tgz#6e9bae183c20e554f9044dbadc1815bc4e01510d"
+  integrity sha512-IGPA+m45NFZijzRgXpKeKemt2+8Yba7Se1ru1/h7t2obhpdw/tcsTLhkBVagWGjSyw7zfVDIEJZTe5y5lxyQbw==
   dependencies:
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/region-info" "1.110.1"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-kinesis@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesis/-/aws-kinesis-1.110.1.tgz#b47c0d58c9c50395236a56bbd6c8c334bf9ab001"
-  integrity sha512-VajcO/1TmOGRv+NSqr4bNT5agEppNptKnSMCBw78hryXliwUBcehsvtXF4c9zYREOoY1JEhPlvpTZOVdhm2PoA==
+"@aws-cdk/aws-kinesis@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesis/-/aws-kinesis-1.122.0.tgz#611fd4fe5b9b62095376f5ee31ea25222fbe7f56"
+  integrity sha512-Jfjcon4IOKJOoFJ1W6aqmc/mDmSWWPx0pB6CIW4nPY4/bHEYvyVnxexTiZW0aG3ucdaur6atDc+DVqo2quyVAg==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/aws-logs" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-kinesisfirehose@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.110.1.tgz#e3feaf0f87e4143521de52a2e8039e4236eacd18"
-  integrity sha512-If/fWeH72sQL80VTbQBy3qiOMw21XnQJXdSu5odwSx7EyFN0gRurLmjxUq1OlIjTz9tpn+flOBjCvq1OnmBlgQ==
+"@aws-cdk/aws-kinesisfirehose@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.122.0.tgz#0aa9954d153e99679c70a6f4b63d8da34dc0b72a"
+  integrity sha512-n7++SIJe0Xpc33gEBrUuxNj5EK0vzhEvELmdTYA6s1gEqjcslEZQzliziwCtlzwsz7G91JCMTrjdc8/0yzofKA==
   dependencies:
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kinesis" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-kms@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.110.1.tgz#dede58153ced1c46dc50513f1848bb0d9d5b2d33"
-  integrity sha512-PTkK7iO/RvpRMhb3RdAxXQl/c9xfbXgz/PbuqnpTxwtg2D+WoS2+5XJUr+3UddtUporrriBjhj4NhHkNuaw55w==
+"@aws-cdk/aws-kms@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.122.0.tgz#0c9710a2ea4828725a4a7fac802a130c8cd9333e"
+  integrity sha512-oVaHgb5L4MXVt/mb1HpDr1dgVuyBNjbVe2To8WOuY1Iah6on7dh725479IObSw72lLS/5STo8XOAGKZ9h0aobA==
   dependencies:
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-lambda-event-sources@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-event-sources/-/aws-lambda-event-sources-1.110.1.tgz#ee9720b7afa982e7c84208fb404c039bfeaef81d"
-  integrity sha512-TQ4gSuuke3fs4vfrgx0+QTE0NGgC79+gETJ20xupeaNXDN/4ETV9t7xICvg/XdwGGy1wUli9G7SXa40ye+/5og==
+"@aws-cdk/aws-lambda-event-sources@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-event-sources/-/aws-lambda-event-sources-1.122.0.tgz#f472c5dbb22c1be074d8f72d1b7aa4a93a3b7c82"
+  integrity sha512-1ftiIwds4AVUjkrCGgkNWqXtL4CDtWaQO7zRdQMZ/7uX25ZjtospJUiPIK6ZILCX/mSYTJtUEQqnMsbuTvqPRg==
   dependencies:
-    "@aws-cdk/aws-apigateway" "1.110.1"
-    "@aws-cdk/aws-dynamodb" "1.110.1"
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-events" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kinesis" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/aws-s3-notifications" "1.110.1"
-    "@aws-cdk/aws-secretsmanager" "1.110.1"
-    "@aws-cdk/aws-sns" "1.110.1"
-    "@aws-cdk/aws-sns-subscriptions" "1.110.1"
-    "@aws-cdk/aws-sqs" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-apigateway" "1.122.0"
+    "@aws-cdk/aws-dynamodb" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kinesis" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-notifications" "1.122.0"
+    "@aws-cdk/aws-secretsmanager" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sns-subscriptions" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-lambda@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.110.1.tgz#84c5685d17e5c38f8578f2d57e052b8d7ef7728e"
-  integrity sha512-y4B8MX6jmAUhpjUTqmHk3pOvB+iH7o0lTcps3qVY6rWzASp3slvVuUxa5vOQvjdZmcK41uyOI1tYlq+gxFDOyA==
+"@aws-cdk/aws-lambda@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.122.0.tgz#1a870272770f0454235bf394c063c556bbc13c4a"
+  integrity sha512-tAJqGEfyrdVebq99V5vCYg8y/6lhcRlhIbSPRn4h3tKzkSfOhiXqRZD+0qfBA1nF6l64oWI5K+Y2N3DyQEemXg==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.110.1"
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-codeguruprofiler" "1.110.1"
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-ecr" "1.110.1"
-    "@aws-cdk/aws-ecr-assets" "1.110.1"
-    "@aws-cdk/aws-efs" "1.110.1"
-    "@aws-cdk/aws-events" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/aws-logs" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/aws-s3-assets" "1.110.1"
-    "@aws-cdk/aws-signer" "1.110.1"
-    "@aws-cdk/aws-sqs" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/aws-applicationautoscaling" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-codeguruprofiler" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-ecr-assets" "1.122.0"
+    "@aws-cdk/aws-efs" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/aws-signer" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-logs@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.110.1.tgz#24c2d458546d2c4ad94228f3ecb8c0be6ef82c50"
-  integrity sha512-unWZUsxVZH4OHvM3j5cefJ5Dz7s/TSXKP5nGycmCMy7aCISbY6MLO3hmUKwoFkRAJpZecJOa4Rn1nCSXwt9B8Q==
+"@aws-cdk/aws-logs@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.122.0.tgz#aefa41273f309dd0bad91e3541390164e91fd35a"
+  integrity sha512-AKoqNClzvkjcFQYJoYZ9VpjmQfqVtGIJ9pTrOlfWQJV+MI7H2wyK5hiX5gOWDOyd1fqXtGTdrI/fvfIbDo2UQQ==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/aws-s3-assets" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-rds@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-rds/-/aws-rds-1.110.1.tgz#caaa2b3dafea3e17e7caaba692527f37f8305f63"
-  integrity sha512-cKsH47kgNF4Hz74urQlI5VpePNN+t2uJw9r0mhilEKwkX6WL1ho7kqe3gH1E7rJx+TfxQX8CAyaJDxKpOIf39A==
+"@aws-cdk/aws-rds@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-rds/-/aws-rds-1.122.0.tgz#a312d74703b9b6079b602a37af079bfa2eed95fe"
+  integrity sha512-Hdx5BFpRTLljT1afI6rFF6XojDpsOT7Gm/e6MrErGxQyxZ4tgJMBTLpHbbmB8cee2fbVXt1zM35XZxY+EXfPTg==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-events" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/aws-logs" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/aws-secretsmanager" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-secretsmanager" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-route53-targets@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.110.1.tgz#902cbc8baf17725dee8b98fba19312a118bad330"
-  integrity sha512-K+8hwgZRnDXqORFnCzuabFDtXFzBEBdD+XiSogBbmF5DkTwtYZQ3qHMd8yQrdJ3Qq4gOQS35LEu65QVH5LuNhQ==
+"@aws-cdk/aws-route53-targets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.122.0.tgz#120128df6344688c692980a967566f03e84e167b"
+  integrity sha512-ZJZ2ogVr1434mSHkNJ9RdN6twMccjziqPr8IsacImJ2WnhYSddzLanvD8dZXJg/Yu4r/Jx6h5Tj0kQcEEG9XPw==
   dependencies:
-    "@aws-cdk/aws-apigateway" "1.110.1"
-    "@aws-cdk/aws-cloudfront" "1.110.1"
-    "@aws-cdk/aws-cognito" "1.110.1"
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-elasticloadbalancing" "1.110.1"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.110.1"
-    "@aws-cdk/aws-globalaccelerator" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-route53" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/region-info" "1.110.1"
+    "@aws-cdk/aws-apigateway" "1.122.0"
+    "@aws-cdk/aws-cloudfront" "1.122.0"
+    "@aws-cdk/aws-cognito" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancing" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-globalaccelerator" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-route53" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-route53@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.110.1.tgz#2a74b455578bb07971bd3f8ebdde93a0096e6dc2"
-  integrity sha512-aboSPQot/p5Rurf1C1o4iFZmwarCfOHtoz/eZ38001Ve8JvHkJZffBYhzGYnjS8T7vmGWFNz5xelAp+x4Ge9hQ==
+"@aws-cdk/aws-route53@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.122.0.tgz#388086a679943a95c06210f1d480c08e0e85d2a3"
+  integrity sha512-rGuohz5NyujKGS2pnS78DsFS7ucvcvlzKVnah62LHYdZq9MO6ZfHpa79d1zWaeyOOS3ELD2nopAeLIfE84pEUQ==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-logs" "1.110.1"
-    "@aws-cdk/cloud-assembly-schema" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/custom-resources" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-s3-assets@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.110.1.tgz#6a89a8825a1524e8c56edf3c8135ac7bb80342c3"
-  integrity sha512-7ft+00cP1D//2rWvs8KZEWH1/ye9COoeeV5BwNDeidWCS3UQos+l2hJbErN9bDQYzbHvG+GevPUdWTpjo2UI7A==
+"@aws-cdk/aws-s3-assets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.122.0.tgz#3e53fa99855932c52ba7a8b11d028579c80e9221"
+  integrity sha512-+Zqt3lK4fXoAUmGFGI5dKGe3ErwOIBrZlejTsXcO7DbrBYXGu2Wxpk3yMgsDkkSyP2uXyEnhxSqCahZOS2vRZQ==
   dependencies:
-    "@aws-cdk/assets" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/assets" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-s3-notifications@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-notifications/-/aws-s3-notifications-1.110.1.tgz#3289a372dee82b0740685951939ac0bfa0d11d9d"
-  integrity sha512-Lj37A+DN4c4jO3nC451c82RQQ0NFFLt62ZdGpwNCoYNwNj7Hpx1aeuSj53i24+a5c9H2aQKvavCNPc28DzCk2w==
+"@aws-cdk/aws-s3-notifications@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-notifications/-/aws-s3-notifications-1.122.0.tgz#83d5eed49a698e18c5b39533199c2d7ab120ea7a"
+  integrity sha512-euq1ZEr9h+zdGbVN0yQHUPgmV+7Y1Qc0RdmMcIbFQafEFTmvvh1A6EnQb/SqPeNVYRwgv0iNj/7JRsnWbBdvuw==
   dependencies:
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/aws-sns" "1.110.1"
-    "@aws-cdk/aws-sqs" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-s3@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.110.1.tgz#d49bdca780dc4b7a7adce4d9dcc0c4933c1788df"
-  integrity sha512-hH/T+wgfriwqG6UEmxT5N9/AEbZiTc6gmpyTlbIhx1u4i9x3Ek/lWYrNcshlaOaYGKaGHcw00frXhudtlIbUsQ==
+"@aws-cdk/aws-s3@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.122.0.tgz#d4432c320559aaa8756c4dacc1d7a517c7121af7"
+  integrity sha512-QveBi5KrUusyEc9Ap3998Gs6gUq5H5FQeYAHX+bDIsYgwOWajVStYpzefPfjnAR5TuH8+hXWVFaDzY7BaID4Uw==
   dependencies:
-    "@aws-cdk/aws-events" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sam@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sam/-/aws-sam-1.110.1.tgz#f1177ad0a0a38c0ec3c35d0a50901f32623f67fa"
-  integrity sha512-csrtY3yXN6PBODVRVzLH46lI2yIPy4lp0R/UPx19QUF3h8kg3ERNsMiFL6pO5Ew7gZ4snvMIQib7Q29SRVP3oQ==
+"@aws-cdk/aws-sam@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sam/-/aws-sam-1.122.0.tgz#9c0d79572fad71c1ebcad6c34031247630888c67"
+  integrity sha512-POuc49ctbNHMnbEdA7vR2h2e+tWasmmYtl2vBYlGqMRNXsBm+o6LvE9+x7/kAcJArGbVB9U42FebcdQN8kAdew==
   dependencies:
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-secretsmanager@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.110.1.tgz#bcd4bfbf429088884afa34115afaa7c78c21ddff"
-  integrity sha512-lE5IrL9O/xEZYhAStyLUwALummi8qEmSMvKMZiUWf+Z2B78wW4vGDz0FBu2feyajvDrlcXh9+hXAY4zyqjjnVg==
+"@aws-cdk/aws-secretsmanager@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.122.0.tgz#077a43422811af6800ff3a5d10ece472b6f32493"
+  integrity sha512-wsmsD4z+SSrljj0u3Nk9/xLzcRusCTxGO4JrlC4gTn5YwIhSqDbsxOauSLRHnM+/tOE6C+t5vOfFd3ZrV2YH9Q==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/aws-sam" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-sam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-servicediscovery@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.110.1.tgz#12f3363c905a4859261089eddabd23adc59fd622"
-  integrity sha512-QaoMxyxomBmvrJ0pICJoXMWQEU30dtCCmzdR0qwNzsBSbjOkf2OrbOfy1qcU0TSb7wdz90KtEUCzHzbBzKz8pg==
+"@aws-cdk/aws-servicediscovery@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.122.0.tgz#267f95f7c874c6ea9cb8093889c0c1eb20d75ab1"
+  integrity sha512-YjdlJS4tEOqdh0h6RpJl065WZZvL0rj1Qp/pDK32bS4SFmpk5YFFwpcIX84zbJXodn9Hhbowyd3Wzm5ZQMr2MQ==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.110.1"
-    "@aws-cdk/aws-route53" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-route53" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-signer@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-signer/-/aws-signer-1.110.1.tgz#9caa1e92c49594ad93b86d05d86c336e4bb8f18b"
-  integrity sha512-eLYvjoQDhI603ArmpFlNNrZ06yhrqqdo6mE45TvQRQALEuNsX/L2qBS4VSJsfsoWN5Vimz722ohIuesSwOy1ZQ==
+"@aws-cdk/aws-signer@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-signer/-/aws-signer-1.122.0.tgz#9a2b6611407f72ca5101bc2ee0294b8b076da418"
+  integrity sha512-6J59KrTKtOyH1i3MxQ/9zIfYIocUgGZdqyq9cV7srZ6yUSQp1s3xR+b7LWbBUxs3UMMLXTwchhX/Birc5mXsUg==
   dependencies:
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sns-subscriptions@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.110.1.tgz#92cd2e4c3cb2404e55275c316f160dc028826c4b"
-  integrity sha512-a0QMVd6TNtnape0emOqG6WR0h5AGW4zF4qnzw2w1kLysPZAudcEMJbPkpvp3tcEhlWf1W+CxHinCp8Z1LXRqWA==
+"@aws-cdk/aws-sns-subscriptions@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.122.0.tgz#73a21c71c51b1f85f9846ee7557b03f2d0cdaa88"
+  integrity sha512-kWshuZLSrniXkROAv9TzA3SyTv/hR0Z5uTRIBuHcG5tkR0OaAFomGW3DUfddAI8a4N7rq6u15cSOWPzLVK4EcQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/aws-sns" "1.110.1"
-    "@aws-cdk/aws-sqs" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sns@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.110.1.tgz#1fbe3ebd3e7efbed415859674c896255a839324b"
-  integrity sha512-1dxpPWEvBQo5bejMeZXm3xWbQPsoaG33swcdcEjpOXMzdeR72F8b8CA7t/bGtsUdEmcHM7FBDaWjR3Qjj6BMWw==
+"@aws-cdk/aws-sns@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.122.0.tgz#66e15ff3b6ad1866a858109d5c844c122e45fc1e"
+  integrity sha512-nAB4eMJI4tHBsLjsLdPmwhkZkl1M8t9JFv6L1VdH6Y0yxz8V4fVOkPf2btovmVQ/oyniHX+DPkJzmyGw8lnsjQ==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-codestarnotifications" "1.110.1"
-    "@aws-cdk/aws-events" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/aws-sqs" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-codestarnotifications" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sqs@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.110.1.tgz#80480342b579de376adb15e3b28be20817ec9eb3"
-  integrity sha512-2XCx2uTeVll5aS3SsjU39k+9gGv1Ig9QhvXOq8VNwCxa4/2QsKkWZzJ1GSLjyBXRFzWcT9pjgcCqfW3ZVtSDUw==
+"@aws-cdk/aws-sqs@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.122.0.tgz#03e0c07a80ab33b38ba37b3eb6243f18a5599a91"
+  integrity sha512-ZamVuEfLMj8JpidjqbYR6jiAIvc8yl/WUoDS73nrypWFZf5G9IF7dDPMZ6NXGKnwF6WUD629UpUNgB7grmB4Qg==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ssm@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.110.1.tgz#8f0933755a7b23f77f778619be2c0b8905355724"
-  integrity sha512-pcxl64YIdJ5sjybHlp3KWsoEpr4gg7a+JL/mMm0oyz9OobetgDbb8yZIjGV5FHqMvse/pW4pyq0gPZwYHZ9I3Q==
+"@aws-cdk/aws-ssm@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.122.0.tgz#31e5707bc818d1166a858db6a5ddd527061006b0"
+  integrity sha512-yoB4tUeV8GgA2MylEMAXlJQUbD9mvOUoZk9zTEGmNyjhpTZBGB24YbBfeoqnq2Igh9PfAlNZkPtguGp/tPZVJQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kms" "1.110.1"
-    "@aws-cdk/cloud-assembly-schema" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-stepfunctions@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.110.1.tgz#dd4e5f515d705342a257bec5c4a59d781f5587ce"
-  integrity sha512-ST1LFjBT/kJ7RoMeJnjqLLynIe+5XoR0yW8i+vcwn8p056KV/HOBuzPicq7dZNasxbXZVQpQT2JsVm25PEXELw==
+"@aws-cdk/aws-stepfunctions-tasks@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions-tasks/-/aws-stepfunctions-tasks-1.122.0.tgz#707f6c7944381167192146350232737fa9f50b76"
+  integrity sha512-AFnttLbi9ZcRB/eSJ3DCWBj3v2NoTxlVidkmf0e11ewzJ3ML/PK21kqzhSqBLz2dEkh5U2alee3sXS/8WjObnQ==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.110.1"
-    "@aws-cdk/aws-events" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-logs" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-apigateway" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-codebuild" "1.122.0"
+    "@aws-cdk/aws-dynamodb" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-ecr-assets" "1.122.0"
+    "@aws-cdk/aws-ecs" "1.122.0"
+    "@aws-cdk/aws-eks" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/aws-stepfunctions" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/cfnspec@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.110.1.tgz#6bbfd8f55f4fbd1dc2238b321d3053be58e35fd7"
-  integrity sha512-5cSKh20hKEiQUd0IzKn69ns2zwq7MmgeJLdO38Bf5dHf8VEVjfZnCAxho7daUJT0kolQWW9Dr1ZeJau/rFvyXA==
+"@aws-cdk/aws-stepfunctions@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.122.0.tgz#4c1f69446306dbfc0d61b5c33ec8e2a2f97081a8"
+  integrity sha512-X7tAW2gtWRdwoIRPMUIoYnCGDgSyPZK8p3NpvmOX8BDocCTKJQcvp+x58nDHTGU0u9znpePd6hULA1A7OuCy+A==
+  dependencies:
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/cfnspec@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.122.0.tgz#c42b76668ba692cea6951e0a29a70399241e4f0e"
+  integrity sha512-41CyWYJLfWfQbJWONNwu1FBIsDfDn3r/0pukc+Bkrsmx2zcPRY/JW+THyFZCyG5x1lO6T4XfGRuF2DfCehLaOQ==
   dependencies:
     md5 "^2.3.0"
 
-"@aws-cdk/cloud-assembly-schema@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.110.1.tgz#84736bdd7f7092856b450f8b357a05677cf7c4d2"
-  integrity sha512-rsv6yNhRXkqO8UP0UOzRH60Cx89vGSUKcWSzyvvL9VrTpozYCUBMMuTqhZsmArAv82PYzb1pTDcwUnJKDLhWtQ==
+"@aws-cdk/cloud-assembly-schema@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.122.0.tgz#8e6b86972bc662ac54e152566141a0a4678ee16a"
+  integrity sha512-xyVIaRZbQEoVI8VPbgreK18o0BVVthavn3zUKw6p+S1NF+FMgqatTLU0pq+bMLOHwI/zyNKuZs3KhBoMLyhZMA==
   dependencies:
     jsonschema "^1.4.0"
     semver "^7.3.5"
 
-"@aws-cdk/cloudformation-diff@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.110.1.tgz#1442d84ca02c5671423f7fd3bfb8d4126d8656e3"
-  integrity sha512-QaVc4YFBwLzp4uPD6enSNAV5stUvJ6aQ0km9hC2BPR68vc0NAHKX+ZZbJoiKPu/0aXjzrYvEqYw4qRIM0d6RlQ==
+"@aws-cdk/cloudformation-diff@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.122.0.tgz#1661bf6adb7421a8702bbd2c71f36d2ea863db54"
+  integrity sha512-syTS6fPd0IASzsOGJUbZtpPzHhW0aTtoPauN4NK7T2ynyEGVMmdW5vikdWBt3Kg5mkTTVvxQix7r1aLiQyMYIw==
   dependencies:
-    "@aws-cdk/cfnspec" "1.110.1"
+    "@aws-cdk/cfnspec" "1.122.0"
     "@types/node" "^10.17.60"
     colors "^1.4.0"
     diff "^5.0.0"
@@ -712,46 +771,64 @@
     string-width "^4.2.2"
     table "^6.7.1"
 
-"@aws-cdk/core@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.110.1.tgz#7fd6408f3e6c2eee7a7bd3a5b8fc48e407a3804c"
-  integrity sha512-E4+DorhqQ3j0qlz6GZ+v95cXvdsQiuyCjO0yYH5Qk/9X2vaXcJoCrbHYh4+Lx6pbBnAVvFMJXtoNFGoA0m9HpA==
+"@aws-cdk/core@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.122.0.tgz#726cee4802f49a16c1ec72d320ad33fa67191422"
+  integrity sha512-8yQmOH1e4YvL/MVIDQj2JS1YeijIePshP2fPw7X5iP4tdLcPcHPTXHXJAp2ARF7XL5u03juVENn/hG7G0B91nw==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
-    "@aws-cdk/region-info" "1.110.1"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     "@balena/dockerignore" "^1.0.2"
     constructs "^3.3.69"
     fs-extra "^9.1.0"
     ignore "^5.1.8"
     minimatch "^3.0.4"
 
-"@aws-cdk/custom-resources@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/custom-resources/-/custom-resources-1.110.1.tgz#0d446296bf21756dd14fd1ade9f7ee56a80b9365"
-  integrity sha512-ZimWriUpcGPtBcrW0o3zPfjLj1mCigI/iF8j0tAC6ou49o8F+i/R/27rlCQnLc0d/1R64hhOiEiEjJ3IU7dZ8w==
+"@aws-cdk/custom-resources@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/custom-resources/-/custom-resources-1.122.0.tgz#e4554dc9b4e3917a4f935ff3884d6bd1ccbca9ed"
+  integrity sha512-vdipr6cpCIYl0lokS0HQI3kY34mqpxns82+MzqYc95xZ7HPYOjnP0aKqL+UKIpaQsTVVUkOqfxZ9cXNdv04Xag==
   dependencies:
-    "@aws-cdk/aws-cloudformation" "1.110.1"
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/aws-logs" "1.110.1"
-    "@aws-cdk/aws-sns" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/aws-cloudformation" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/cx-api@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.110.1.tgz#909ab5d48e6f51b6cfebfefc29868b51dd9e9897"
-  integrity sha512-InY00PETF2wYiRA6SsldsjceIi4uRt5ED0nTNx0fApBr6k4OUfBUV44wUyTm6ZuNzeTU3qxaDKH2APRfiH06yA==
+"@aws-cdk/cx-api@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.122.0.tgz#431f3a5a7ec339fdfff0387e85f2e5956a43fb17"
+  integrity sha512-x2SPWc3RNBWi5UBdq/gZvW5He9X5NRb2j9pcBcUPhVSSEB7Fl5lqPU82q8mBy+76zHkfWILpLGJr/jNQ4ZRAeA==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.110.1"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
     semver "^7.3.5"
 
-"@aws-cdk/region-info@1.110.1":
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.110.1.tgz#27eec01f1db9768bdbbfe2037c3e65d9b372b74f"
-  integrity sha512-sRRTO2qH8kWsh4s62bKTmk9IU8uXYmRJHkOjWo6RUC/W0sv7S6VeB1XHZ7QReDF3woJ/n3oPJzsf/bu33m4l+g==
+"@aws-cdk/lambda-layer-awscli@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/lambda-layer-awscli/-/lambda-layer-awscli-1.122.0.tgz#ec3aedc6bc595e191fd8993f95b2c81cf3ec75b5"
+  integrity sha512-ecWutnWFluWYgAjGORiHUTvCCcD24FPl0b6NqT2Ex5vQmTXHCO4CdHncL0CIwQwNE6zGzQitTKEc3snumGVGng==
+  dependencies:
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/lambda-layer-kubectl@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/lambda-layer-kubectl/-/lambda-layer-kubectl-1.122.0.tgz#6e0b21f1843dcb89eaa47087591008e155b26272"
+  integrity sha512-TxZUaAUMCQbTeZPz8PWVOU/b/gMEHOoJ2AONNhYB/vDNHNBPdReBguCh6BLWYtIXlfWBrAJ3kluTmsZFGIGlvA==
+  dependencies:
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/region-info@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.122.0.tgz#05dc2fe82c365dc6b458a5e1138faa833c578e19"
+  integrity sha512-6nFk66RE+PYh85aU07tA3TxsfKUHZZxnPITidwnyJYZ2OgimxMRIuWQce1bSLkZrcaQhachcJTJ1o8mF20kJmg==
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"
@@ -1080,30 +1157,36 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@21.0.0":
-  version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-21.0.0.tgz#724b9c666d5dc7d5111e04a4d1b955bb3cc0551e"
-  integrity sha512-TB/lQpbmGY6VHhcEVfnsAQjMXU6+Xng0Y+YTwh8s/nskVBbv/duqabVItMRxPUNWrUOOIo+mpwDrsBf4rve1zg==
+"@guardian/cdk@26.2.1":
+  version "26.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-26.2.1.tgz#e597a973b219401f17357666ba68d9198fa89ecf"
+  integrity sha512-AKSPhJURsBzBoFsCgOra8yWGltCqtYV9qcJIusQ+UiZsB+yOfD0u4TKZ7sUg5yNv9NEUMwj25CtY9/u+hmsT1w==
   dependencies:
-    "@aws-cdk/assert" "1.110.1"
-    "@aws-cdk/aws-apigateway" "1.110.1"
-    "@aws-cdk/aws-autoscaling" "1.110.1"
-    "@aws-cdk/aws-cloudwatch-actions" "1.110.1"
-    "@aws-cdk/aws-ec2" "1.110.1"
-    "@aws-cdk/aws-elasticloadbalancing" "1.110.1"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.110.1"
-    "@aws-cdk/aws-events-targets" "1.110.1"
-    "@aws-cdk/aws-iam" "1.110.1"
-    "@aws-cdk/aws-kinesis" "1.110.1"
-    "@aws-cdk/aws-lambda" "1.110.1"
-    "@aws-cdk/aws-lambda-event-sources" "1.110.1"
-    "@aws-cdk/aws-rds" "1.110.1"
-    "@aws-cdk/aws-s3" "1.110.1"
-    "@aws-cdk/core" "1.110.1"
-    aws-sdk "^2.936.0"
+    "@aws-cdk/assert" "1.122.0"
+    "@aws-cdk/aws-apigateway" "1.122.0"
+    "@aws-cdk/aws-autoscaling" "1.122.0"
+    "@aws-cdk/aws-cloudwatch-actions" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-ecs" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancing" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-events-targets" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kinesis" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-lambda-event-sources" "1.122.0"
+    "@aws-cdk/aws-rds" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-stepfunctions" "1.122.0"
+    "@aws-cdk/aws-stepfunctions-tasks" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    aws-sdk "^2.996.0"
+    chalk "^4.1.2"
     execa "^5.1.1"
-    git-url-parse "^11.5.0"
+    git-url-parse "^11.6.0"
     read-pkg-up "7.0.1"
+    yargs "^17.2.1"
 
 "@guardian/eslint-config-typescript@^0.6.0":
   version "0.6.0"
@@ -1330,6 +1413,14 @@
     "@types/node" "*"
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
+
+"@jsii/check-node@1.33.0":
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.33.0.tgz#55d75cbef1c84e2012c67ab8d6de63f773be4a9b"
+  integrity sha512-Bajxa09dhkuQ8bM1ve6qtm2oFNhW9/+GaKRh4Deewsk/G86ovLXI/rRS6TfCsSw4E0TGPFWzWy0tBeJuEDo7sw==
+  dependencies:
+    chalk "^4.1.2"
+    semver "^7.3.5"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1784,19 +1875,20 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-aws-cdk@1.110.1:
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.110.1.tgz#d0b78a66536a6da14fe4e78fd9156a1905d7d0af"
-  integrity sha512-9OZtCcHVUt1xeDutxWZdjOhKelqfFBI7az63rdFgPJxCspg3HxQNrrcqDGMZZ3R/fSeVol/zoZz5wHWB730qLw==
+aws-cdk@1.122.0:
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.122.0.tgz#2efa6d1b7c1474344b6c68dff52aa056591a70f9"
+  integrity sha512-AdWTa0Oxkcz51Cm6sdYwtTB0NQ32j8UW34W2C9Z2G5G8SMUSJd4tH+RS+XEHNaYyYLGaP+Gpvajt+cDviOIBjA==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.110.1"
-    "@aws-cdk/cloudformation-diff" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
-    "@aws-cdk/region-info" "1.110.1"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/cloudformation-diff" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
+    "@jsii/check-node" "1.33.0"
     archiver "^5.3.0"
-    aws-sdk "^2.848.0"
+    aws-sdk "^2.979.0"
     camelcase "^6.2.0"
-    cdk-assets "1.110.1"
+    cdk-assets "1.122.0"
     colors "^1.4.0"
     decamelize "^5.0.0"
     fs-extra "^9.1.0"
@@ -1828,10 +1920,10 @@ aws-sdk@^2.848.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
-aws-sdk@^2.936.0:
-  version "2.937.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.937.0.tgz#6dce5f72343c89bf06672403af3135397eba0fe7"
-  integrity sha512-Ko5fATHxfHWMVJjS5/7eNEeIZ0Sja3B5f7ZvdyGmyRdUv7JVeppkNmc6cK5jFt/qGxVOK2OZnY/vE6D/INwGiQ==
+aws-sdk@^2.979.0, aws-sdk@^2.996.0:
+  version "2.1001.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1001.0.tgz#c4da256aa0058438ba611ae06fa850f4f7d63abc"
+  integrity sha512-DpmslPU8myCaaRUwMzB/SqAMtD2zQckxYwq3CguIv8BI+JHxDLeTdPCLfA5jffQ8k6dcvISOuiqdpwCZucU0BA==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -2028,13 +2120,13 @@ caniuse-lite@^1.0.30001219:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz#4b7783661515b8e7151fc6376cfd97f0e427b9e5"
   integrity sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw==
 
-cdk-assets@1.110.1:
-  version "1.110.1"
-  resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-1.110.1.tgz#103ee721fbde9df9b6776710dab4fa44f62d9912"
-  integrity sha512-Jkp+4q/HBLT+Vd6XH1aaOY+VYkcefLEANQO2XmOgfgj94AJSUPsMJmxDX31QojYGyaEJl51MK79x+LaPxtekuQ==
+cdk-assets@1.122.0:
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-1.122.0.tgz#dd5f58b11499021a72cb16c16b0c01be4be0bc12"
+  integrity sha512-AbJgrROkwj0hmFLcCtqxJLTAVqFyMP+rIS9XM9nfrEIgoNzJnmy1KgJneuXNA9U7dquSFlTPYfAoy2UCTrryBw==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.110.1"
-    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     archiver "^5.3.0"
     aws-sdk "^2.848.0"
     glob "^7.1.7"
@@ -2054,6 +2146,14 @@ chalk@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
   integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -2930,10 +3030,10 @@ git-up@^4.0.0:
     is-ssh "^1.3.0"
     parse-url "^5.0.0"
 
-git-url-parse@^11.5.0:
-  version "11.5.0"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.5.0.tgz#acaaf65239cb1536185b19165a24bbc754b3f764"
-  integrity sha512-TZYSMDeM37r71Lqg1mbnMlOqlHd7BSij9qN7XwTkRqSAYFMihGLGhfHwgqQob3GUhEneKnV4nskN9rbQw2KGxA==
+git-url-parse@^11.6.0:
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.6.0.tgz#c634b8de7faa66498a2b88932df31702c67df605"
+  integrity sha512-WWUxvJs5HsyHL6L08wOusa/IXYtMuCAhrMmnTjQPpBU0TTHyDhnOATNH3xNQz7YOQUsqIIPTGr4xiVti1Hsk5g==
   dependencies:
     git-up "^4.0.0"
 
@@ -5463,6 +5563,19 @@ yargs@^16.0.3, yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
+
+yargs@^17.2.1:
+  version "17.2.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.2.1.tgz#e2c95b9796a0e1f7f3bf4427863b42e0418191ea"
+  integrity sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"


### PR DESCRIPTION
## What does this change?
This change updates the Update @guardian/cdk to version 26.2.1


## How to test
run /script/test and fix any errors
Deploy to CODE

## How can we measure success?
keeping things up-to-date

## Have we considered potential risks?
this change mitigates risks of cdk version becoming too far out of date. Main risk is that there is some unknown change in the latest versions of cdk which we havent captured in our testing, the greater risk is not to update though.