### PR TITLE
Fix base image End of Life label

### DIFF
--- a/app/views/fragments/eolStatus.scala.html
+++ b/app/views/fragments/eolStatus.scala.html
@@ -2,6 +2,6 @@
 
 @BaseImage.eolStatus(image) match {
     case Supported => { <span class="label label-success">Supported</span> }
-    case EndOfLife => { <span class="label label-error">End of Life</span> }
+    case EndOfLife => { <span class="label label-danger">End of Life</span> }
     case EndOfLifeSoon => { <span class="label label-warning">End of Life Soon</span> }
 }


### PR DESCRIPTION
While pairing with @philmcmahon earlier today we spotted that the label for end of life images was not displaying correctly.

This is because the `label-error` CSS class does not exist. This PR addresses the problem and makes the label readable.

## Before
![image](https://user-images.githubusercontent.com/57295823/146590131-dd232a91-bb30-4012-8f26-8a507355c834.png)

## After
![image](https://user-images.githubusercontent.com/57295823/146590194-ed42a780-05d5-42be-a633-066674268001.png)
