### PR TITLE
Delete roles/mongo-helper-scripts directory

### DIFF
--- a/roles/mongo-helper-scripts/meta/main.yml
+++ b/roles/mongo-helper-scripts/meta/main.yml
@@ -1,4 +1,0 @@
----
-dependencies:
-  - install-ruby
-

--- a/roles/mongo-helper-scripts/tasks/main.yml
+++ b/roles/mongo-helper-scripts/tasks/main.yml
@@ -1,7 +1,0 @@
----
-- name: install ruby gems for helper scripts
-  gem: name={{item.name}} version={{item.version}} executable=true
-  with_items:
-    - { name: 'mongo', version: 2 }
-    - { name: 'bson', version: 3 }
-


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

These are not used.

It looks like they were originally [added](https://github.com/guardian/amigo/pull/87) for flexible-content, which has now [migrated to Postgres](https://www.theguardian.com/info/2018/nov/30/bye-bye-mongo-hello-postgres).