### PR TITLE
Remove Log streaming from showBake page

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,7 @@ name: CI
 on:
   pull_request:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+
 jobs:
   CI:
     runs-on: ubuntu-latest

--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -1,7 +1,6 @@
 package components
 
 import akka.actor.typed.ActorSystem
-import akka.stream.scaladsl.Source
 import com.amazonaws.{ AmazonClientException, AmazonWebServiceRequest, ClientConfiguration }
 import com.amazonaws.auth.{ AWSCredentialsProviderChain, InstanceProfileCredentialsProvider }
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
@@ -24,7 +23,7 @@ import event.{ ActorSystemWrapper, BakeEvent, Behaviours }
 import housekeeping._
 import housekeeping.utils.{ BakesRepo, PackerEC2Client }
 import models.NotificationConfig
-import notification.{ AmiCreatedNotifier, LambdaDistributionBucket, NotificationSender, SNS }
+import notification.{ LambdaDistributionBucket, NotificationSender, SNS }
 import org.joda.time.Duration
 import org.quartz.Scheduler
 import org.quartz.impl.StdSchedulerFactory
@@ -193,11 +192,8 @@ class AppComponents(context: Context, identity: AppIdentity)
     LambdaDistributionBucket.updateBucketPolicy(s3Client, bucketName, stage, accountNumbers)
   }
 
