### PR TITLE
Manage Amigo's dns CName record via CDK

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -79,6 +79,33 @@ Object {
     },
   },
   "Resources": Object {
+    "AmigoCname": Object {
+      "Properties": Object {
+        "Name": Object {
+          "Fn::FindInMap": Array [
+            "stagemapping",
+            Object {
+              "Ref": "Stage",
+            },
+            "domainName",
+          ],
+        },
+        "RecordType": "CNAME",
+        "ResourceRecords": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LoadBalancerAmigoC3017FAF",
+              "DNSName",
+            ],
+          },
+        ],
+        "Stage": Object {
+          "Ref": "Stage",
+        },
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
     "AmigoDataBucket": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {


### PR DESCRIPTION
## What does this change?
The aim of this change is to "dogfood" our own dns as software changes before we roll them out to the other teams
Trello card for this is: https://trello.com/c/GmsQlZhj/896-dog-food-dns-resource-type

## How to test
Ran test script and ensure changes are expected ones
Deployed to code
Confirmed record was inherited correctly via checking dynamo db table
Updated ttl via a different branch to prove that updates work ok
Confirmed update was applied in NS1

## How can we measure success?
Developers on team can now manage amigo's dns record for themselves

## Have we considered potential risks?
Developers on team can now manage amigo's dns record for themselves!!!
