### PR TITLE
Update test dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,8 +95,9 @@ libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "autoscaling" % awsV2SdkVersion,
   "net.logstash.logback" % "logstash-logback-encoder" % "5.1",
   "com.gu" % "kinesis-logback-appender" % "1.4.2",
-  "org.scalatest" %% "scalatest" % "2.2.6" % Test,
-  "org.mockito" % "mockito-core" % "2.7.19" % Test,
+  "org.scalatest" %% "scalatest-flatspec" % "3.2.11" % Test,
+  "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.11" % Test,
+  "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test,
   "fun.mike" % "diff-match-patch" % "0.0.2",
   "com.gu" % "anghammarad-client_2.11" % "1.1.3"
 )

--- a/test/ansible/PlaybookGeneratorSpec.scala
+++ b/test/ansible/PlaybookGeneratorSpec.scala
@@ -2,9 +2,10 @@ package ansible
 
 import models._
 import org.joda.time.DateTime
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PlaybookGeneratorSpec extends FlatSpec with Matchers {
+class PlaybookGeneratorSpec extends AnyFlatSpec with Matchers {
 
   it should "generate an Ansible playbook containing the base image's builtin roles and the recipe's roles" in {
     val recipe = Recipe(

--- a/test/ansible/RoleParserSpec.scala
+++ b/test/ansible/RoleParserSpec.scala
@@ -1,9 +1,10 @@
 package ansible
 
 import models.{ RoleId, Yaml }
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class RoleParserSpec extends FlatSpec with Matchers {
+class RoleParserSpec extends AnyFlatSpec with Matchers {
 
   it should "extract dependencies" in {
     val yaml = Yaml(

--- a/test/data/PackageListTest.scala
+++ b/test/data/PackageListTest.scala
@@ -1,9 +1,10 @@
 package data
 
 import models.{ BakeId, RecipeId }
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PackageListTest extends FlatSpec with Matchers {
+class PackageListTest extends AnyFlatSpec with Matchers {
 
   "s3Url" should "return valid S3 url of expected pattern" in {
     val url = PackageList.s3Url(BakeId(RecipeId("cauldron-cake"), 1), "mr-hole")

--- a/test/data/RolesTest.scala
+++ b/test/data/RolesTest.scala
@@ -3,9 +3,10 @@ package data
 import models.Dependency
 import models._
 import org.joda.time.DateTime
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class RolesTest extends FlatSpec with Matchers {
+class RolesTest extends AnyFlatSpec with Matchers {
 
   it should "find all transitive dependencies" in {
     val r0 = RoleSummary(RoleId("id0"), Set(RoleId("id1"), RoleId("id2")), null, null)

--- a/test/housekeeping/DeleteLongRunningEC2InstancesSpec.scala
+++ b/test/housekeeping/DeleteLongRunningEC2InstancesSpec.scala
@@ -6,12 +6,14 @@ import models.{ BakeId, RecipeId }
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
-import org.scalatest.{ FlatSpec, Matchers, OptionValues }
+import org.scalatest.OptionValues
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.JavaConversions._
 
-class DeleteLongRunningEC2InstancesSpec extends FlatSpec with Matchers with MockitoSugar with OptionValues {
+class DeleteLongRunningEC2InstancesSpec extends AnyFlatSpec with Matchers with MockitoSugar with OptionValues {
 
   trait Mocks {
     val bakesRepo: BakesRepo = mock[BakesRepo]

--- a/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
+++ b/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
@@ -2,10 +2,11 @@ package housekeeping
 
 import models._
 import org.joda.time.{ DateTime, DateTimeZone }
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import prism.{ BakeUsage, RecipeUsage }
 
-class MarkOldUnusedBakesForDeletionSpec extends FlatSpec with Matchers {
+class MarkOldUnusedBakesForDeletionSpec extends AnyFlatSpec with Matchers {
   val oldDate = new DateTime(2018, 5, 28, 0, 0, 0, DateTimeZone.UTC)
   val newDate = new DateTime(2018, 6, 20, 0, 0, 0, DateTimeZone.UTC)
   val oldBake1: Bake = fixtureBake(fixtureRecipe("recipe-1", oldDate), Some(AmiId("ami-1")), oldDate)

--- a/test/housekeeping/MarkOrphanedBakesForDeletionSpec.scala
+++ b/test/housekeeping/MarkOrphanedBakesForDeletionSpec.scala
@@ -2,9 +2,10 @@ package housekeeping
 
 import models._
 import org.joda.time.{ DateTime, DateTimeZone }
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class MarkOrphanedBakesForDeletionSpec extends FlatSpec with Matchers {
+class MarkOrphanedBakesForDeletionSpec extends AnyFlatSpec with Matchers {
   val date = new DateTime(2018, 5, 28, 0, 0, 0, DateTimeZone.UTC)
 
   def fixtureBakeDbModel(recipeId: String, amiId: Option[AmiId]): Bake.DbModel = {

--- a/test/housekeeping/TimeOutLongRunningBakesSpec.scala
+++ b/test/housekeeping/TimeOutLongRunningBakesSpec.scala
@@ -6,10 +6,11 @@ import models.{ Bake, BakeId, BakeStatus, RecipeId }
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
-class TimeOutLongRunningBakesSpec extends FlatSpec with Matchers with MockitoSugar {
+class TimeOutLongRunningBakesSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
   trait Mocks {
     val bakesRepo: BakesRepo = mock[BakesRepo]

--- a/test/models/BakeIdTest.scala
+++ b/test/models/BakeIdTest.scala
@@ -1,7 +1,8 @@
 package models
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class BakeIdTest extends FlatSpec with Matchers {
+class BakeIdTest extends AnyFlatSpec with Matchers {
 
   "toFilename" should "produce expected filename" in {
     val bakeId = BakeId(RecipeId("puking-pastilles"), 1)

--- a/test/models/BaseImageTest.scala
+++ b/test/models/BaseImageTest.scala
@@ -1,9 +1,10 @@
 package models
 
 import org.joda.time.DateTime
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class BaseImageTest extends FlatSpec with Matchers {
+class BaseImageTest extends AnyFlatSpec with Matchers {
 
   def makeBaseImage(eolDate: DateTime): BaseImage =
     BaseImage(

--- a/test/models/CustomisedRoleTest.scala
+++ b/test/models/CustomisedRoleTest.scala
@@ -1,29 +1,31 @@
 package models
 
-import org.scalatest.{ EitherValues, FunSuite, ShouldMatchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import cats.syntax.either._
+import org.scalatest.EitherValues
 
-class CustomisedRoleTest extends FunSuite with ShouldMatchers with EitherValues {
+class CustomisedRoleTest extends AnyFlatSpec with Matchers with EitherValues {
 
-  test("should parse a map of variables") {
-    CustomisedRole.formInputTextToVariables("ssh_keys_bucket: bucket, ssh_keys_prefix: Team").right.value
+  "CustomisedRole.formInputTextToVariables" should "parse a map of variables" in {
+    CustomisedRole.formInputTextToVariables("ssh_keys_bucket: bucket, ssh_keys_prefix: Team").value
       .shouldBe(Map("ssh_keys_bucket" -> SingleParamValue("bucket"), "ssh_keys_prefix" -> SingleParamValue("Team")))
   }
 
-  test("should parse variable lists") {
-    CustomisedRole.formInputTextToVariables("packages: [python-pip, emacs24]").right.value
+  "CustomisedRole.formInputTextToVariables" should "parse variable lists" in {
+    CustomisedRole.formInputTextToVariables("packages: [python-pip, emacs24]").value
       .shouldBe(Map("packages" -> ListParamValue.of("python-pip", "emacs24")))
   }
 
-  test("should round trip param values") {
+  "ParamValue.format" should "round trip param values" in {
     def roundTrip(pv: ParamValue) = ParamValue.format.read(ParamValue.format.write(pv)).toOption.get
     roundTrip(SingleParamValue("X")) shouldBe SingleParamValue("X")
     roundTrip(DictParamValue(Map("elasticsearch" -> SingleParamValue("http://host.domain:port/flying/monkeys")))) shouldBe DictParamValue(Map("elasticsearch" -> SingleParamValue("http://host.domain:port/flying/monkeys")))
   }
 
-  test("should parse variable dicts") {
-    val value = CustomisedRole.formInputTextToVariables("repositories: {elasticsearch: 'http://host.domain:port/flying/monkeys'}")
-    value.right.value
+  "CustomisedRole.formInputTextToVariables" should "parse variable dicts" in {
+    val result = CustomisedRole.formInputTextToVariables("repositories: {elasticsearch: 'http://host.domain:port/flying/monkeys'}")
+    result.value
       .shouldBe(Map("repositories" -> DictParamValue(Map("elasticsearch" -> SingleParamValue("http://host.domain:port/flying/monkeys")))))
   }
 }

--- a/test/notification/LambdaDistributionBucketSpec.scala
+++ b/test/notification/LambdaDistributionBucketSpec.scala
@@ -1,8 +1,9 @@
 package notification
 
-import org.scalatest.{ FlatSpec, ShouldMatchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class LambdaDistributionBucketSpec extends FlatSpec with ShouldMatchers {
+class LambdaDistributionBucketSpec extends AnyFlatSpec with Matchers {
   import LambdaDistributionBucket._
   "updateCopierStatement" should "replace the previous statement" in {
     val copierStatement = createCopierStatement("bucket", "TEST", List("234"))

--- a/test/notification/SNSSpec.scala
+++ b/test/notification/SNSSpec.scala
@@ -1,8 +1,9 @@
 package notification
 
-import org.scalatest.{ FlatSpec, ShouldMatchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class SNSSpec extends FlatSpec with ShouldMatchers {
+class SNSSpec extends AnyFlatSpec with Matchers {
   "listAwsResource" should "return just the first set if there is no next token" in {
     val results = SNS.listAwsResource {
       case None => List(1, 2, 3, 4) -> None

--- a/test/packer/PackerOutputParserSpec.scala
+++ b/test/packer/PackerOutputParserSpec.scala
@@ -1,9 +1,10 @@
 package packer
 
-import org.scalatest._
-import models.{ MessagePart, AmiId }
+import models.{ AmiId, MessagePart }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PackerOutputParserSpec extends FlatSpec with Matchers {
+class PackerOutputParserSpec extends AnyFlatSpec with Matchers {
 
   it should "parse a line of Packer output" in {
     PackerOutputParser.parseLine("1455354962,,ui,say,ubuntu-wily-java8 output will be in this color.") should be(

--- a/test/prism/PrismSpec.scala
+++ b/test/prism/PrismSpec.scala
@@ -1,7 +1,8 @@
 package prism
 
 import models.AmiId
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.{ Configuration, Environment }
 import play.api.http.DefaultFileMimeTypesProvider
 import play.api.http.HttpConfiguration.HttpConfigurationProvider
@@ -16,7 +17,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class PrismSpec extends FlatSpec with Matchers {
+class PrismSpec extends AnyFlatSpec with Matchers {
 
   val environment = Environment.simple()
   val httpConfiguration = new HttpConfigurationProvider(Configuration.load(environment), environment).get

--- a/test/prism/RecipeUsageSpec.scala
+++ b/test/prism/RecipeUsageSpec.scala
@@ -4,12 +4,13 @@ import models._
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.{ FlatSpec, Matchers }
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import prism.Prism.{ AWSAccount, Image, Instance, LaunchConfiguration }
 import services.PrismData
 
-class RecipeUsageSpec extends FlatSpec with Matchers with MockitoSugar {
+class RecipeUsageSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
   def fixtureBaseImage(baseImageId: String): BaseImage = BaseImage(BaseImageId(baseImageId), "MyDescription", AmiId("ami-1"), List(), "Test", DateTime.now, "Test", DateTime.now)
   def fixtureRecipe(id: String): Recipe = Recipe(RecipeId(id), None, fixtureBaseImage(s"base-image-$id"), None, List(), "Test", DateTime.now, "Test", DateTime.now, None, Nil)


### PR DESCRIPTION
## What does this change?

This PR updates all test dependencies to ensure that we are using versions which are compatible with the most recent versions of Scala (we are hoping to upgrade soon).

There have been a couple of significant changes since these dependencies were last updated which makes this diff a little noisy (hence the separate PR):

* The library [has been modularised](https://www.scalatest.org/release_notes/3.1.0), which means that we can improve standardisation within the project by only including the [test styles](https://www.scalatest.org/user_guide/selecting_a_style) that we need.
* The library/approach for using ScalaTest with Mockito seems to have changed - I've followed the approach described [here](https://www.scalatest.org/plus/mockito).

## How to test

CI should be sufficient for this PR.