### PR TITLE
Add corretto 17 role

### DIFF
--- a/roles/java11corretto/README.md
+++ b/roles/java11corretto/README.md
@@ -3,4 +3,4 @@ Java 11 Corretto
 
 This is the AWS flavour of the JVM for which support is provided via AWS enterprise agreements.
 
-This role installs the JDK and also modifies the default DNS cache control to cache for 30s instead of forever.
+This role installs the JDK and also modifies the default DNS cache control to cache for 60s instead of forever.

--- a/roles/java17corretto/README.md
+++ b/roles/java17corretto/README.md
@@ -1,0 +1,6 @@
+Java 17 Corretto
+================
+
+This is the AWS flavour of the JVM for which support is provided via AWS enterprise agreements.
+
+This role installs the JDK and also modifies the default DNS cache control to cache for 60s instead of forever.

--- a/roles/java17corretto/meta/main.yml
+++ b/roles/java17corretto/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - role: apt
+    when: ansible_os_family == "Debian"

--- a/roles/java17corretto/spec/java17corretto_spec.rb
+++ b/roles/java17corretto/spec/java17corretto_spec.rb
@@ -1,0 +1,4 @@
+
+describe command('java -version') do
+  its(:stdout) { should match /java version "17\..*/ }
+end

--- a/roles/java17corretto/tasks/main.yml
+++ b/roles/java17corretto/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Add AWS Corretto signing key
+  apt_key:
+    url: "https://apt.corretto.aws/corretto.key"
+    state: present
+
+- name: Add AWS Corretto repo
+  apt_repository:
+    repo: 'deb https://apt.corretto.aws stable main'
+    state: present
+
+- name: Install Java 17 Corretto JDK
+  apt:
+    name:
+    - java-17-amazon-corretto-jdk
+    state: latest
+  when: ansible_os_family == "Debian"
+
+## This modifies the JVM's DNS cache TTL, changing it from the default of INFINITY to 60
+## seconds. See this issue for full details: https://github.com/guardian/amigo/issues/238
+- name: Change JVM DNS cache TTL
+  replace:
+    path: /usr/lib/jvm/java-17-amazon-corretto/conf/security/java.security
+    regexp: '#networkaddress.cache.ttl=.*'
+    replace: 'networkaddress.cache.ttl=60'
+    backup: yes
+  when: ansible_os_family == "Debian"
+


### PR DESCRIPTION
## What does this change?

Adds Corretto's Java 17. See also https://github.com/guardian/amigo/pull/678.

We should probably go further than this and actually express a clear preference over which Java distro to use. But that is beyond the scope of this PR.

cc @philmcmahon .

## How to test

Tested locally.

![Screenshot 2022-01-06 at 16 49 10](https://user-images.githubusercontent.com/858402/148419625-40663edc-3693-4f10-9ccb-8411173db140.png)
