### PR TITLE
Use latest version of awscli in aws-tools role

### DIFF
--- a/roles/aws-tools/tasks/install-pip-aws-cli-Debian.yml
+++ b/roles/aws-tools/tasks/install-pip-aws-cli-Debian.yml
@@ -3,4 +3,4 @@
   apt: name=python3-pip state=present
 
 - name: Install latest AWS CLI
-  command: pip3 install -I awscli==1.19.12
+  command: pip3 install -I awscli==1.22.22


### PR DESCRIPTION
## What does this change?
This bumps the version of the awscli we're installing in an effort to fix an error affecting all bionic builds using aws-tools at the moment. The error output is below, for an example bake see [here](https://amigo.gutools.co.uk/recipes/bionic-mobile-node-ARM/bakes/220) 


```
[2021-12-09 12:03:08] bionic-mobile-node-ARM: TASK [aws-tools : Install AWS CFN tools] ***************************************
[2021-12-09 12:03:09] bionic-mobile-node-ARM: [1;30mFAILED - RETRYING: Install AWS CFN tools (5 retries left).[0m
[2021-12-09 12:03:16] bionic-mobile-node-ARM: [1;30mFAILED - RETRYING: Install AWS CFN tools (4 retries left).[0m
[2021-12-09 12:03:22] bionic-mobile-node-ARM: [1;30mFAILED - RETRYING: Install AWS CFN tools (3 retries left).[0m
[2021-12-09 12:03:28] bionic-mobile-node-ARM: [1;30mFAILED - RETRYING: Install AWS CFN tools (2 retries left).[0m
[2021-12-09 12:03:34] bionic-mobile-node-ARM: [1;30mFAILED - RETRYING: Install AWS CFN tools (1 retries left).[0m
[2021-12-09 12:03:40] bionic-mobile-node-ARM: fatal: [127.0.0.1]: FAILED! => {"attempts": 5, "changed": true, "cmd": ["pip", "install", "/tmp/aws-cfn-bootstrap-latest/"], "delta": "0:00:01.109518", "end": "2021-12-09 12:03:40.574524", "msg": "non-zero return code", "rc": 1, "start": "2021-12-09 12:03:39.465006", "stderr": "Command \"python setup.py egg_info\" failed with error code 1 in /tmp/pip-build-j5fNBx/pystache/", "stderr_lines": ["Command \"python setup.py egg_info\" failed with error code 1 in /tmp/pip-build-j5fNBx/pystache/"], "stdout": "Processing /tmp/aws-cfn-bootstrap-latest
Collecting pystache>=0.4.0 (from aws-cfn-bootstrap==1.4)
Using cached https://files.pythonhosted.org/packages/3f/e7/8750ba6c6101d6aa5ceeb20c013adf2c6f3554a12c71d75654b468404bfa/pystache-0.6.0.tar.gz
Complete output from command python setup.py egg_info:
Traceback (most recent call last):
File \"\", line 1, in
File \"/tmp/pip-build-j5fNBx/pystache/setup.py\", line 183
command = f\"pandoc -f markdown-smart --write=rst --output={rst_temp_path} {md_path}\"
^
SyntaxError: invalid syntax

----------------------------------------", "stdout_lines": ["Processing /tmp/aws-cfn-bootstrap-latest", "Collecting pystache>=0.4.0 (from aws-cfn-bootstrap==1.4)", " Using cached https://files.pythonhosted.org/packages/3f/e7/8750ba6c6101d6aa5ceeb20c013adf2c6f3554a12c71d75654b468404bfa/pystache-0.6.0.tar.gz", " Complete output from command python setup.py egg_info:", " Traceback (most recent call last):", " File \"\", line 1, in ", " File \"/tmp/pip-build-j5fNBx/pystache/setup.py\", line 183", " command = f\"pandoc -f markdown-smart --write=rst --output={rst_temp_path} {md_path}\"", " ^", " SyntaxError: invalid syntax", " ", " ----------------------------------------"]}
```