### PR TITLE
Remove dependency on akka-agent

### DIFF
--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -40,7 +40,7 @@ import play.filters.HttpFiltersComponents
 import prism.Prism
 import router.Routes
 import schedule.{ BakeScheduler, ScheduledBakeRunner }
-import services.{ AmiMetadataLookup, ElkLogging, Loggable, PrismAgents }
+import services.{ AmiMetadataLookup, ElkLogging, Loggable, PrismData }
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -146,7 +146,7 @@ class AppComponents(context: Context)
   val amiMetadataLookup: AmiMetadataLookup = new AmiMetadataLookup(ec2Client)
 
   val prism = new Prism(wsClient)
-  val prismAgents = new PrismAgents(prism, applicationLifecycle, actorSystem.scheduler, environment)
+  val prismAgents = new PrismData(prism, applicationLifecycle, actorSystem.scheduler, environment)
 
   // do this synchronously at startup so we can set permissions
   val accountNumbers: Seq[String] = Await.result(prism.findAllAWSAccounts(), 30 seconds).map(_.accountNumber)

--- a/app/controllers/BakeController.scala
+++ b/app/controllers/BakeController.scala
@@ -11,8 +11,8 @@ import models._
 import play.api.i18n.I18nSupport
 import play.api.libs.EventSource
 import play.api.mvc._
-import services.{ AmiMetadataLookup, Loggable, PrismAgents }
-import services.{ Loggable, PrismAgents }
+import services.{ AmiMetadataLookup, Loggable, PrismData }
+import services.{ Loggable, PrismData }
 import play.api.libs.json._
 import prism.{ RecipeUsage, SimpleBakeUsage }
 
