### PR TITLE
Make oauth2-proxy role work for ARM

### DIFF
--- a/roles/oauth2-proxy/tasks/main.yml
+++ b/roles/oauth2-proxy/tasks/main.yml
@@ -1,9 +1,19 @@
 ---
-- name: Download oauth proxy
+- name: Download oauth proxy - amd64
   unarchive: src=https://github.com/oauth2-proxy/oauth2-proxy/releases/download/v{{ oauth_version }}/oauth2-proxy-v{{ oauth_version }}.linux-amd64.tar.gz dest=/opt remote_src=True
+  when: ansible_architecture == "x86_64"
 
-- name: Rename folder
+- name: Download oauth proxy - arm64
+  unarchive: src=https://github.com/oauth2-proxy/oauth2-proxy/releases/download/v{{ oauth_version }}/oauth2-proxy-v{{ oauth_version }}.linux-arm64.tar.gz dest=/opt remote_src=True
+  when: ansible_architecture == "aarch64"
+
+- name: Rename folder - amd64
   shell: mv /opt/oauth2-proxy-v{{ oauth_version }}.linux-amd64 /opt/oauth2-proxy
+  when: ansible_architecture == "x86_64"
+
+- name: Rename folder - arm64
+  shell: mv /opt/oauth2-proxy-v{{ oauth_version }}.linux-arm64 /opt/oauth2-proxy
+  when: ansible_architecture == "aarch64"
 
 - name: Create oauth2-proxy group
   group: name=oauth2-proxy


### PR DESCRIPTION
## What does this change?

While moving our Kibana instance from amd64 to arm64, I discovered that oauth2-proxy will silently fail (AMIgo will happily install it, but the binary is not built for ARM, so the service fails to start). This PR fixes installs for arm64.

This adds 2 steps to the oauth2-proxy role, which will conditionally pull down an arm64 version of oauth2-proxy if ansible_architecture == "aarch64". I've also added conditionals to existing tasks, so the amd64 version will only be installed on amd64. 

This should be an improvement over the existing tasks, as although we're unlikely to need oauth2-proxy outside of amd64/arm64, the role was unaware that it had installed an unusable version (amd64 on arm64) of oauth2-proxy. In future, if this role is run on say, sparc, the task which moves the resulting directory (retrieved in the arch specific tasks) will fail, which is desirable. 

## How to test

Deploy on AMIgo CODE and build an arm64 recipe (probably Kibana) to be deployed and tested on CODE. 

## How can we measure success?

The role should work on both amd64 and arm64, and should fail on any other architecture. 
