### PR TITLE
Upgrade to Scala 2.12

### DIFF
--- a/app/controllers/BakeController.scala
+++ b/app/controllers/BakeController.scala
@@ -51,7 +51,7 @@ class BakeController(
     Bakes.findById(recipeId, buildNumber).fold[Result](NotFound) { bake: Bake =>
       val bakeLogs = BakeLogs.list(BakeId(recipeId, buildNumber))
       val packageList = PackageList.getPackageList(s3Client, BakeId(recipeId, buildNumber), amigoDataBucket)
-      val packageListDiff = packageList.right.flatMap(p => PackageList.getPackageListDiff(s3Client, p, previousBakeId, amigoDataBucket))
+      val packageListDiff = packageList.flatMap(p => PackageList.getPackageListDiff(s3Client, p, previousBakeId, amigoDataBucket))
 
       val recipeUsage: RecipeUsage = RecipeUsage(Seq(bake))(prism)
       val recentCopies = prism.copiedImages(Set(bake.amiId).flatten)

--- a/app/controllers/ControllerHelpers.scala
+++ b/app/controllers/ControllerHelpers.scala
@@ -12,7 +12,7 @@ object ControllerHelpers {
     val rolesOrErrors = enabledRoles.map { roleName =>
       val variablesString = form.get(s"role-$roleName-variables").flatMap(_.headOption).getOrElse("")
       val variables = CustomisedRole.formInputTextToVariables(variablesString)
-      variables.right.map(CustomisedRole(RoleId(roleName), _))
+      variables.map(CustomisedRole(RoleId(roleName), _))
     }
     val roles = rolesOrErrors.collect { case Right(role) => role }
     val errors = rolesOrErrors.collect { case Left(error) => error }

--- a/app/data/BakeLogs.scala
+++ b/app/data/BakeLogs.scala
@@ -10,7 +10,6 @@ import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 
 object BakeLogs extends Loggable {
-  import cats.syntax.either._
   import Dynamo._
 
   private val BATCH_SIZE = 25

--- a/app/data/Bakes.scala
+++ b/app/data/Bakes.scala
@@ -6,7 +6,6 @@ import org.joda.time.DateTime
 
 object Bakes {
   import Dynamo._
-  import cats.syntax.either._
 
   def create(recipe: Recipe, buildNumber: Int, startedBy: String)(implicit dynamo: Dynamo): Bake = {
     val bake = Bake(recipe, buildNumber, status = BakeStatus.Running, amiId = None, startedBy = startedBy, startedAt = DateTime.now(), deleted = false)

--- a/app/data/BaseImages.scala
+++ b/app/data/BaseImages.scala
@@ -3,7 +3,6 @@ package data
 import com.gu.scanamo.syntax._
 import models._
 import org.joda.time.DateTime
-import cats.syntax.either._
 import com.amazonaws.services.dynamodbv2.model.DeleteItemResult
 import data.Recipes.table
 

--- a/app/data/PackageList.scala
+++ b/app/data/PackageList.scala
@@ -60,7 +60,7 @@ object PackageList extends Loggable {
     previousBakeId.map { pid =>
       val oldPackageList = getPackageList(s3Client, pid, bucket)
       for {
-        oldList <- oldPackageList.right
+        oldList <- oldPackageList
       } yield diffPackageLists(newPackageList, oldList, pid)
     }
   }.getOrElse(Left("No previous bake to diff with"))

--- a/app/data/Recipes.scala
+++ b/app/data/Recipes.scala
@@ -80,7 +80,7 @@ object Recipes {
     }
 
     val update = table.update('id -> recipe.id, updateExpr)
-    update.exec().right.map(Recipe.db2domain(_, baseImage))
+    update.exec().map(Recipe.db2domain(_, baseImage))
   }
 
   def delete(recipe: Recipe)(implicit dynamo: Dynamo): DeleteItemResult = {

--- a/app/housekeeping/DeleteLongRunningEC2Instances.scala
+++ b/app/housekeeping/DeleteLongRunningEC2Instances.scala
@@ -1,6 +1,5 @@
 package housekeeping
 
-import cats.syntax.either._
 import com.amazonaws.services.ec2.model.Instance
 import housekeeping.utils.{BakesRepo, PackerEC2Client}
 import models.BakeId

--- a/app/housekeeping/DeleteLongRunningEC2Instances.scala
+++ b/app/housekeeping/DeleteLongRunningEC2Instances.scala
@@ -8,7 +8,7 @@ import org.joda.time.DateTime
 import org.quartz.{ScheduleBuilder, SimpleScheduleBuilder, Trigger}
 import services.Loggable
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 // TimeOutLongRunningBakes was failing to delete some long running EC2 instances.
 // The issue was that the bake corresponding to the long running EC2 instance would have status Failed.
@@ -63,7 +63,7 @@ object DeleteLongRunningEC2Instances {
 
   def getBakeIdFromInstance(instance: Instance): Option[BakeId] = {
     for {
-      raw <- instance.getTags.find(_.getKey == "BakeId")
+      raw <- instance.getTags.asScala.find(_.getKey == "BakeId")
       id <- BakeId.fromString(raw.getValue).toOption
     } yield id
   }

--- a/app/packer/PackerRunner.scala
+++ b/app/packer/PackerRunner.scala
@@ -26,7 +26,7 @@ class PackerRunner(maxInstances: Int) extends Loggable {
    */
   def createImage(stage: String, bake: Bake, prism: PrismData, eventBus: EventBus, ansibleVars: Map[String, String], debug: Boolean, amiMetadataLookup: AmiMetadataLookup, amigoDataBucket: Option[String])(implicit packerConfig: PackerConfig): Future[Int] = {
     val sourceAmi = bake.recipe.baseImage.amiId.value
-    val amiMetadata = amiMetadataLookup.lookupMetadataFor(sourceAmi).right.getOrElse(throw new IllegalStateException(s"Unable to identify the architecture for $sourceAmi"))
+    val amiMetadata = amiMetadataLookup.lookupMetadataFor(sourceAmi).getOrElse(throw new IllegalStateException(s"Unable to identify the architecture for $sourceAmi"))
 
     val playbookYaml = PlaybookGenerator.generatePlaybook(bake.recipe,
       ansibleVars ++ Map(

--- a/app/services/AmiMetadataLookup.scala
+++ b/app/services/AmiMetadataLookup.scala
@@ -1,10 +1,10 @@
-package services;
+package services
 
 import cats.syntax.either._
 import com.amazonaws.services.ec2.AmazonEC2
 import com.amazonaws.services.ec2.model.{ DescribeImagesRequest, Image }
 
-import scala.collection.JavaConverters._;
+import scala.collection.JavaConverters._
 
 case class AmiMetadata(architecture: String, debArchitecture: String)
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import java.time.{ZoneId, ZonedDateTime}
 
 name := "amigo"
 version := "1.0-latest"
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.0"
 
 javaOptions in Universal ++= Seq(
   s"-Dpidfile.path=/dev/null",
@@ -74,7 +74,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.gu" %% "scanamo" % "1.0.0-M4",
-  "com.beachape" %% "enumeratum" % "1.3.7",
+  "com.beachape" %% "enumeratum" % "1.6.1",
   "com.typesafe.akka" %% "akka-actor-typed" % "2.5.21",
   "com.gu" %% "simple-configuration-ssm" % "1.5.6",
   "com.typesafe.play" %% "play-iteratees" % "2.6.1",
@@ -82,7 +82,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "play-googleauth" % "0.7.6",
   "com.adrianhurt" %% "play-bootstrap" % "1.6.1-P26-B3",
   "org.quartz-scheduler" % "quartz" % "2.3.2",
-  "com.lihaoyi" %% "fastparse" % "0.4.1",
+  "com.lihaoyi" %% "fastparse" % "0.4.4",
   "com.amazonaws" % "aws-java-sdk-ec2" % awsV1SdkVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % awsV1SdkVersion,
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsV1SdkVersion,
@@ -99,7 +99,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.11" % Test,
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test,
   "fun.mike" % "diff-match-patch" % "0.0.2",
-  "com.gu" % "anghammarad-client_2.11" % "1.1.3"
+  "com.gu" %% "anghammarad-client" % "1.1.3"
 )
 routesGenerator := InjectedRoutesGenerator
 routesImport += "models._"

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.gu" %% "scanamo" % "1.0.0-M4",
   "com.beachape" %% "enumeratum" % "1.6.1",
-  "com.typesafe.akka" %% "akka-actor-typed" % "2.5.21",
+  "com.typesafe.akka" %% "akka-actor-typed" % "2.5.26",
   "com.gu" %% "simple-configuration-ssm" % "1.5.6",
   "com.typesafe.play" %% "play-iteratees" % "2.6.1",
   "com.typesafe.play" %% "play-iteratees-reactive-streams" % "2.6.1",

--- a/test/housekeeping/DeleteLongRunningEC2InstancesSpec.scala
+++ b/test/housekeeping/DeleteLongRunningEC2InstancesSpec.scala
@@ -11,7 +11,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class DeleteLongRunningEC2InstancesSpec extends AnyFlatSpec with Matchers with MockitoSugar with OptionValues {
 
@@ -23,7 +23,7 @@ class DeleteLongRunningEC2InstancesSpec extends AnyFlatSpec with Matchers with M
 
   "getBakeIdFromInstance" should "successfully parse a bake id from a tag" in {
     val instance = mock[Instance]
-    when(instance.getTags).thenReturn(List(new Tag("BakeId", "recipe #2")))
+    when(instance.getTags).thenReturn(List(new Tag("BakeId", "recipe #2")).asJava)
     DeleteLongRunningEC2Instances.getBakeIdFromInstance(instance).value shouldEqual BakeId(RecipeId("recipe"), 2)
   }
 

--- a/test/models/CustomisedRoleTest.scala
+++ b/test/models/CustomisedRoleTest.scala
@@ -2,7 +2,6 @@ package models
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import cats.syntax.either._
 import org.scalatest.EitherValues
 
 class CustomisedRoleTest extends AnyFlatSpec with Matchers with EitherValues {

--- a/test/prism/RecipeUsageSpec.scala
+++ b/test/prism/RecipeUsageSpec.scala
@@ -43,6 +43,7 @@ class RecipeUsageSpec extends AnyFlatSpec with Matchers with MockitoSugar {
         case recipe1.id => Seq(bakeR1A1, bakeR1A2)
         case recipe2.id => Seq(bakeR2A3, bakeR2F)
         case recipe3.id => Seq(bakeR3A4)
+        case _ => Seq() // Without this compilation fails due to non-exhaustive match
       }
     }
 


### PR DESCRIPTION
## What does this change?

This PR upgrades the project to use Scala 2.12. Key changes for this codebase include:

* [`Either` becomes right-biased](https://www.scala-lang.org/news/2.12.0/#either-is-now-right-biased), allowing us to remove some boilerplate (and some usages of `cats`)
* [`JavaConversions` is deprecated and replaced by `JavaConverters`](https://www.scala-lang.org/news/2.12.0/#other-changes-and-deprecations), which requires more explicit syntax for conversion between Java and Scala

Although this is not the latest Scala version*, it unblocks a couple of key upgrades:

* Play Framework version 2.8.x, which [drops 2.11 support](https://www.playframework.com/documentation/2.8.x/Migration28#Scala-2.11-support-discontinued)
* Recent versions of [`play-google-auth`](https://github.com/guardian/play-googleauth) (and its mandatory dependency [`play-secret-rotation`](https://github.com/guardian/play-secret-rotation)), which only supports 2.12 and above

Before we can move to Scala 2.13 we need to remove/update several more dependencies, hence the desire to break these upgrades down into multiple stages/PRs.

*As it happens, it's not even the latest version of Scala 2.12. Weirdly, this project will not compile with later versions of 2.11.x _or_ 2.12.x, due to errors related to implicits. I spent a while looking at this but ended up down a rabbit hole, so I think we should use this PR as a stepping stone and revisit this if it's still a problem when we try to move to 2.13 (there are a couple of [answers on Stack Overflow](https://stackoverflow.com/a/66229034/15960596) which give me hope!).

## How to test

I've deployed this to `CODE` and tested some basic functionality (baking an AMI, viewing bake logs, creating/editing recipes).

## How can we measure success?

* We are using a more recent Scala version
* Play Framework / `play-google-auth` upgrades are unblocked

## Have we considered potential risks?

This PR should be pretty low risk given the testing performed.
