### PR TITLE
Migrate to GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+name: CI
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+      - uses: actions/setup-node@v2 # This is required by cdk
+        with:
+          cache: 'yarn'
+          cache-dependency-path: 'cdk/yarn.lock'
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - name: CI
+        run: |
+          LAST_TEAMCITY_BUILD=3006
+          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+          ./script/ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           cache: 'yarn'
           cache-dependency-path: 'cdk/yarn.lock'
+          node-version-file: 'cdk/.nvmrc'
       - uses: actions/setup-java@v2
         with:
           java-version: '8'

--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ lazy val root = (project in file("."))
     maintainer := "Guardian Developer Experience <devx@theguardian.com>",
 
     serverLoading in Debian := Some(Systemd),
+    riffRaffManifestProjectName := s"tools::${name.value}",
     riffRaffPackageType := (packageBin in Debian).value,
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds"),

--- a/build.sbt
+++ b/build.sbt
@@ -30,8 +30,6 @@ lazy val root = (project in file("."))
     serverLoading in Debian := Some(Systemd),
     riffRaffManifestProjectName := s"tools::${name.value}",
     riffRaffPackageType := (packageBin in Debian).value,
-    riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
-    riffRaffUploadManifestBucket := Option("riffraff-builds"),
     riffRaffArtifactResources ++= Seq(
       (packageBin in Universal in imageCopier).value -> "imagecopier/imagecopier.zip",
       baseDirectory.value / "cdk/cdk.out/AMIgo.template.json" -> "cloudformation/AMIgo.template.json"

--- a/cdk/script/ci
+++ b/cdk/script/ci
@@ -2,27 +2,7 @@
 
 set -e
 
-nvm_available() {
-  type -t nvm > /dev/null
-}
-
-source_nvm() {
-  if ! nvm_available; then
-    [ -e "/usr/local/opt/nvm/nvm.sh" ] && source /usr/local/opt/nvm/nvm.sh
-  fi
-  if ! nvm_available; then
-    [ -e "$HOME/.nvm/nvm.sh" ] && source "$HOME/.nvm/nvm.sh"
-  fi
-}
-
-source_nvm
-nvm install
-nvm use
-
-npm install -g yarn
-
 yarn install --frozen-lockfile
-
 yarn test
 yarn build
 yarn synth

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.0")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts Artifact("jdeb", "jar", "jar")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/script/ci
+++ b/script/ci
@@ -8,4 +8,4 @@ set -e
  ./script/ci
 )
 
-sbt clean compile test riffRaffNotifyTeamcity
+sbt clean compile test riffRaffUpload


### PR DESCRIPTION
## What does this change?

This PR configures GitHub Actions for AMIgo (as a replacement for [TeamCity](https://teamcity.gutools.co.uk/admin/editBuildRunners.html?id=buildType:Tools_Amigo)).

## How to test

I've deployed a branch built via GitHub Actions to `CODE`.

## How can we measure success?

All configuration related to CI is now in version control.

## Have we considered potential risks?

Yes, CI performance may be slightly worse on GitHub Actions. As there are plans to address that over the next few months I'm not especially concerned about it.