### PR TITLE
chore: Update dependency update batching workflow to latest

### DIFF
--- a/.github/workflows/dep-updates_pr-tracking-branch-to-default.yml
+++ b/.github/workflows/dep-updates_pr-tracking-branch-to-default.yml
@@ -1,0 +1,12 @@
+name: Create batch dependency update PR
+
+on:
+  schedule:
+    - cron: "35 10 * * MON"
+  # Provide support for manually triggering the workflow via GitHub.
+  workflow_dispatch:
+
+jobs:
+  pr-tracking-branch:
+    name: Open a PR from dependency-updates targeting main
+    uses: guardian/.github/.github/workflows/pr-batching_pr-tracking-branch-to-default.yml@v1.0.1

--- a/.github/workflows/dep-updates_set-automerge.yml
+++ b/.github/workflows/dep-updates_set-automerge.yml
@@ -1,0 +1,11 @@
+name: Set automerge on dependency update PRs
+
+on:
+  pull_request:
+    branches:
+      - dependency-updates
+
+jobs:
+  set-automerge:
+    name: Set automerge on opened PRs targeting the tracking branch
+    uses: guardian/.github/.github/workflows/pr-batching_set-automerge.yml@v1.0.1

--- a/.github/workflows/dep-updates_tracking-branch.yml
+++ b/.github/workflows/dep-updates_tracking-branch.yml
@@ -1,0 +1,11 @@
+name: Maintain dependency update batching branch
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-dependency-update-branch:
+    name: Keep tracking branch up to date with main
+    uses: guardian/.github/.github/workflows/pr-batching_tracking-branch.yml@v1.0.1


### PR DESCRIPTION
Updates our versions of the dependency-update-batching reusable workflows to v1.0.1, which bring in some small adjustments for reliability. In particular, the workflows should support squash-merging the batched PR, and auto-merging the granular PRs when rebase isn't available.