### PR TITLE
Revert "Bump wazuh repo version"

### DIFF
--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Add wazuh apt repository
   apt_repository: 
-    repo: 'deb https://packages.wazuh.com/4.x/apt/ stable main' 
+    repo: 'deb https://packages.wazuh.com/3.x/apt/ stable main' 
     state: present 
     filename: wazuh 
     update_cache: yes


### PR DESCRIPTION
Not 100% confirmed yet, but there's a strong possiblity that this change is making instances unhealthy on boot.

Reverts guardian/amigo#660