### PR TITLE
chore: Remove `aws-lambda-java-log4j` dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,6 @@ lazy val imageCopier = (project in file("imageCopier"))
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
       "com.amazonaws" % "aws-lambda-java-events" % "2.0.2",
-      "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
       "io.circe" %% "circe-parser" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion
     )


### PR DESCRIPTION
## What does this change?

This is part of the work to resolve the log4j remote code execution vulnerability.

It looks like `aws-lambda-java-log4j` is being used to ship logs from the imageCopier lambda into ELK. However this is handled by https://github.com/guardian/cloudwatch-logs-management already.

`cloudwatch-logs-management` will forward CloudWatch Logs to Central ELK. Therefore, the only requirement for a lambda to log into Central ELK is for it to write logs to CloudWatch Logs.

This is the default behaviour - `println`ing a message will be shipped to ELK automagically.

## How to test

- Deploy and execute the lambda by baking an encrypted AMI
- Observe logs landing in Central ELK

## How can we measure success?

Fewer dependencies and resolving the log4j RCE.