-  val (eventsEnumerator, eventsChannel) = Concurrent.broadcast[BakeEvent]
-  val eventsSource = Source.fromPublisher(IterateeStreams.enumeratorToPublisher(eventsEnumerator))
   val eventBusActorSystem: ActorSystem[BakeEvent] = {
     val eventListeners = Map(
-      "channelSender" -> Behaviours.sendToChannel(eventsChannel),
       "logWriter" -> Behaviours.writeToLog,
       "dynamoWriter" -> Behaviours.persistBakeEvent(notificationConfig)
     )
@@ -206,7 +202,6 @@ class AppComponents(context: Context, identity: AppIdentity)
   implicit val eventBus = new ActorSystemWrapper(eventBusActorSystem)
 
   val sender: NotificationSender = new NotificationSender(sns, region.getName, stage)
-  val completedBakeNotifier: AmiCreatedNotifier = new AmiCreatedNotifier(eventsSource, sender.sendTopicMessage)
 
   val googleAuthConfig = GoogleAuthConfig(
     clientId = mandatoryConfig("google.clientId"),
@@ -281,7 +276,6 @@ class AppComponents(context: Context, identity: AppIdentity)
   val bakeController = new BakeController(
     authAction,
     stage,
-    eventsSource,
     prismAgents,
     controllerComponents,
     ansibleVariables,

--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -31,8 +31,6 @@ import packer.{ PackerConfig, PackerRunner }
 import play.api.BuiltInComponentsFromContext
 import play.api.ApplicationLoader.Context
 import play.api.i18n.I18nComponents
-import play.api.libs.iteratee.Concurrent
-import play.api.libs.iteratee.streams.IterateeStreams
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.{ AnyContent, EssentialFilter }
 import play.api.routing.Router

--- a/app/controllers/BakeController.scala
+++ b/app/controllers/BakeController.scala
@@ -9,10 +9,8 @@ import models.BakeStatus.DeletionScheduled
 import packer._
 import models._
 import play.api.i18n.I18nSupport
-import play.api.libs.EventSource
 import play.api.mvc._
 import services.{ AmiMetadataLookup, Loggable, PrismData }
-import services.{ Loggable, PrismData }
 import play.api.libs.json._
 import prism.{ RecipeUsage, SimpleBakeUsage }
 

--- a/app/controllers/BakeController.scala
+++ b/app/controllers/BakeController.scala
@@ -19,7 +19,6 @@ import prism.{ RecipeUsage, SimpleBakeUsage }
 class BakeController(
   val authAction: AuthAction[AnyContent],
   stage: String,
-  eventsSource: Source[BakeEvent, _],
   prism: PrismData,
   components: ControllerComponents,
   ansibleVars: Map[String, String],
@@ -67,14 +66,6 @@ class BakeController(
     } else {
       Ok(Json.obj("packages" -> Json.toJson(list.right.get)))
     }
-  }
-
-  def bakeEvents(recipeId: RecipeId, buildNumber: Int) = authAction { implicit req =>
-    val bakeId = BakeId(recipeId, buildNumber)
-    val source = eventsSource
-      .filter(_.bakeId == bakeId) // only include events relevant to this bake
-      .via(EventSource.flow)
-    Ok.chunked(source).as("text/event-stream")
   }
 
   def allBakeUsages: Action[AnyContent] = authAction {

--- a/app/event/BakeEvent.scala
+++ b/app/event/BakeEvent.scala
@@ -3,9 +3,8 @@ package event
 import java.util.UUID
 
 import models.{ BakeLog, AmiId, BakeId }
-import org.joda.time.DateTime
 import play.api.libs.EventSource.{ EventIdExtractor, EventDataExtractor }
-import play.api.libs.json.{ JsArray, JsNumber, JsString, JsObject }
+import play.api.libs.json.{ JsNumber, JsString, JsObject }
 
 sealed abstract class BakeEvent(val bakeId: BakeId, val eventId: String = UUID.randomUUID().toString)
 

--- a/app/event/Behaviours.scala
+++ b/app/event/Behaviours.scala
@@ -5,7 +5,6 @@ import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 import data.{ BakeLogs, Bakes, Dynamo }
 import event.BakeEvent._
 import models.{ Bake, BakeStatus, NotificationConfig }
-import play.api.libs.iteratee.Concurrent.Channel
 import services.Loggable
 
 import scala.concurrent.ExecutionContext
@@ -37,15 +36,6 @@ object Behaviours extends Loggable {
    * For more details, see: https://doc.akka.io/docs/akka/2.5/typed/fault-tolerance.html
    */
   def automaticallyRestart(behavior: Behavior[BakeEvent]): Behavior[BakeEvent] = Behaviors.supervise(behavior).onFailure(SupervisorStrategy.restart)
-
-  /**
-   * Forwards all events to a Channel for sending as Server Sent Events
-   */
-  def sendToChannel(channel: Channel[BakeEvent]): Behavior[BakeEvent] = Behaviors.receiveMessage[BakeEvent] {
-    event =>
-      channel.push(event)
-      Behaviors.same
-  }
 
   /**
    * Forwards all Packer-related logging to Amigo's application logs

--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -43,11 +43,10 @@
       </div>
     </div>
 
-  <div>
-    <label>
-      <input id="tail-log" type="checkbox" value="" checked>
-      Auto scroll
-    </label>
+  <div class="well" id="packer-output">
+    @for(log <- bakeLogs) {
+      <div class="bake-log">[@log.timestamp.toString("YYYY-MM-dd HH:mm:ss")] @log.messageHtml</div>
+    }
   </div>
 
   <div class="package-list">

--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -44,8 +44,10 @@
     </div>
 
   <div class="well" id="packer-output">
-    @for(log <- bakeLogs) {
+    @if(bakeLogs.isEmpty){<div class="bake-log">Refresh the page to view new log messages</div>}else{
+      @for(log <- bakeLogs) {
       <div class="bake-log">[@log.timestamp.toString("YYYY-MM-dd HH:mm:ss")] @log.messageHtml</div>
+      }
     }
   </div>
 

--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -44,11 +44,10 @@
     </div>
 
   <div class="well" id="packer-output">
-    @if(bakeLogs.isEmpty){<div class="bake-log">Refresh the page to view new log messages</div>}else{
-      @for(log <- bakeLogs) {
+    @for(log <- bakeLogs) {
       <div class="bake-log">[@log.timestamp.toString("YYYY-MM-dd HH:mm:ss")] @log.messageHtml</div>
-      }
     }
+    <div class="bake-log">Refresh the page to view new log messages</div>
   </div>
 
   <div class="package-list">

--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -50,12 +50,6 @@
     </label>
   </div>
 
-  <div class="well" id="packer-output" data-eventsource-url="@controllers.routes.BakeController.bakeEvents(bake.recipe.id, bake.buildNumber)" data-initial-highest-log-number="@{bakeLogs.lastOption.map(_.logNumber).getOrElse(-1)}">
-    @for(log <- bakeLogs) {
-      <div class="bake-log">[@log.timestamp.toString("YYYY-MM-dd HH:mm:ss")] @log.messageHtml</div>
-    }
-  </div>
-
   <div class="package-list">
 
       @packageListDiff match {

--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -34,7 +34,7 @@
         <span>@if(inUse){Bake in use and cannot be deleted}else{Bake is not currently used}</span>
       </li>
       <li class="list-group-item">
-        <span>Refresh page to see current status.</span>
+        <span class="bake--info--refresh--message"><b>Refresh page to see current status.</b></span>
     </ul>
   </div>
 

--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -33,6 +33,8 @@
         <span class="bake--info--title">Usage: </span>
         <span>@if(inUse){Bake in use and cannot be deleted}else{Bake is not currently used}</span>
       </li>
+      <li class="list-group-item">
+        <span>Refresh page to see current status.</span>
     </ul>
   </div>
 

--- a/build.sbt
+++ b/build.sbt
@@ -76,8 +76,6 @@ libraryDependencies ++= Seq(
   "com.beachape" %% "enumeratum" % "1.6.1",
   "com.typesafe.akka" %% "akka-actor-typed" % "2.6.18",
   "com.gu" %% "simple-configuration-ssm" % "1.5.6",
-  "com.typesafe.play" %% "play-iteratees" % "2.6.1",
-  "com.typesafe.play" %% "play-iteratees-reactive-streams" % "2.6.1",
   "com.gu.play-googleauth" %% "play-v28" % "2.2.2",
   "com.gu.play-secret-rotation" %% "play-v28" % "0.33",
   "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "0.33",

--- a/conf/routes
+++ b/conf/routes
@@ -37,7 +37,6 @@ GET     /recipes/:id/usages         controllers.RecipeController.showUsages(id: 
 POST    /recipes/:id/bake                               controllers.BakeController.startBaking(id: RecipeId, debug: Boolean ?= false)
 GET     /recipes/:recipeId/bakes/:buildNumber           controllers.BakeController.showBake(recipeId: RecipeId, buildNumber: Int)
 GET     /recipes/:recipeId/bakes/:buildNumber/packages  controllers.BakeController.bakePackages(recipeId: RecipeId, buildNumber: Int)
-GET     /recipes/:recipeId/bakes/:buildNumber/events    controllers.BakeController.bakeEvents(recipeId: models.RecipeId, buildNumber: Int)
 GET     /recipes/:recipeId/bakes/:buildNumber/delete    controllers.BakeController.deleteConfirm(recipeId: models.RecipeId, buildNumber: Int)
 POST     /recipes/:recipeId/bakes/:buildNumber/delete   controllers.BakeController.deleteBake(recipeId: models.RecipeId, buildNumber: Int)
 

--- a/public/javascripts/show-bake.js
+++ b/public/javascripts/show-bake.js
@@ -11,55 +11,19 @@ function initPackerOutputComponent() {
 
   $window.resize(resizeDiv);
   resizeDiv();
+  scrollToBottom();
 }
 
 function scrollToBottom() {
-  var tailCheckbox = $("#tail-log");
-  if (tailCheckbox.is(':checked')) {
-    var div = $('#packer-output');
-    var height = div.get(0).scrollHeight;
-    div.animate({
-      scrollTop: height,
-      queue: false
-    }, 500);
-  }
-}
-
-function initShowBakePage() {
-  var eventSourceUrl = document.getElementById("packer-output").dataset.eventsourceUrl;
-  var highestLogNumber = document.getElementById("packer-output").dataset.initialHighestLogNumber;
-  var packerOutputDiv = document.getElementById("packer-output");
-  var amiIdDiv = document.getElementById("ami-id");
-  var statusDiv = document.getElementById("status");
-
-  var feed = new EventSource(eventSourceUrl);
-  var handler = function(event){
-    var msg = JSON.parse(event.data);
-    switch (msg.eventType) {
-      case "log":
-        if (msg.log.number > highestLogNumber) {
-          var html = "<div class=\"bake-log\">[" + msg.timestamp + "] " + msg.log.messageHtml + "</div>";
-          packerOutputDiv.innerHTML += html;
-          highestLogNumber = msg.log.number;
-          scrollToBottom();
-        }
-        break;
-      case "ami-created":
-        amiIdDiv.innerText = msg.amiId;
-        break;
-      case "packer-process-exited":
-        var status = msg.exitCode === 0 ? "Complete" : "Failed";
-        statusDiv.innerText = status;
-        break;
-      default:
-        console.log("Unsupported message received", msg);
-    }
-  };
-  feed.addEventListener('message', handler, false);
+  var div = $('#packer-output');
+  var height = div.get(0).scrollHeight;
+  div.animate({
+    scrollTop: height,
+    queue: false
+  }, 500);
 }
 
 $(function() {
   initPackerOutputComponent();
-  initShowBakePage();
   scrollToBottom();
 });

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -64,6 +64,10 @@ body { padding-top: 70px; }
     margin-left: auto;
 }
 
+.bake--info--refresh--message {
+    align-items: center;
+}
+
 .block-link {
     display: block;
     width: 100%;


### PR DESCRIPTION
## What does this change?
This PR is preparation for upgrading to Scala 2.13
Amigo uses  the Play "iteratees" and "reactive-streams" libraries to surface the logs in real time on the  "show-bake" pages for a bake that is in progress.
These libraries have reached their end of life and do not have a version supported in Scala 2.13.
In later versions of Play, Akka streams are used in place of the reactive streams used to-date. However the implementation of these is different enough to be non-trivial.
It was also determined that live-streaming the logs for a bake that can often take 20 minutes to complete was not of great value as it is unlikely to be watched for that long. The logs are loaded when the page is refreshed after completion of bake - which is  when a user is most likely to be looking at them in any case.
As such it was determined that - in order to allow an upgrade of Amigo to scala 2.13 - it would be necessary to remove the live streaming of logs functionality.

## How to test

Tested by compiling locally,
Running tests locally
Deploying to CODE
Creating a new Bake on the code Amigo site
When refreshed after completion of Bake confirm that:
- [x] Bake completed successfully
- [x] The auto-scroll dropdown was not shown on the show-bake page;
- [x] Logs were displayed in the correct section on the show-bake page; 
- [x] When package changes were forced on an existing recipe, those changes were displayed in the Package Changes section of the show-bake page;
- [x] All installed packages were listed in the "All installed packages" section of the show-bake page.

Before change - streaming happens during bake:
![before](https://user-images.githubusercontent.com/7239344/158210884-dbdb9c79-f88f-4eec-bd4d-7c977bba49ff.gif)

After change - no streaming during bake:
![afterstart2](https://user-images.githubusercontent.com/7239344/158796981-cc57d2a7-bab0-4a20-a052-ea7347d44fe5.gif)

After change - When refreshing after bake completion logs are present:
![afterstart3](https://user-images.githubusercontent.com/7239344/158800189-b1a851c0-d424-45d2-9097-d46606bb2652.gif)

