### PR TITLE
Set verbose to false for log4j patch agent

### DIFF
--- a/roles/security-patches/files/log4j-systemd.conf
+++ b/roles/security-patches/files/log4j-systemd.conf
@@ -1,2 +1,2 @@
 [Manager]
-DefaultEnvironment="JAVA_TOOL_OPTIONS=-javaagent:/usr/local/log4j-hotpatch/Log4jHotPatch.jar"
+DefaultEnvironment="JAVA_TOOL_OPTIONS=-javaagent:/usr/local/log4j-hotpatch/Log4jHotPatch.jar=log4jFixerVerbose=false"

--- a/roles/security-patches/tasks/main.yml
+++ b/roles/security-patches/tasks/main.yml
@@ -26,4 +26,4 @@
     path: /etc/environment
     create: yes
     insertafter: EOF
-    line: JAVA_TOOL_OPTIONS=-javaagent:/usr/local/log4j-hotpatch/Log4jHotPatch.jar
+    line: JAVA_TOOL_OPTIONS=-javaagent:/usr/local/log4j-hotpatch/Log4jHotPatch.jar=log4jFixerVerbose=false


### PR DESCRIPTION
## What does this change?
This sets a [verbose logging flag](https://github.com/corretto/hotpatch-for-apache-log4j2/pull/45/files) for the Log4j hotpatch JAR, which will silence some of the logging. In particular it prevents a message `Loading Java Agent version 1 (using ASM9).` upon startup.  This appears to be important in at least one edge case we've identified.

Namely, on Play <=2.5 the bash script that starts your service (provided by sbt-native-packager) has a java version check which fails when this message is printed during an execution of `java -version`. Strangely, this has been very difficult to reproduce manually, but I have verified that setting this flag does allow the service to start.

This hasn't appeared to be an issue in Play >=2.6 because the bash script was updated https://github.com/sbt/sbt-native-packager/pull/1111/files

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Amigo itself is on Play 2.5, so you can deploy this to CODE, bake a recipe Amigo uses, cloudform Amigo CODE with the generated encrypted AMI, and then spin up a new instance.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
Less edge cases where programs grepping stderr output of java commands are confused by the new message 😱 

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
This'll make it harder to tell if the agent is running successfully, but we've already verified that works, and setting this flag shouldn't impact that.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->