### PR TITLE
Wazuh-agent role systemd service file fix

### DIFF
--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -120,15 +120,10 @@
       fi
 
 
-- name: Patch wazuh-agent service to call boot script before starting agent and restart on failure
-  lineinfile:
-    path: /lib/systemd/system/wazuh-agent.service
-    insertbefore: '^ExecStart'
-    line: "{{ item }}"
-  with_items:
-    - "ExecStartPre=/usr/local/bin/authenticate-with-wazuh-manager.sh"
-    - "Restart=on-failure"
-    - "RestartSec=300s"
+- name: Template wazuh-agent systemd service file
+  template:
+    src: templates/wazuh-agent.service.template
+    dest: /etc/systemd/system/wazuh-agent.service
 
 - name: Enable wazuh-agent service
   service:

--- a/roles/wazuh-agent/templates/wazuh-agent.service.template
+++ b/roles/wazuh-agent/templates/wazuh-agent.service.template
@@ -1,0 +1,21 @@
+[Unit]
+Description=Wazuh agent
+Wants=network-online.target
+After=network.target network-online.target
+
+[Service]
+Type=forking
+
+ExecStartPre=/usr/local/bin/authenticate-with-wazuh-manager.sh
+ExecStart=/usr/bin/env /var/ossec/bin/wazuh-control start
+ExecStop=/usr/bin/env /var/ossec/bin/wazuh-control stop
+ExecReload=/usr/bin/env /var/ossec/bin/wazuh-control reload
+
+Restart=on-failure
+RestartSec=300s
+
+KillMode=none
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## What does this change?

#737 introduced an issue where recipes failed to bake, as the path to the systemd service file was incorrect. This was changed between v4.1.5 and v4.3.1. In order for agents to register with the wazuh coordinator, the authentication script should be run before the service starts, which is achieved by inserting "ExecStartPre=/usr/local/bin/authenticate-with-wazuh-manager.sh" into the [Service] section of the service file. 

Previously we inserted a single line into the service file contained in the package. Now, instead of relying on the package version, a new systemd service file will be templated in /etc/systemd/system/wazuh-agent.service.

## How to test

- [x] Deploy on CODE and check builds are successful 

## How can we measure success?

Builds no longer fail due to wazuh-agent lineinfile task not finding a file to edit at /lib/systemd/system/wazuh-agent.service.  


