### PR TITLE
Default dist_bucket var

### DIFF
--- a/roles/cdk-base/defaults/main.yml
+++ b/roles/cdk-base/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+dist_bucket: amigo-data


### PR DESCRIPTION
Follows https://github.com/guardian/amigo/pull/706, which is fine but will fail the bake is the var isn't defined. 

Note, the bucket is already described in Amigo's code so this isn't a secret.