### PR TITLE
Enable fluentbit to ensure startup in cdk-base

### DIFF
--- a/roles/cdk-base/tasks/main.yml
+++ b/roles/cdk-base/tasks/main.yml
@@ -21,3 +21,8 @@
     chmod +x /var/lib/cloud/scripts/per-instance/01-$NAME
   when:
     - ansible_os_family == "Debian"
+
+- name: Enable Fluentbit (to run on startup)
+  ansible.builtin.systemd:
+    name: td-agent-bit.service
+    enabled: true


### PR DESCRIPTION
Ensure fluentbit is started as part of cdk-base. Arguably the Fluentbit role itself should do this, but am wary of changing its existing behaviour here as there are already a number of production users.