### PR TITLE
Rollback to nvm 0.33.11 and specify default Node version (16)

### DIFF
--- a/roles/teamcity-agent/defaults/main.yml
+++ b/roles/teamcity-agent/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-nvm_version: 0.39.1
+nvm_version: 0.33.11

--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -66,7 +66,7 @@
 - name: install nvm
   shell: |
     set -e
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v{{nvm_version}}/install.sh | bash
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v{{nvm_version}}/install.sh | bash
     source /opt/teamcity/.nvm/nvm.sh
     nvm install node
     nvm install --lts

--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -68,8 +68,6 @@
     set -e
     curl -o- https://raw.githubusercontent.com/creationix/nvm/v{{nvm_version}}/install.sh | bash
     source /opt/teamcity/.nvm/nvm.sh
-    nvm install node
-    nvm install --lts
   become: yes
   become_user: teamcity
   args:

--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -70,6 +70,7 @@
     source /opt/teamcity/.nvm/nvm.sh
     # Gallium is Node 16
     nvm install --lts=Gallium
+    nvm alias default 16
   become: yes
   become_user: teamcity
   args:

--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -68,6 +68,8 @@
     set -e
     curl -o- https://raw.githubusercontent.com/creationix/nvm/v{{nvm_version}}/install.sh | bash
     source /opt/teamcity/.nvm/nvm.sh
+    # Gallium is Node 16
+    nvm install --lts=Gallium
   become: yes
   become_user: teamcity
   args:


### PR DESCRIPTION
## What does this change?

We recently attempted to upgrade `nvm` (partly to keep things up to date and partly in an attempt to fix failing AMIgo bakes): https://github.com/guardian/amigo/pull/389.

Although this [fixed the AMIgo bakes, it caused unexpected problems with many of our builds](https://github.com/guardian/amigo/pull/389#issuecomment-1127501180).

This PR reverts to `nvm` version 0.33.11* and updates the way that we install the default version of Node to workaround the problems that we were seeing with our AMIgo bakes. 

The old method installed the 'current' (i.e. latest) version of Node _and_ the latest version of Node under long-term-support. [Recently, the 'current' version of Node has changed to Node 18](https://nodejs.org/en/about/releases/):

![image](https://user-images.githubusercontent.com/19384074/168596036-c523e3a2-44f9-418f-8409-1e4945bfe51d.png)

The fact that we are now trying to install Node 18 seems to have caused the breakage with baking AMIs - see [this similar issue](https://community.cloudflare.com/t/pages-build-failed-when-using-node-18-due-to-missing-glibc/379201/2). This non-deterministic approach can be a bit confusing; the AMIgo bakes just 'started failing', even though we didn't change anything deliberately on our side.

As a result, we now explicitly install Node 16 as the default version. 

*We know that this version works with our builds and there are a few confusing factors at play here, so we're trying to eliminate some variables - we should update it later (via a separate PR)

## How to test

We have:

* [Deployed this change to `CODE`](https://riffraff.gutools.co.uk/deployment/view/521810e4-b287-4e93-9f67-45e2ecd6fe96)
* [Baked a test AMI](https://amigo.code.dev-gutools.co.uk/recipes/teamcity-agent-test/bakes/103)
* [Set up a separate agent with this AMI](https://teamcity.gutools.co.uk/admin/settingsDiffView.html?id=project:_Root&versionBefore=521&versionAfter=522&actionId=99412), as per the [testing instructions](https://github.com/guardian/deploy-tools-platform/blob/main/docs/testing-teamcity-agent-amis.md).
* [Run a test build](https://teamcity.gutools.co.uk/buildConfiguration/Tools_TeamcityNvmDebug/769912?buildTab=log&logView=flowAware&linesState=101&focusLine=0) ✅ 

## How can we measure success?

* Bakes should start working again, so we can pick up OS updates (and meet our SLO!)
* Builds should continue working as normal

## Have we considered potential risks?

This should be pretty low risk; we have manually rolled back to an old AMI already, so none of our active agents are using the newer version of `nvm` anyway.

We expect most builds to be specifying their own Node version (via `.nvmrc` or similar) anyway, so I don't think that hardcoding the default version here matters too much.