### PR TITLE
Remove automagic dependency

### DIFF
--- a/app/models/Bake.scala
+++ b/app/models/Bake.scala
@@ -29,13 +29,25 @@ object Bake {
     val bakeId = BakeId(recipeId, buildNumber)
   }
 
-  import automagic._
+  def domain2db(bake: Bake): DbModel = DbModel(
+    recipeId = bake.recipe.id,
+    buildNumber = bake.buildNumber,
+    status = bake.status,
+    amiId = bake.amiId,
+    startedBy = bake.startedBy,
+    startedAt = bake.startedAt,
+    deleted = Some(bake.deleted)
+  )
 
-  def domain2db(bake: Bake): DbModel =
-    transform[Bake, Bake.DbModel](bake, "recipeId" -> bake.recipe.id, "deleted" -> Some(bake.deleted))
-
-  def db2domain(dbModel: DbModel, recipe: Recipe): Bake =
-    transform[Bake.DbModel, Bake](dbModel, "recipe" -> recipe, "deleted" -> dbModel.deleted.getOrElse(false))
+  def db2domain(dbModel: DbModel, recipe: Recipe): Bake = Bake(
+    recipe = recipe,
+    buildNumber = dbModel.buildNumber,
+    status = dbModel.status,
+    amiId = dbModel.amiId,
+    startedBy = dbModel.startedBy,
+    startedAt = dbModel.startedAt,
+    deleted = dbModel.deleted.getOrElse(false)
+  )
 
   def updateStatusAndNotifyFailure(bakeId: BakeId, status: BakeStatus, notificationConfig: Option[NotificationConfig])(implicit dynamo: Dynamo, exec: ExecutionContext): Unit = {
     if (status == BakeStatus.Failed || status == BakeStatus.TimedOut) {

--- a/app/models/Recipe.scala
+++ b/app/models/Recipe.scala
@@ -31,10 +31,33 @@ object Recipe {
     bakeSchedule: Option[BakeSchedule],
     encryptFor: Option[List[AccountNumber]])
 
-  import automagic._
+  def db2domain(dbModel: DbModel, baseImage: BaseImage): Recipe = Recipe(
+    id = dbModel.id,
+    description = dbModel.description,
+    baseImage = baseImage,
+    diskSize = dbModel.diskSize,
+    roles = dbModel.roles,
+    createdBy = dbModel.createdBy,
+    createdAt = dbModel.createdAt,
+    modifiedBy = dbModel.modifiedBy,
+    modifiedAt = dbModel.modifiedAt,
+    bakeSchedule = dbModel.bakeSchedule,
+    encryptFor = dbModel.encryptFor.getOrElse(Nil)
+  )
 
-  def db2domain(dbModel: DbModel, baseImage: BaseImage): Recipe = transform[DbModel, Recipe](dbModel, "baseImage" -> baseImage, "encryptFor" -> dbModel.encryptFor.getOrElse(Nil))
-
-  def domain2db(recipe: Recipe, nextBuildNumber: Int): DbModel = transform[Recipe, DbModel](recipe, "baseImageId" -> recipe.baseImage.id, "nextBuildNumber" -> nextBuildNumber, "encryptFor" -> Some(recipe.encryptFor))
+  def domain2db(recipe: Recipe, nextBuildNumber: Int): DbModel = DbModel(
+    id = recipe.id,
+    description = recipe.description,
+    baseImageId = recipe.baseImage.id,
+    diskSize = recipe.diskSize,
+    roles = recipe.roles,
+    nextBuildNumber = nextBuildNumber,
+    createdBy = recipe.createdBy,
+    createdAt = recipe.createdAt,
+    modifiedBy = recipe.modifiedBy,
+    modifiedAt = recipe.modifiedAt,
+    bakeSchedule = recipe.bakeSchedule,
+    encryptFor = Some(recipe.encryptFor)
+  )
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,6 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.gu" %% "scanamo" % "1.0.0-M4",
-  "com.github.cb372" %% "automagic" % "0.1",
   "com.beachape" %% "enumeratum" % "1.3.7",
   "com.typesafe.akka" %% "akka-actor-typed" % "2.5.21",
   "com.typesafe.akka" %% "akka-agent" % "2.4.2",


### PR DESCRIPTION
## What does this change?

This repository was using https://github.com/cb372/automagic to reduce boilerplate when converting between models. This was pretty neat, but it's no longer maintained (and is not published for more recent Scala versions), so I've removed the dependency at the expense of some boilerplate.

## How to test

I've deployed this to `CODE` and tested some basic functionality (creating a recipe, modifying a recipe, viewing recipes, viewing bakes, starting a new bake).

## How can we measure success?

It will be easier to upgrade to a more recent Scala version without this dependency.

## Have we considered potential risks?

I don't think this PR is especially risky given the testing performed.
