### PR TITLE
Ensure credentials update

### DIFF
--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -120,9 +120,8 @@ class AppComponents(context: Context, identity: AppIdentity)
   val elkLogging = new ElkLogging(identity, elkLoggingStream, awsCredsForV1)
 
   implicit val dynamo = {
-    val credentialsProvider = StaticCredentialsProvider.create(awsCredsForV2.resolveCredentials())
     val dynamoClient: DynamoDbClient = DynamoDbClient.builder()
-      .credentialsProvider(credentialsProvider)
+      .credentialsProvider(awsCredsForV2)
       .region(Region.of(region.getName))
       .build()
     new Dynamo(dynamoClient, stage)


### PR DESCRIPTION
The static provider doesn't update credentials, which was resulting
in this error:

`software.amazon.awssdk.services.dynamodb.model.DynamoDbException: The security token included in the request is expired`

(Hopefully a fix for https://github.com/guardian/amigo/pull/712.)