### PR TITLE
docs: Update `cdk-base` permissions

### DIFF
--- a/roles/cdk-base/README.md
+++ b/roles/cdk-base/README.md
@@ -42,7 +42,6 @@ Resources:
 EC2 instances must have the following IAM permissions:
 - `kinesis:DescribeStream` scoped to the Kinesis stream above
 - `kinesis:PutRecord` scoped to the Kinesis stream above
-- `autoscaling:DescribeAutoScalingInstances`
 - `ec2:DescribeTags`
 - `ec2:DescribeInstances`
 
@@ -83,7 +82,6 @@ Resources:
         - Effect: Allow
           Resource: '*'
           Action:
-          - autoscaling:DescribeAutoScalingInstances
           - ec2:DescribeTags
           - ec2:DescribeInstances
   InstanceProfile:


### PR DESCRIPTION
An update on #735 as I missed the review comment.

The `autoscaling:DescribeAutoScalingInstances` permission is not needed by `cdk-base`.

See https://github.com/guardian/amigo/pull/735#pullrequestreview-982786995.