### PR TITLE
TEST: Revert "chore: Remove `aws-lambda-java-log4j` dependency"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # AMIgo
 
+
 AMIgo is an application for baking AMIs (Amazon Machine Images).
 For information on how to use Amigo baked AMIs with Riffraff check [here](./docs/riffraff-integration.md).
 This project is built in [teamcity](https://teamcity.gutools.co.uk/buildConfiguration/Tools_Amigo).

--- a/build.sbt
+++ b/build.sbt
@@ -105,6 +105,7 @@ lazy val imageCopier = (project in file("imageCopier"))
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
       "com.amazonaws" % "aws-lambda-java-events" % "2.0.2",
+      "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
       "io.circe" %% "circe-parser" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion
     )


### PR DESCRIPTION
Reverts guardian/amigo#666

Want to test if snyk is picking this up as a vulnerability