### PR TITLE
Upgrade wazuh-agent to v4.3.1-1

### DIFF
--- a/roles/wazuh-agent/defaults/main.yml
+++ b/roles/wazuh-agent/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 stage: PROD
-agent_version: 4.1.5-1
+agent_version: 4.3.1-1

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -120,11 +120,15 @@
       fi
 
 
-- name: Patch wazuh-agent service to call boot script before starting agent
+- name: Patch wazuh-agent service to call boot script before starting agent and restart on failure
   lineinfile:
-    path: /usr/lib/systemd/system/wazuh-agent.service
+    path: /etc/systemd/system/wazuh-agent.service
     insertbefore: '^ExecStart'
-    line: ExecStartPre=/usr/local/bin/authenticate-with-wazuh-manager.sh
+    line: "{{ item }}"
+  with_items:
+    - "ExecStartPre=/usr/local/bin/authenticate-with-wazuh-manager.sh"
+    - "Restart=on-failure"
+    - "RestartSec=120s"
 
 - name: Enable wazuh-agent service
   service:

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -122,7 +122,7 @@
 
 - name: Patch wazuh-agent service to call boot script before starting agent and restart on failure
   lineinfile:
-    path: /etc/systemd/system/wazuh-agent.service
+    path: /lib/systemd/system/wazuh-agent.service
     insertbefore: '^ExecStart'
     line: "{{ item }}"
   with_items:

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -122,7 +122,7 @@
 
 - name: Patch wazuh-agent service to call boot script before starting agent
   lineinfile:
-    path: /etc/systemd/system/wazuh-agent.service
+    path: /usr/lib/systemd/system/wazuh-agent.service
     insertbefore: '^ExecStart'
     line: ExecStartPre=/usr/local/bin/authenticate-with-wazuh-manager.sh
 

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -128,7 +128,7 @@
   with_items:
     - "ExecStartPre=/usr/local/bin/authenticate-with-wazuh-manager.sh"
     - "Restart=on-failure"
-    - "RestartSec=120s"
+    - "RestartSec=300s"
 
 - name: Enable wazuh-agent service
   service:


### PR DESCRIPTION
## What does this change?

This PR changes the role defaults for the wazuh-agent roles, changing the agent_version parameter from 4.1.5-1 to 4.3.1-1. Future wazuh-agents will be installed with the newer version. 

Restart behaviour was also added to make agents capable of registration if registration fails during initial startup. The impact of this is very low, with a frequency of 5 minutes. 

## How to test

- [x] Deploy to AMIgo-CODE and check recipes build
- [x] Check wazuh-agent is v4.3.1-1
- [x] Check wazuh-agent is still able to register with coordinator

## Have we considered potential risks?

Wazuh-agent is installed on every build, so we should make sure this won't introduce any build failures, agent registration failures, or other instability. 

The impact of restarting the service was tested on a micro instance. Without a registration with the wazuh manager, it's extremely minimal, and once registered the service will not restart. 