### PR TITLE
Revert "Remove Log streaming from showBake page"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,9 @@ name: CI
 on:
   pull_request:
   workflow_dispatch:
-
+  push:
+    branches:
+      - main
 jobs:
   CI:
     runs-on: ubuntu-latest

--- a/app/controllers/BakeController.scala
+++ b/app/controllers/BakeController.scala
@@ -9,14 +9,17 @@ import models.BakeStatus.DeletionScheduled
 import packer._
 import models._
 import play.api.i18n.I18nSupport
+import play.api.libs.EventSource
 import play.api.mvc._
 import services.{ AmiMetadataLookup, Loggable, PrismData }
+import services.{ Loggable, PrismData }
 import play.api.libs.json._
 import prism.{ RecipeUsage, SimpleBakeUsage }
 
 class BakeController(
   val authAction: AuthAction[AnyContent],
   stage: String,
+  eventsSource: Source[BakeEvent, _],
   prism: PrismData,
   components: ControllerComponents,
   ansibleVars: Map[String, String],
@@ -64,6 +67,14 @@ class BakeController(
     } else {
       Ok(Json.obj("packages" -> Json.toJson(list.right.get)))
     }
+  }
+
+  def bakeEvents(recipeId: RecipeId, buildNumber: Int) = authAction { implicit req =>
+    val bakeId = BakeId(recipeId, buildNumber)
+    val source = eventsSource
+      .filter(_.bakeId == bakeId) // only include events relevant to this bake
+      .via(EventSource.flow)
+    Ok.chunked(source).as("text/event-stream")
   }
 
   def allBakeUsages: Action[AnyContent] = authAction {

--- a/app/event/BakeEvent.scala
+++ b/app/event/BakeEvent.scala
@@ -3,8 +3,9 @@ package event
 import java.util.UUID
 
 import models.{ BakeLog, AmiId, BakeId }
+import org.joda.time.DateTime
 import play.api.libs.EventSource.{ EventIdExtractor, EventDataExtractor }
-import play.api.libs.json.{ JsNumber, JsString, JsObject }
+import play.api.libs.json.{ JsArray, JsNumber, JsString, JsObject }
 
 sealed abstract class BakeEvent(val bakeId: BakeId, val eventId: String = UUID.randomUUID().toString)
 

--- a/app/event/Behaviours.scala
+++ b/app/event/Behaviours.scala
@@ -5,6 +5,7 @@ import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 import data.{ BakeLogs, Bakes, Dynamo }
 import event.BakeEvent._
 import models.{ Bake, BakeStatus, NotificationConfig }
+import play.api.libs.iteratee.Concurrent.Channel
 import services.Loggable
 
 import scala.concurrent.ExecutionContext
@@ -36,6 +37,15 @@ object Behaviours extends Loggable {
    * For more details, see: https://doc.akka.io/docs/akka/2.5/typed/fault-tolerance.html
    */
   def automaticallyRestart(behavior: Behavior[BakeEvent]): Behavior[BakeEvent] = Behaviors.supervise(behavior).onFailure(SupervisorStrategy.restart)
+
+  /**
+   * Forwards all events to a Channel for sending as Server Sent Events
+   */
+  def sendToChannel(channel: Channel[BakeEvent]): Behavior[BakeEvent] = Behaviors.receiveMessage[BakeEvent] {
+    event =>
+      channel.push(event)
+      Behaviors.same
+  }
 
   /**
    * Forwards all Packer-related logging to Amigo's application logs

--- a/app/views/showBake.scala.html
+++ b/app/views/showBake.scala.html
@@ -33,8 +33,6 @@
         <span class="bake--info--title">Usage: </span>
         <span>@if(inUse){Bake in use and cannot be deleted}else{Bake is not currently used}</span>
       </li>
-      <li class="list-group-item">
-        <span class="bake--info--refresh--message"><b>Refresh page to see current status.</b></span>
     </ul>
   </div>
 
@@ -45,11 +43,17 @@
       </div>
     </div>
 
-  <div class="well" id="packer-output">
+  <div>
+    <label>
+      <input id="tail-log" type="checkbox" value="" checked>
+      Auto scroll
+    </label>
+  </div>
+
+  <div class="well" id="packer-output" data-eventsource-url="@controllers.routes.BakeController.bakeEvents(bake.recipe.id, bake.buildNumber)" data-initial-highest-log-number="@{bakeLogs.lastOption.map(_.logNumber).getOrElse(-1)}">
     @for(log <- bakeLogs) {
       <div class="bake-log">[@log.timestamp.toString("YYYY-MM-dd HH:mm:ss")] @log.messageHtml</div>
     }
-    <div class="bake-log">Refresh the page to view new log messages</div>
   </div>
 
   <div class="package-list">

--- a/build.sbt
+++ b/build.sbt
@@ -76,6 +76,8 @@ libraryDependencies ++= Seq(
   "com.beachape" %% "enumeratum" % "1.6.1",
   "com.typesafe.akka" %% "akka-actor-typed" % "2.6.18",
   "com.gu" %% "simple-configuration-ssm" % "1.5.6",
+  "com.typesafe.play" %% "play-iteratees" % "2.6.1",
+  "com.typesafe.play" %% "play-iteratees-reactive-streams" % "2.6.1",
   "com.gu.play-googleauth" %% "play-v28" % "2.2.2",
   "com.gu.play-secret-rotation" %% "play-v28" % "0.33",
   "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "0.33",

--- a/conf/routes
+++ b/conf/routes
@@ -37,6 +37,7 @@ GET     /recipes/:id/usages         controllers.RecipeController.showUsages(id: 
 POST    /recipes/:id/bake                               controllers.BakeController.startBaking(id: RecipeId, debug: Boolean ?= false)
 GET     /recipes/:recipeId/bakes/:buildNumber           controllers.BakeController.showBake(recipeId: RecipeId, buildNumber: Int)
 GET     /recipes/:recipeId/bakes/:buildNumber/packages  controllers.BakeController.bakePackages(recipeId: RecipeId, buildNumber: Int)
+GET     /recipes/:recipeId/bakes/:buildNumber/events    controllers.BakeController.bakeEvents(recipeId: models.RecipeId, buildNumber: Int)
 GET     /recipes/:recipeId/bakes/:buildNumber/delete    controllers.BakeController.deleteConfirm(recipeId: models.RecipeId, buildNumber: Int)
 POST     /recipes/:recipeId/bakes/:buildNumber/delete   controllers.BakeController.deleteBake(recipeId: models.RecipeId, buildNumber: Int)
 

--- a/public/javascripts/show-bake.js
+++ b/public/javascripts/show-bake.js
@@ -11,19 +11,55 @@ function initPackerOutputComponent() {
 
   $window.resize(resizeDiv);
   resizeDiv();
-  scrollToBottom();
 }
 
 function scrollToBottom() {
-  var div = $('#packer-output');
-  var height = div.get(0).scrollHeight;
-  div.animate({
-    scrollTop: height,
-    queue: false
-  }, 500);
+  var tailCheckbox = $("#tail-log");
+  if (tailCheckbox.is(':checked')) {
+    var div = $('#packer-output');
+    var height = div.get(0).scrollHeight;
+    div.animate({
+      scrollTop: height,
+      queue: false
+    }, 500);
+  }
+}
+
+function initShowBakePage() {
+  var eventSourceUrl = document.getElementById("packer-output").dataset.eventsourceUrl;
+  var highestLogNumber = document.getElementById("packer-output").dataset.initialHighestLogNumber;
+  var packerOutputDiv = document.getElementById("packer-output");
+  var amiIdDiv = document.getElementById("ami-id");
+  var statusDiv = document.getElementById("status");
+
+  var feed = new EventSource(eventSourceUrl);
+  var handler = function(event){
+    var msg = JSON.parse(event.data);
+    switch (msg.eventType) {
+      case "log":
+        if (msg.log.number > highestLogNumber) {
+          var html = "<div class=\"bake-log\">[" + msg.timestamp + "] " + msg.log.messageHtml + "</div>";
+          packerOutputDiv.innerHTML += html;
+          highestLogNumber = msg.log.number;
+          scrollToBottom();
+        }
+        break;
+      case "ami-created":
+        amiIdDiv.innerText = msg.amiId;
+        break;
+      case "packer-process-exited":
+        var status = msg.exitCode === 0 ? "Complete" : "Failed";
+        statusDiv.innerText = status;
+        break;
+      default:
+        console.log("Unsupported message received", msg);
+    }
+  };
+  feed.addEventListener('message', handler, false);
 }
 
 $(function() {
   initPackerOutputComponent();
+  initShowBakePage();
   scrollToBottom();
 });

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -64,10 +64,6 @@ body { padding-top: 70px; }
     margin-left: auto;
 }
 
-.bake--info--refresh--message {
-    align-items: center;
-}
-
 .block-link {
     display: block;
     width: 100%;


### PR DESCRIPTION
Reverts guardian/amigo#700

We have discovered an issue with this PR, The removal of the event source in line:
https://github.com/guardian/amigo/pull/700/files#diff-275086bef5d49fdfbb4cdd7573d272b5cc4facdc931fff59175d3e8cd1ddf5eeL209

will prevent the creation of encrypted copies of AMI's
