### PR TITLE
Add base image usages to list view

### DIFF
--- a/app/controllers/BaseImageController.scala
+++ b/app/controllers/BaseImageController.scala
@@ -18,7 +18,9 @@ class BaseImageController(
   import BaseImageController._
 
   def listBaseImages = AuthAction {
-    Ok(views.html.baseImages(BaseImages.list()))
+    val baseImages = BaseImages.list()
+    val usageMap = baseImages.map(base => (base, Recipes.findByBaseImage(base.id))).toMap
+    Ok(views.html.baseImages(usageMap))
   }
 
   def showBaseImage(id: BaseImageId) = AuthAction { implicit request =>

--- a/app/views/baseImages.scala.html
+++ b/app/views/baseImages.scala.html
@@ -1,4 +1,4 @@
-@(images: Iterable[BaseImage])
+@(imageUsages: Map[BaseImage, Iterable[Recipe]])
 @simpleLayout("AMIgo"){
 
   <h1>Base images</h1>
@@ -16,13 +16,15 @@
     <thead>
       <th>Name</th>
       <th>Description</th>
+      <th>Usages</th>
       <th>Status</th>
     </thead>
     <tbody>
-    @for(image <- images.toList.sortBy(_.id.value.toLowerCase)) {
+    @for((image, usages) <- imageUsages.toList.sortBy(_._1.id.value.toLowerCase)) {
       <tr>
         <td class="has-block-link"><a href="@routes.BaseImageController.showBaseImage(image.id)" class="block-link">@image.id</a></td>
         <td class="has-block-link"><a href="@routes.BaseImageController.showBaseImage(image.id)" class="block-link">@image.description</a></td>
+        <td class="has-block-link"><a href="@routes.BaseImageController.showBaseImage(image.id)" class="block-link">@usages.size</a></td>
         <td class="has-block-link"><a href="@routes.BaseImageController.showBaseImage(image.id)" class="block-link">@fragments.eolStatus(image)</a></td>
       </tr>
     }


### PR DESCRIPTION
## What does this change?
Adds the number of usages in recipes of a base image. This is useful to quickly see unused and less-used base images.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Deployed to CODE

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images
![image](https://user-images.githubusercontent.com/8754692/148257995-9189f83c-fa8d-460f-989f-d89f6d9e0506.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
