### PR TITLE
Make agent version a recipe parameter rather than an SSM one

### DIFF
--- a/roles/wazuh-agent/defaults/main.yml
+++ b/roles/wazuh-agent/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 stage: PROD
+agent_version: 4.1.5-1

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -45,7 +45,7 @@
 
 - name: Install Wazuh Agent
   apt:
-    name: wazuh-agent=4.1.5-1
+    name: wazuh-agent={{ stage }}
     state: present
     update_cache: yes
 

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -45,7 +45,7 @@
 
 - name: Install Wazuh Agent
   apt:
-    name: wazuh-agent={{ stage }}
+    name: wazuh-agent={{ agent_version }}
     state: present
     update_cache: yes
 

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -43,14 +43,9 @@
   register: manager_address
   failed_when: "'error' in manager_address.stderr"
 
-- name: Get agent version
-  shell: "/usr/local/bin/get-ssm-parameter.sh {{ aws_region.stdout }} /{{ stage }}/deploy/amigo-role/wazuh-agent/agent-version"
-  register: agent_version
-  failed_when: "'error' in agent_version.stderr"
-
 - name: Install Wazuh Agent
   apt:
-    name: wazuh-agent={{ agent_version.stdout }}
+    name: wazuh-agent=4.1.5-1
     state: present
     update_cache: yes
 


### PR DESCRIPTION
## What does this change?

This moves agent version from SSM to a recipe parameter.

One concern with having it be a parameter rather than hardcoded is having to keeping the parameters of all base images in sync, but this addressed by setting the version we currently want as a default, and have the base image rely on it.

## How to test

Deploy to code and see if it still works!

## Have we considered potential risks?

Break every amigo recipe in the department!