### PR TITLE
Fix cloudwatch-hardware-monitoring-cronjob role

### DIFF
--- a/roles/cloudwatch-hardware-monitoring-cronjob/tasks/main.yml
+++ b/roles/cloudwatch-hardware-monitoring-cronjob/tasks/main.yml
@@ -31,4 +31,4 @@
 
 - name: Add hardware data collection cronjob
   cron: name="send hardware data information to cloudwatch" minute="*/5" job="/usr/local/aws-scripts-mon/mon-put-instance-data.pl {{ mem_avail_option | default("") }} {{ mem_used_option | default("") }} {{ disk_space_avail_option | default("") }} {{ disk_space_util_option | default("") }} {{ disk_space_used_option | default("") }} {{ mem_util_option | default("") }} {{ item }} --auto-scaling --from-cron"
-  with_items: "{{ paths | map('regex_replace', '(.*)', '--disk-path \\1') | join(' ') }}"
+  with_items: "{{ paths | map('regex_replace', '(.+)', '--disk-path \\1') | join(' ') }}"


### PR DESCRIPTION
## What does this change?
cloudwatch-hardware-monitoring-cronjob is useful for checking memory/disk usage of an app over time. Especially useful in reservation season! 

Currently the outputted command from this role is broken, it messes up the --disk-path parameters.

For example, for the paths input `paths: [/, /data]` it generates a command like this:
`/usr/local/aws-scripts-mon/mon-put-instance-data.pl    --disk-space-util  --mem-util --disk-path /--disk-path  --disk-path /data--disk-path`

If you look closely at ^ you can see there are a load of erroneuous `--disk-path` strings, and worse there's no space between then and the paths, resulting in very dodgy paths. We get an error when running this command:

`Disk file path '/--disk-path' does not exist or cannot be accessed.`

This change fixes it. I'm not sure why! But it's something to do with regex_replace - maybe if you do .* it matches the string itself plus an 'empty' string as well. I worked it out using this thing:

https://ansible.sivel.net/test/

if you want to have a play try pasting the string `{{ '/' | regex_replace('(.*)', '--disk-path \\1') }}` into the template - you'll see that if you use .* it breaks but .+ is fine

## How to test
I've tested this by baking an AMI on CODE and verifying that the role succesfully creates metrics in cloudwatch

## How can we measure success?
We'll be able to measure memory usage and disk usage again in cloudwatch metrics, yay!
