### PR TITLE
Make Kibana role work for ARM

### DIFF
--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -2,5 +2,10 @@
 - name: Add Elasticsearch repository key
   apt_key: url=https://artifacts.elastic.co/GPG-KEY-elasticsearch state=present
 
-- name: Ensure Kibana is installed
+- name: Ensure Kibana is installed - amd64
   apt: deb=https://artifacts.elastic.co/downloads/kibana/kibana-{{ version }}-amd64.deb state=present
+  when: ansible_architecture == "x86_64"
+
+- name: Ensure Kibana is installed - arm64
+  apt: deb=https://artifacts.elastic.co/downloads/kibana/kibana-{{ version }}-arm64.deb state=present
+  when: ansible_architecture == "aarch64"


### PR DESCRIPTION
## What does this change?

Similarly to #713 , I found that the kibana role doesn't work for ARM. 

This adds a step to the Kibana role, which will conditionally pull down an arm64 version of Kibana if ansible_architecture == "aarch64". I've also added conditionals to the existing task, so the amd64 version will only be installed on amd64. This also (may) have the advantage of failing on other architectures (it may already fail, off hand I can't remember if dpkg is fussy or aware of architecture). 

## How to test

Build Kibana AMI on AMIgo CODE and deploy CODE stack. Build both ARM64 and AMD64 versions to verify neither are impacted. Also a good idea to mirror and use existing recipes from AMIgo PROD, to make sure this change doesn't impact other deployments. 

## How can we measure success?

AMIgo should be able to build Kibana AMIs for both amd64 and arm64, without needing to modify any existing recipes.

## Have we considered potential risks?

Existing recipes may fail, so at least one recipe from PROD should be mirrored on CODE and built to ensure this isn't the case. 

This could have been achieved in a similar way to other roles, by changing the "version" variable to include the architecture. This would however require any recipes using the role to change their parameters, or risk failing builds. This way existing recipes will build as usual. 
