### PR TITLE
Update metricbeat role to support ARM architecture

### DIFF
--- a/roles/metricbeat/README.md
+++ b/roles/metricbeat/README.md
@@ -4,8 +4,8 @@ Install [metricbeat](https://www.elastic.co/beats/metricbeat) to gather metrics 
 
 Configuration to be supplied at launch time.
 
-Basic use allows the version of metricbeat to be specified:
+## Configure role
 
-```
-version: 7.8.1
-```
+You must specify the version of metricbeat to be installed:
+
+    version: 7.17.1

--- a/roles/metricbeat/tasks/main.yml
+++ b/roles/metricbeat/tasks/main.yml
@@ -7,9 +7,9 @@
 
 - name: Add repository
   ansible.builtin.apt_repository:
-    repo: deb https://artifacts.elastic.co/packages/{{ major_version }}.x/apt stable main
+    repo: deb https://artifacts.elastic.co/packages/{{ version |regex_search('^(\\d*)\\.','\\1') }}.x/apt stable main
 
 - name: Install
   apt:
-    name: metricbeat={{full_version}}
+    name: metricbeat={{version}}
     update_cache: yes

--- a/roles/metricbeat/tasks/main.yml
+++ b/roles/metricbeat/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Add repository
   ansible.builtin.apt_repository:
-    repo: deb https://artifacts.elastic.co/packages/{{ version |regex_search('^(\\d*)\\.','\\1') }}.x/apt stable main
+    repo: deb https://artifacts.elastic.co/packages/{{ version | regex_search('^(\d+)\.','\1') }}.x/apt stable main
 
 - name: Install
   apt:

--- a/roles/metricbeat/tasks/main.yml
+++ b/roles/metricbeat/tasks/main.yml
@@ -1,6 +1,15 @@
 ---
-- name: Add Elastic repository key
-  apt_key: url=https://artifacts.elastic.co/GPG-KEY-elasticsearch state=present
+# See https://www.elastic.co/guide/en/beats/metricbeat/7.17/setup-repositories.html
 
-- name: Ensure Metricbeat is installed
-  apt: deb=https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{ version }}-amd64.deb state=present
+- name: Add GPG key
+  apt_key:
+    url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
+
+- name: Add repository
+  ansible.builtin.apt_repository:
+    repo: deb https://artifacts.elastic.co/packages/{{ major_version }}.x/apt stable main
+
+- name: Install
+  apt:
+    name: metricbeat={{full_version}}
+    update_cache: yes

--- a/roles/metricbeat/tasks/main.yml
+++ b/roles/metricbeat/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Add repository
   ansible.builtin.apt_repository:
-    repo: deb https://artifacts.elastic.co/packages/{{ version | regex_search('^(\d+)\.','\1') }}.x/apt stable main
+    repo: deb https://artifacts.elastic.co/packages/{{ version | regex_search('^(\\d+)','\\1') }}.x/apt stable main
 
 - name: Install
   apt:


### PR DESCRIPTION
This switches from directly specifying the download url for the debian package, to using Elastic's APT repository, in the hope that APT will correctly download the correct architecture - ie ARM/AArch64 when we want it!

The configuration in this commit- adding an APT repository - is based on the configuration in the `fluentbit` role.

See also:
* https://www.elastic.co/guide/en/beats/metricbeat/7.17/setup-repositories.html
* https://github.com/guardian/amigo/pull/377#issuecomment-1064983514

