### PR TITLE
Use @guardian/cdk 31.0.0

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,12 +1,12 @@
 import { App } from "@aws-cdk/core";
 import { AmigoStack } from "../lib/amigo";
 
-const stackName = process.env.GU_CDK_STACK_NAME;
+const cloudFormationStackName = process.env.GU_CFN_STACK_NAME;
 
 const app = new App();
 
 new AmigoStack(app, "AMIgo", {
   stack: "deploy",
   migratedFromCloudFormation: true,
-  stackName,
+  cloudFormationStackName,
 });

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -35,7 +35,7 @@
     "@aws-cdk/aws-lambda": "1.132.0",
     "@aws-cdk/aws-s3": "1.132.0",
     "@aws-cdk/core": "1.132.0",
-    "@guardian/cdk": "30.0.0",
+    "@guardian/cdk": "31.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/cdk/script/diff
+++ b/cdk/script/diff
@@ -26,7 +26,7 @@ checkCredentials() {
 
 checkCredentials
 
-export GU_CDK_STACK_NAME=${STACK_NAME}
+export GU_CFN_STACK_NAME=${STACK_NAME}
 export AWS_PROFILE=${PROFILE}
 
 yarn diff

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -1177,10 +1177,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@30.0.0":
-  version "30.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-30.0.0.tgz#6bade73415949a5510f4017cfc1bb6b58478b195"
-  integrity sha512-BUZNZScvpLvK5RzClk8AgVJoA8k7nnCu5n8mtXjk8RhnMaL5vJ/zSB9y9OAJNQj19e16/SoPoVUT2rKfNIPnWQ==
+"@guardian/cdk@31.0.0":
+  version "31.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-31.0.0.tgz#b0a3b063acda301a976c90a57754aa1bfb424102"
+  integrity sha512-cMRJh4OJQDRUyjIxDOLJDlJpCijehdy6Ufs3sz/Zt6kd0MNZIjY1j+aTnAFynyg9IDmx8/6CMi0+XzqvCpBIsg==
   dependencies:
     "@aws-cdk/assert" "1.132.0"
     "@aws-cdk/aws-apigateway" "1.132.0"


### PR DESCRIPTION
## What does this change?

Brings in https://github.com/guardian/cdk/pull/919 and copes with the breaking change.

## How to test

* CI
* I've also run `./script/diff` locally and confirmed that the only changes relate to tagging

## How can we measure success?

* We are using the latest version of `@guardian/cdk`

## Have we considered potential risks?

* This should be low risk due to testing described above