### PR TITLE
Use latest version of quartz

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-iteratees-reactive-streams" % "2.6.1",
   "com.gu" %% "play-googleauth" % "0.7.6",
   "com.adrianhurt" %% "play-bootstrap" % "1.6.1-P26-B3",
-  "org.quartz-scheduler" % "quartz" % "2.2.3",
+  "org.quartz-scheduler" % "quartz" % "2.3.2",
   "com.lihaoyi" %% "fastparse" % "0.4.1",
   "com.amazonaws" % "aws-java-sdk-sns" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,


### PR DESCRIPTION
## What does this change?

Upgrades `quartz` to avoid a vulnerability and bring things up to date.

## How to test

I've deployed this to `CODE` and confirmed that a scheduled bake is still triggered by inspecting the [logging](https://logs.gutools.co.uk/s/devx/goto/1fbe1850-7de4-11ec-b6e1-55bd2b673f28). Scheduled bakes [don't actually run](https://github.com/guardian/amigo/blob/61f44c2f6f6ba6e67310f8982c299e533edbc3f5/app/components/AppComponents.scala#L228-L232)  in `CODE`!

## How can we measure success?

We should have fewer vulnerabilities in Snyk as a result of this PR.

## Have we considered potential risks?

I don't think this PR is especially risky given the testing performed.


