### PR TITLE
Try using pip3 to install aws-cfn-tools

### DIFF
--- a/roles/aws-tools/tasks/install-cfn-tools-Debian.yml
+++ b/roles/aws-tools/tasks/install-cfn-tools-Debian.yml
@@ -3,7 +3,7 @@
     apt: name=python-pip state=present
   
   - name: Download AWS CFN tools
-    get_url: url=https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz dest=/tmp/aws-cfn-bootstrap-latest.tar.gz 
+    get_url: url=https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz dest=/tmp/aws-cfn-bootstrap-latest.tar.gz 
   
   - name: Create directory for AWS CFN tools
     file: path=/tmp/aws-cfn-bootstrap-latest state=directory

--- a/roles/aws-tools/tasks/install-cfn-tools-Debian.yml
+++ b/roles/aws-tools/tasks/install-cfn-tools-Debian.yml
@@ -13,7 +13,7 @@
   
     # this package has dependencies that are not compatible with Python 3 so we use `pip`
   - name: Install AWS CFN tools
-    command: pip install /tmp/aws-cfn-bootstrap-latest/
+    command: pip3 install /tmp/aws-cfn-bootstrap-latest/
     register: result
     until: result.rc == 0
     retries: 5

--- a/roles/aws-tools/tasks/install-cfn-tools-Debian.yml
+++ b/roles/aws-tools/tasks/install-cfn-tools-Debian.yml
@@ -11,7 +11,6 @@
   - name: Extract AWS CFN tools
     command: tar xvfz /tmp/aws-cfn-bootstrap-latest.tar.gz --strip-components=1 -C /tmp/aws-cfn-bootstrap-latest
   
-    # this package has dependencies that are not compatible with Python 3 so we use `pip`
   - name: Install AWS CFN tools
     command: pip3 install /tmp/aws-cfn-bootstrap-latest/
     register: result

--- a/roles/aws-tools/tasks/install-cfn-tools-Debian.yml
+++ b/roles/aws-tools/tasks/install-cfn-tools-Debian.yml
@@ -1,6 +1,6 @@
 --- 
-  - name: Install pip
-    apt: name=python-pip state=present
+  - name: Install pip3
+    apt: name=python3-pip state=present
   
   - name: Download AWS CFN tools
     get_url: url=https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz dest=/tmp/aws-cfn-bootstrap-latest.tar.gz 

--- a/roles/aws-tools/tasks/install-cfn-tools-Ubuntu-post-focal.yml
+++ b/roles/aws-tools/tasks/install-cfn-tools-Ubuntu-post-focal.yml
@@ -6,7 +6,7 @@
       - python-setuptools
 
   - name: Download AWS CFN tools
-    get_url: url=https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz dest=/tmp/aws-cfn-bootstrap-latest.tar.gz 
+    get_url: url=https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz dest=/tmp/aws-cfn-bootstrap-latest.tar.gz 
   
   - name: Create directory for AWS CFN tools
     file: path=/tmp/aws-cfn-bootstrap-latest state=directory

--- a/roles/aws-tools/tasks/install-cfn-tools-Ubuntu-post-focal.yml
+++ b/roles/aws-tools/tasks/install-cfn-tools-Ubuntu-post-focal.yml
@@ -6,7 +6,7 @@
       - python-setuptools
 
   - name: Download AWS CFN tools
-    get_url: url=https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz dest=/tmp/aws-cfn-bootstrap-latest.tar.gz 
+    get_url: url=https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz dest=/tmp/aws-cfn-bootstrap-latest.tar.gz 
   
   - name: Create directory for AWS CFN tools
     file: path=/tmp/aws-cfn-bootstrap-latest state=directory

--- a/roles/aws-tools/tasks/install-cfn-tools.yml
+++ b/roles/aws-tools/tasks/install-cfn-tools.yml
@@ -1,6 +1,6 @@
 --- 
   - name: Download AWS CFN tools
-    get_url: url=https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz dest=/tmp/aws-cfn-bootstrap-latest.tar.gz 
+    get_url: url=https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz dest=/tmp/aws-cfn-bootstrap-latest.tar.gz
   
   - name: Create directory for AWS CFN tools
     file: path=/tmp/aws-cfn-bootstrap-latest state=directory
@@ -10,7 +10,7 @@
   
     # this package has dependencies that are not compatible with Python 3 so we use `pip`
   - name: Install AWS CFN tools
-    command: pip install /tmp/aws-cfn-bootstrap-latest/
+    command: pip3 install /tmp/aws-cfn-bootstrap-latest/
     register: result
     until: result.rc == 0
     retries: 5

--- a/roles/aws-tools/tasks/install-cfn-tools.yml
+++ b/roles/aws-tools/tasks/install-cfn-tools.yml
@@ -1,4 +1,7 @@
 --- 
+  - name: Install pip3
+    apt: name=python3-pip state=present
+
   - name: Download AWS CFN tools
     get_url: url=https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz dest=/tmp/aws-cfn-bootstrap-latest.tar.gz
   


### PR DESCRIPTION
## What does this change?
This attempts to fix a bug we are seeing with installing aws-cfn-tools in AMIgo. It looks like an update to https://pypi.org/project/pystache/#history two days ago has broken the python2 version of the aws-cfn-tools - as pystache now only supports python 3. 

This PR (needs more description) aims to try using the latest version of the tools which support python 3