### PR TITLE
Bump wazuh repo version

### DIFF
--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Add wazuh apt repository
   apt_repository: 
-    repo: 'deb https://packages.wazuh.com/3.x/apt/ stable main' 
+    repo: 'deb https://packages.wazuh.com/4.x/apt/ stable main' 
     state: present 
     filename: wazuh 
     update_cache: yes


### PR DESCRIPTION

Replaces https://github.com/guardian/amigo/pull/659  - text below copied from @louishather PR

## What does this change?

Wazuh agents currently use version 3.13.1, and while they shouldbe upgraded as a matter of course, version 4.x offers a number of benefits, specifically around the lifecycle of agents and managers.

To change the version the apt source for wazuh-agent was set to 4.x, rather than 3.x. 

The role pulls SSM parameters to retrieve agent config, and specific wazuh-agent version. If the agent version parameter isn't changed when this change is merged, AMIs that use the wazuh-agent role will fail to build.

## Have we considered potential risks?

Applying this change needs coordination to change the SSM parameter values simultaneously. 