@@ -20,7 +20,7 @@ class BakeController(
   val authAction: AuthAction[AnyContent],
   stage: String,
   eventsSource: Source[BakeEvent, _],
-  prism: PrismAgents,
+  prism: PrismData,
   components: ControllerComponents,
   ansibleVars: Map[String, String],
   debugAvailable: Boolean,

--- a/app/controllers/BaseImageController.scala
+++ b/app/controllers/BaseImageController.scala
@@ -9,11 +9,11 @@ import play.api.data.Forms._
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import prism.RecipeUsage
-import services.PrismAgents
+import services.PrismData
 
 class BaseImageController(
     val authAction: AuthAction[AnyContent],
-    prismAgents: PrismAgents,
+    prismAgents: PrismData,
     components: ControllerComponents)(implicit dynamo: Dynamo) extends AbstractController(components) with I18nSupport {
   import BaseImageController._
 

--- a/app/controllers/RecipeController.scala
+++ b/app/controllers/RecipeController.scala
@@ -10,14 +10,14 @@ import play.api.i18n.I18nSupport
 import play.api.mvc._
 import prism.RecipeUsage
 import schedule.BakeScheduler
-import services.PrismAgents
+import services.PrismData
 
 import scala.util.Try
 
 class RecipeController(
     val authAction: AuthAction[AnyContent],
     bakeScheduler: BakeScheduler,
-    prismAgents: PrismAgents,
+    prismAgents: PrismData,
     components: ControllerComponents,
     debugAvailable: Boolean)(implicit dynamo: Dynamo) extends AbstractController(components) with I18nSupport {
   import RecipeController._

--- a/app/event/Behaviours.scala
+++ b/app/event/Behaviours.scala
@@ -33,9 +33,9 @@ object Behaviours extends Loggable {
   }
 
   /**
-    * Ensures that child actors are restarted after encountering an exception
-    * For more details, see: https://doc.akka.io/docs/akka/2.5/typed/fault-tolerance.html
-    */
+   * Ensures that child actors are restarted after encountering an exception
+   * For more details, see: https://doc.akka.io/docs/akka/2.5/typed/fault-tolerance.html
+   */
   def automaticallyRestart(behavior: Behavior[BakeEvent]): Behavior[BakeEvent] = Behaviors.supervise(behavior).onFailure(SupervisorStrategy.restart)
 
   /**

--- a/app/housekeeping/BakeDeletion.scala
+++ b/app/housekeeping/BakeDeletion.scala
@@ -5,19 +5,19 @@ import models.BakeId
 import notification.NotificationSender
 import org.quartz.SimpleScheduleBuilder
 import prism.RecipeUsage
-import services.{ Loggable, PrismAgents }
+import services.{ Loggable, PrismData }
 
 /*
   This class deletes bakes that have been marked deleted
  */
 class BakeDeletion(dynamo: Dynamo,
     amigoAwsAccount: String,
-    prismAgents: PrismAgents,
+    prismAgents: PrismData,
     notificationSender: NotificationSender,
     frequencyMinutes: Int) extends HousekeepingJob with Loggable {
 
   implicit private val implDynamo: Dynamo = dynamo
-  implicit private val implPrismAgents: PrismAgents = prismAgents
+  implicit private val implPrismAgents: PrismData = prismAgents
 
   override val schedule = SimpleScheduleBuilder.repeatMinutelyForever(frequencyMinutes)
 

--- a/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
+++ b/app/housekeeping/MarkOldUnusedBakesForDeletion.scala
@@ -5,7 +5,7 @@ import models.{ Bake, RecipeId }
 import org.joda.time.{ DateTime, Duration }
 import org.quartz.SimpleScheduleBuilder
 import prism.RecipeUsage
-import services.{ Loggable, PrismAgents }
+import services.{ Loggable, PrismData }
 
 object MarkOldUnusedBakesForDeletion {
   val MAX_AGE = 30
@@ -30,11 +30,11 @@ object MarkOldUnusedBakesForDeletion {
   }
 }
 
-class MarkOldUnusedBakesForDeletion(prismAgents: PrismAgents, dynamo: Dynamo) extends HousekeepingJob with Loggable {
+class MarkOldUnusedBakesForDeletion(prismAgents: PrismData, dynamo: Dynamo) extends HousekeepingJob with Loggable {
   override val schedule = SimpleScheduleBuilder.repeatHourlyForever(1)
 
   override def housekeep(): Unit = {
-    implicit val implicitPrismAgents: PrismAgents = prismAgents
+    implicit val implicitPrismAgents: PrismData = prismAgents
     implicit val implicitDynamo: Dynamo = dynamo
     log.info(s"Started marking old, unused bakes for deletion")
     val now = new DateTime()

--- a/app/housekeeping/MarkOrphanedBakesForDeletion.scala
+++ b/app/housekeeping/MarkOrphanedBakesForDeletion.scala
@@ -3,7 +3,7 @@ package housekeeping
 import data.{ Bakes, Dynamo, Recipes }
 import models.{ Bake, BakeId, RecipeId }
 import org.quartz.SimpleScheduleBuilder
-import services.{ Loggable, PrismAgents }
+import services.{ Loggable, PrismData }
 
 /*
 If a recipe has been deleted from a table but not the associated bake, then these
@@ -19,11 +19,11 @@ object MarkOrphanedBakesForDeletion {
   }
 }
 
-class MarkOrphanedBakesForDeletion(prismAgents: PrismAgents, dynamo: Dynamo) extends HousekeepingJob with Loggable {
+class MarkOrphanedBakesForDeletion(prismAgents: PrismData, dynamo: Dynamo) extends HousekeepingJob with Loggable {
   override val schedule = SimpleScheduleBuilder.repeatHourlyForever(24)
 
   override def housekeep(): Unit = {
-    implicit val implicitPrismAgents: PrismAgents = prismAgents
+    implicit val implicitPrismAgents: PrismData = prismAgents
     implicit val implicitDynamo: Dynamo = dynamo
     val (errors, recipes) = Recipes.recipesWithErrors
     errors match {

--- a/app/packer/PackerRunner.scala
+++ b/app/packer/PackerRunner.scala
@@ -5,7 +5,7 @@ import event.EventBus
 import models.Bake
 import models.packer.PackerVariablesConfig
 import play.api.libs.json.Json
-import services.{ AmiMetadataLookup, Loggable, PrismAgents }
+import services.{ AmiMetadataLookup, Loggable, PrismData }
 
 import java.io.File
 import java.nio.charset.StandardCharsets
@@ -24,7 +24,7 @@ class PackerRunner(maxInstances: Int) extends Loggable {
    *
    * @return a Future of the process's exit value
    */
-  def createImage(stage: String, bake: Bake, prism: PrismAgents, eventBus: EventBus, ansibleVars: Map[String, String], debug: Boolean, amiMetadataLookup: AmiMetadataLookup, amigoDataBucket: Option[String])(implicit packerConfig: PackerConfig): Future[Int] = {
+  def createImage(stage: String, bake: Bake, prism: PrismData, eventBus: EventBus, ansibleVars: Map[String, String], debug: Boolean, amiMetadataLookup: AmiMetadataLookup, amigoDataBucket: Option[String])(implicit packerConfig: PackerConfig): Future[Int] = {
     val sourceAmi = bake.recipe.baseImage.amiId.value
     val amiMetadata = amiMetadataLookup.lookupMetadataFor(sourceAmi).right.getOrElse(throw new IllegalStateException(s"Unable to identify the architecture for $sourceAmi"))
 

--- a/app/schedule/ScheduledBakeRunner.scala
+++ b/app/schedule/ScheduledBakeRunner.scala
@@ -4,9 +4,9 @@ import data.{ Bakes, Dynamo, Recipes }
 import event.EventBus
 import models.RecipeId
 import packer.{ PackerConfig, PackerRunner }
-import services.{ AmiMetadataLookup, Loggable, PrismAgents }
+import services.{ AmiMetadataLookup, Loggable, PrismData }
 
-class ScheduledBakeRunner(stage: String, enabled: Boolean, prism: PrismAgents, eventBus: EventBus,
+class ScheduledBakeRunner(stage: String, enabled: Boolean, prism: PrismData, eventBus: EventBus,
     ansibleVars: Map[String, String], amiMetadataLookup: AmiMetadataLookup, amigoDataBucket: Option[String],
     packerRunner: PackerRunner)(implicit dynamo: Dynamo, packerConfig: PackerConfig) extends Loggable {
 

--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,6 @@ libraryDependencies ++= Seq(
   "com.github.cb372" %% "automagic" % "0.1",
   "com.beachape" %% "enumeratum" % "1.3.7",
   "com.typesafe.akka" %% "akka-actor-typed" % "2.5.21",
-  "com.typesafe.akka" %% "akka-agent" % "2.4.2",
   "com.gu" %% "configuration-magic-play2-4" % "1.3.0",
   "com.typesafe.play" %% "play-iteratees" % "2.6.1",
   "com.typesafe.play" %% "play-iteratees-reactive-streams" % "2.6.1",

--- a/test/prism/RecipeUsageSpec.scala
+++ b/test/prism/RecipeUsageSpec.scala
@@ -7,7 +7,7 @@ import org.mockito.Mockito._
 import org.scalatest.{ FlatSpec, Matchers }
 import org.scalatest.mock.MockitoSugar
 import prism.Prism.{ AWSAccount, Image, Instance, LaunchConfiguration }
-import services.PrismAgents
+import services.PrismData
 
 class RecipeUsageSpec extends FlatSpec with Matchers with MockitoSugar {
 
@@ -54,7 +54,7 @@ class RecipeUsageSpec extends FlatSpec with Matchers with MockitoSugar {
     val lc1 = LaunchConfiguration("lc-1", amiId1, account)
     val lc2 = LaunchConfiguration("lc-2", amiId3, account)
 
-    val mockPrismAgents = mock[PrismAgents]
+    val mockPrismAgents = mock[PrismData]
     when(mockPrismAgents.allInstances) thenReturn Seq(instance1, instance2, instance5)
     when(mockPrismAgents.allLaunchConfigurations) thenReturn Seq(lc1, lc2)
     when(mockPrismAgents.copiedImages(any())) thenReturn Map[AmiId, Seq[Image]]()


### PR DESCRIPTION
## What does this change?

Akka Agents are [deprecated in Akka 2.5.x](https://doc.akka.io/docs/akka/2.5.32/agents.html) (which this repo currently uses) and have been [removed](https://doc.akka.io/docs/akka/current/project/migration-guide-2.5.x-2.6.x.html#removed-features-that-were-deprecated) completely in 2.6.x. Consequently, this PR removes the `akka-agent` dependency and uses `AtomicReference` instead, following the guidance (and code!) from https://github.com/guardian/box, which was the Guardian's initial replacement for Akka Agents.

There's a bit of noise in this PR due to renaming. The important change is [here](https://github.com/guardian/amigo/pull/686/files#diff-90b9ecce377f41a739fe88b5a599f38211626430fa009780e5f8ce01a138fe0f).

## How to test

I've tested this by:

1. Deploying to `CODE`
2. Launching an EC2 instance from an AMI which was baked by AMIgo `CODE` 
3. Confirming that the 'usages' functionality still works as expected

## How can we measure success?

* It'll be easier to upgrade Akka modules to 2.6.x
* We're using less deprecated things

## Have we considered potential risks?

I don't think this PR is especially risky given the testing performed.