### PR TITLE
Don't run Snyk on granular dependency update PRs

### DIFF
--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -6,7 +6,9 @@ on:
   push:
     branches:
       - main
-  pull_request:    
+  pull_request:   
+    branches-ignore:
+      - dependency-updates
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What does this change?
Avoids running unnecessary actions on PRs targeting the `dependency-updates` branch, which are intended to be reviewed/tested after being batched as a single PR targeting `main`.