### PR TITLE
Upgrade wazuh-agent to 4.x returns

### DIFF
--- a/roles/wazuh-agent/defaults/main.yml
+++ b/roles/wazuh-agent/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 stage: PROD
+agent_version: 4.1.5-1

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -129,4 +129,4 @@
 - name: Enable wazuh-agent service
   service:
     name: wazuh-agent
-    state: enabled
+    enabled: yes

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -43,14 +43,9 @@
   register: manager_address
   failed_when: "'error' in manager_address.stderr"
 
-- name: Get agent version
-  shell: "/usr/local/bin/get-ssm-parameter.sh {{ aws_region.stdout }} /{{ stage }}/deploy/amigo-role/wazuh-agent/agent-version"
-  register: agent_version
-  failed_when: "'error' in agent_version.stderr"
-
 - name: Install Wazuh Agent
   apt:
-    name: wazuh-agent={{ agent_version.stdout }}
+    name: wazuh-agent={{ agent_version }}
     state: present
     update_cache: yes
 

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Add wazuh apt repository
   apt_repository: 
-    repo: 'deb https://packages.wazuh.com/3.x/apt/ stable main' 
+    repo: 'deb https://packages.wazuh.com/4.x/apt/ stable main' 
     state: present 
     filename: wazuh 
     update_cache: yes

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -125,3 +125,8 @@
     path: /etc/systemd/system/wazuh-agent.service
     insertbefore: '^ExecStart'
     line: ExecStartPre=/usr/local/bin/authenticate-with-wazuh-manager.sh
+
+- name: Enable wazuh-agent service
+  service:
+    name: wazuh-agent
+    state: enabled


### PR DESCRIPTION
## What does this change?

This is another attempt at upgrading the wazuh-agent version, as #662 reverted the previous attempt. This was reverted as the wazuh-agent didn't start up, so there must have been changes to its default systemd configuration. There's now a task to explicitly enable the agent was part of the wazuh-agent role.  

Rather than use the script to retrieve the (non-secret) version from SSM, I've included it in the roles defaults file. This will mean future version upgrades can be tested without changes to the role or parameters in SSM - we can instead change the value for the base images. 

From #659 

> Wazuh agents currently use version 3.13.1, and while they shouldbe upgraded as a matter of course, version 4.x offers a number of benefits, specifically around the lifecycle of agents and managers.
> 
> To change the version the apt source for wazuh-agent was set to 4.x, rather than 3.x.
> 
> The role pulls SSM parameters to retrieve agent config, and specific wazuh-agent version. If the agent version parameter isn't changed when this change is merged, AMIs that use the wazuh-agent role will fail to build.

## How to test

Deploy an image built with Amigo CODE (after deploying this branch) and check the wazuh-agent is performing correctly on version 4.x. 

## Have we considered potential risks?

This should not be merged until this branch has been tested on amigo CODE, as it may cause new instances to not report to wazuh for the duration of their existence. 