### PR TITLE
chore(deps): Update sbt-riffraff-artifact to 1.1.17

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,8 +30,6 @@ lazy val root = (project in file("."))
 
     serverLoading in Debian := Systemd,
     riffRaffPackageType := (packageBin in Debian).value,
-    riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
-    riffRaffUploadManifestBucket := Option("riffraff-builds"),
     riffRaffArtifactResources ++= Seq(
       (packageBin in Universal in imageCopier).value -> "imagecopier/imagecopier.zip",
       baseDirectory.value / "cdk/cdk.out/AMIgo.template.json" -> "cloudformation/AMIgo.template.json"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.17")
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts Artifact("jdeb", "jar", "jar")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/script/ci
+++ b/script/ci
@@ -8,4 +8,4 @@ set -e
  ./script/ci
 )
 
-sbt clean compile test riffRaffNotifyTeamcity
+sbt clean compile test riffRaffUpload


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This version allows us to remove a couple of properties from `build.sbt` as the library provides defaults now.

Also moves from `riffRaffNotifyTeamcity` to `riffRaffUpload`.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

CI should produce a deployable artifact.