### PR TITLE
Introduce devx-logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Brewfile.lock.json
 
 roles/*.log
 roles/.vagrant
+
+.metals
+.vscode

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ it possible to SSH onto the instance that is being used to build the AMI.
 
 ### Testing ansible scripts without runing amigo/packer
 
+*Warning: Multipass seems to struggle if running at the same time as the VPN. We
+recommend not running the VPN when using Multipass locally.*
+
 Amigo roles are simply Ansible scripts and can be run independently of Amigo
 itself. This is often a lot easier than running Amigo itself.
 
@@ -59,6 +62,8 @@ If the Multipass VM is timing out, try deleting and then re-running the script:
     $ multipass stop amigo-test
     $ multipass delete amigo-test
     $ multipass purge amigo-test
+
+You should also disconnect from the VPN too if using it.
 
 *Previously Vagrant was used but Virtualbox, which is used under the hood,
 doesn't support M1/arm64 macs unfortunately.*

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ To test roles locally, run:
 This will install [Multipass](https://multipass.run/), a Canonical tool to
 manage Ubuntu VMs, and execute Ansible roles within it.
 
+If you want to run commands/debug directly in the VM then (post installing
+things via run.sh), run:
+
+    $ multipass shell amigo-test
+
+If the Multipass VM is timing out, try deleting and then re-running the script:
+
+    $ multipass stop amigo-test
+    $ multipass delete amigo-test
+    $ multipass purge amigo-test
+
 *Previously Vagrant was used but Virtualbox, which is used under the hood,
 doesn't support M1/arm64 macs unfortunately.*
 

--- a/multipass/playbook.yaml
+++ b/multipass/playbook.yaml
@@ -6,7 +6,7 @@
 
   # Uncomment to pass vars to your roles
   #vars:
-  #  foo=bar
+  #  foo: bar
 
   roles:
     - ROLE_GOES_HERE

--- a/multipass/run.sh
+++ b/multipass/run.sh
@@ -25,7 +25,7 @@ if ! multipass list | grep $vm_name | grep Running > /dev/null
 then
     echo 'Creating and provisioning multipass VM...'
     multipass launch --name $vm_name 20.04
-    multipass mount ../roles $vm_name:$target_dir/.ansible/roles
+    multipass mount $script_dir/../roles $vm_name:$target_dir/.ansible/roles
     multipass mount $script_dir $vm_name:$target_dir/test
     multipass exec $vm_name -- $target_dir/test/bootstrap-vm.sh
 fi

--- a/multipass/run.sh
+++ b/multipass/run.sh
@@ -4,7 +4,7 @@ set -e
 
 script_dir=$(dirname "$0")
 target_dir=/home/ubuntu
-custom_playbook="$script_dir/playbook-custom.yaml"
+custom_playbook="playbook-custom.yaml"
 vm_name=amigo-test
 
 if ! command -v multipass &> /dev/null
@@ -13,7 +13,7 @@ then
     brew install --cask multipass
 fi
 
-if [ ! -e "$custom_playbook" ]
+if [ ! -e "$script_dir/$custom_playbook" ]
 then
     echo "Creating local playbook file ($custom_playbook)..."
     cp $script_dir/playbook.yaml $script_dir/playbook-custom.yaml

--- a/roles/cdk-base/README.md
+++ b/roles/cdk-base/README.md
@@ -1,7 +1,24 @@
 CDK base config
 ===============
 
-This role includes boot tasks that the Guardian's EC2 CDK patterns and best practices rely on.
+This role includes boot tasks that the Guardian's EC2 CDK patterns and best
+practices rely on.
 
-Initially this will be fetching and writing tags and configuration to `/etc/config`.
+At the moment this means the following:
 
+* fetch instance tags and store under /etc/config
+* ship cloud-init logs to a Kinesis stream
+
+We strongly recommend [enabling tag metadata on your
+instance](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-launchtemplatedata-metadataoptions.html#cfn-ec2-launchtemplate-launchtemplatedata-metadataoptions-instancemetadatatags)
+as this does not require remote AWS API calls at runtime.
+
+To ship logs, ensure your instance has the following tag:
+
+    LogKinesisStreamName
+
+set to the name of your logging Kinesis Stream.
+
+For more information on behaviour, see
+[instance-tag-discovery](https://github.com/guardian/instance-tag-discovery) and
+[devx-logs](https://github.com/guardian/devx-logs).

--- a/roles/cdk-base/README.md
+++ b/roles/cdk-base/README.md
@@ -1,6 +1,9 @@
 CDK base config
 ===============
 
+**WARNING: this role is experimental and not recommended for Production use
+yet.**
+
 This role includes boot tasks that the Guardian's EC2 CDK patterns and best
 practices rely on.
 

--- a/roles/cdk-base/meta/main.yml
+++ b/roles/cdk-base/meta/main.yml
@@ -1,4 +1,4 @@
 ---
 dependencies:
   - aws-tools
-  - fluenbit
+  - fluentbit

--- a/roles/cdk-base/meta/main.yml
+++ b/roles/cdk-base/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - aws-tools
+  - fluenbit

--- a/roles/cdk-base/tasks/main.yml
+++ b/roles/cdk-base/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: Install instance-tag-discovery
   ansible.builtin.shell: |
     NAME=instance-tag-discovery
-    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/00-$NAME
+    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}/$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/00-$NAME
     chmod +x /var/lib/cloud/scripts/per-instance/00-$NAME
   when:
     - ansible_os_family == "Debian"
@@ -16,7 +16,7 @@
 - name: Install devx-logs
   ansible.builtin.shell: |
     NAME=devx-logs
-    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/01-$NAME
+    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}/$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/01-$NAME
     chmod +x /var/lib/cloud/scripts/per-instance/01-$NAME
   when:
     - ansible_os_family == "Debian"

--- a/roles/cdk-base/tasks/main.yml
+++ b/roles/cdk-base/tasks/main.yml
@@ -1,9 +1,16 @@
 ---
-- name: Download a package from an S3 bucket
-  command: /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}instance-tag-discovery-{{ deb_arch }}_1.0-1.deb /tmp/instance-tag-discovery.deb
+- name: Install instance-tag-discovery
+  ansible.builtin.shell: |
+    NAME=instance-tag-discovery-{{ deb_arch }}
+    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}$NAME /var/lib/cloud/scripts/per-instance/00-$NAME
+    chmod +x /var/lib/cloud/scripts/per-instance/00-$NAME
   when:
     - ansible_os_family == "Debian"
 
-- name: Install cloudwatch agent
-  apt:
-    deb: /tmp/instance-tag-discovery.deb
+- name: Install devx-logs
+  ansible.builtin.shell: |
+    NAME=devx-logs-linux-{{ deb_arch }}
+    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}$NAME /var/lib/cloud/scripts/per-instance/01-$NAME
+    chmod +x /var/lib/cloud/scripts/per-instance/01-$NAME
+  when:
+    - ansible_os_family == "Debian"

--- a/roles/cdk-base/tasks/main.yml
+++ b/roles/cdk-base/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
 - name: Setup target directory
-  shell: |
-    mkdir -p /var/lib/cloud/scripts/per-instance
+  file:
+    path: /var/lib/cloud/scripts/per-instance
+    state: directory
   when:
     - ansible_os_family == "Debian"
 

--- a/roles/cdk-base/tasks/main.yml
+++ b/roles/cdk-base/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 - name: Install instance-tag-discovery
   ansible.builtin.shell: |
-    NAME=instance-tag-discovery-{{ deb_arch }}
-    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}$NAME /var/lib/cloud/scripts/per-instance/00-$NAME
+    NAME=instance-tag-discovery
+    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}$NAME/$NAME-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/00-$NAME
     chmod +x /var/lib/cloud/scripts/per-instance/00-$NAME
   when:
     - ansible_os_family == "Debian"
 
 - name: Install devx-logs
   ansible.builtin.shell: |
-    NAME=devx-logs-linux-{{ deb_arch }}
-    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}$NAME /var/lib/cloud/scripts/per-instance/01-$NAME
+    NAME=devx-logs-linux
+    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}$NAME/$NAME-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/01-$NAME
     chmod +x /var/lib/cloud/scripts/per-instance/01-$NAME
   when:
     - ansible_os_family == "Debian"

--- a/roles/cdk-base/tasks/main.yml
+++ b/roles/cdk-base/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: Install instance-tag-discovery
   ansible.builtin.shell: |
     NAME=instance-tag-discovery
-    /usr/local/bin/aws s3 cp s3://{{ dist_bucket }}/packages/$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/00-$NAME
+    /usr/local/bin/aws s3 cp s3://{{ dist_bucket | quote }}/packages/$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/00-$NAME
     chmod +x /var/lib/cloud/scripts/per-instance/00-$NAME
   when:
     - ansible_os_family == "Debian"
@@ -16,7 +16,7 @@
 - name: Install devx-logs
   ansible.builtin.shell: |
     NAME=devx-logs
-    /usr/local/bin/aws s3 cp s3://{{ dist_bucket }}/packages/$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/01-$NAME
+    /usr/local/bin/aws s3 cp s3://{{ dist_bucket | quote }}/packages/$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/01-$NAME
     chmod +x /var/lib/cloud/scripts/per-instance/01-$NAME
   when:
     - ansible_os_family == "Debian"

--- a/roles/cdk-base/tasks/main.yml
+++ b/roles/cdk-base/tasks/main.yml
@@ -1,16 +1,22 @@
 ---
+- name: Setup target directory
+  ansible.builtin.shell: |
+    mkdir -p /var/lib/cloud/scripts/per-instance
+  when:
+    - ansible_os_family == "Debian"
+
 - name: Install instance-tag-discovery
   ansible.builtin.shell: |
     NAME=instance-tag-discovery
-    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}$NAME/$NAME-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/00-$NAME
+    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/00-$NAME
     chmod +x /var/lib/cloud/scripts/per-instance/00-$NAME
   when:
     - ansible_os_family == "Debian"
 
 - name: Install devx-logs
   ansible.builtin.shell: |
-    NAME=devx-logs-linux
-    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}$NAME/$NAME-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/01-$NAME
+    NAME=devx-logs
+    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/01-$NAME
     chmod +x /var/lib/cloud/scripts/per-instance/01-$NAME
   when:
     - ansible_os_family == "Debian"

--- a/roles/cdk-base/tasks/main.yml
+++ b/roles/cdk-base/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: Install instance-tag-discovery
   ansible.builtin.shell: |
     NAME=instance-tag-discovery
-    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}/$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/00-$NAME
+    /usr/local/bin/aws s3 cp s3://{{ dist_bucket }}/packages/$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/00-$NAME
     chmod +x /var/lib/cloud/scripts/per-instance/00-$NAME
   when:
     - ansible_os_family == "Debian"
@@ -16,7 +16,7 @@
 - name: Install devx-logs
   ansible.builtin.shell: |
     NAME=devx-logs
-    /usr/local/bin/aws s3 cp s3://{{ s3_bucket }}/{{ s3_prefix }}/$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/01-$NAME
+    /usr/local/bin/aws s3 cp s3://{{ dist_bucket }}/packages/$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/01-$NAME
     chmod +x /var/lib/cloud/scripts/per-instance/01-$NAME
   when:
     - ansible_os_family == "Debian"

--- a/roles/cdk-base/tasks/main.yml
+++ b/roles/cdk-base/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Setup target directory
-  ansible.builtin.shell: |
+  shell: |
     mkdir -p /var/lib/cloud/scripts/per-instance
   when:
     - ansible_os_family == "Debian"
 
 - name: Install instance-tag-discovery
-  ansible.builtin.shell: |
+  shell: |
     NAME=instance-tag-discovery
     /usr/local/bin/aws s3 cp s3://{{ dist_bucket | quote }}/packages/$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/00-$NAME
     chmod +x /var/lib/cloud/scripts/per-instance/00-$NAME
@@ -14,7 +14,7 @@
     - ansible_os_family == "Debian"
 
 - name: Install devx-logs
-  ansible.builtin.shell: |
+  shell: |
     NAME=devx-logs
     /usr/local/bin/aws s3 cp s3://{{ dist_bucket | quote }}/packages/$NAME/$NAME-linux-{{ deb_arch }} /var/lib/cloud/scripts/per-instance/01-$NAME
     chmod +x /var/lib/cloud/scripts/per-instance/01-$NAME


### PR DESCRIPTION
**Note, this is being trialled in DevX and not ready for other teams yet, but please shout if interested in testing it.**

See role README for more info.

Eventual plan is to include this in the standard base images, but that can be in a subsequent PR once we've tested thoroughly and are convinced it's the right approach.

Initially devx-logs ships Cloud Init Output, but will be extended to application logging too in the near future.

See also:

* [instance-tag-discovery](https://github.com/guardian/instance-tag-discovery)
* [devx-logs](https://github.com/guardian/devx-logs)

And these related PRs:

* https://github.com/guardian/instance-tag-discovery/pull/3
* https://github.com/guardian/amigo/pull/710