### PR TITLE
Update agent to use log4j v2.16.0

### DIFF
--- a/roles/aws-kinesis-agent/tasks/main.yml
+++ b/roles/aws-kinesis-agent/tasks/main.yml
@@ -9,15 +9,15 @@
   file: path=/opt/aws-kinesis-agent/ state=directory mode=0755
 
 - name: Download Amazon Kinesis Agent
-  get_url: url="https://github.com/awslabs/amazon-kinesis-agent/archive/2.0.1.tar.gz" dest=/opt/aws-kinesis-agent/2.0.1.tar.gz mode=0754
+  get_url: url="https://github.com/awslabs/amazon-kinesis-agent/archive/2.0.4.tar.gz" dest=/opt/aws-kinesis-agent/2.0.4.tar.gz mode=0754
 
 - name: Extract Amazon Kinesis Agent
-  shell: cd /opt/aws-kinesis-agent/ && tar xf 2.0.1.tar.gz
+  shell: cd /opt/aws-kinesis-agent/ && tar xf 2.0.4.tar.gz
   args:
     executable: /bin/bash
 
 - name: Setup Amazon Kinesis Agent
-  shell: cd /opt/aws-kinesis-agent/amazon-kinesis-agent-2.0.1 && sudo ./setup --install
+  shell: cd /opt/aws-kinesis-agent/amazon-kinesis-agent-2.0.4 && sudo ./setup --install
   args:
     executable: /bin/bash
 


### PR DESCRIPTION
## What does this change?

Updates the kinesis agent to the latest version, which was released specifically to bump the log4j version. See https://github.com/awslabs/amazon-kinesis-agent/releases


## How to test

I'm not sure how to test this actually

## Have we considered potential risks?

This role is used by dotcom rendering, most of MAPI's infrastructure and a few others. If this is broken, it might break bakes, or break the apps ability to ship logs to kinesis.
