### PR TITLE
Attempt (crude) fix of bake deletion housekeeping job

### DIFF
--- a/app/data/Bakes.scala
+++ b/app/data/Bakes.scala
@@ -94,9 +94,14 @@ object Bakes extends Loggable {
       .exec()
   }
 
-  def findDeleted(limit: Int = 10)(implicit dynamo: Dynamo): List[Bake.DbModel] = {
+  def findDeleted(limit: Int = 1000)(implicit dynamo: Dynamo): List[Bake.DbModel] = {
     val res = table
       .filter("deleted" === true)
+
+      // Note, this is a Dynamo limit so it doesn't do what you think!
+      // See:
+      // * https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Limit
+      // * https://github.com/scanamo/scanamo/pull/996 (possible source of break when Scanamo was updated)
       .limit(limit)
       .scan()
       .exec()


### PR DESCRIPTION
My guess is that the behaviour of 'limit' changed when Scanamo was updated at the end of March 2022 - a timeframe that corresponds to when we start seeing this fail.

It looks like Scanamo 'fixed' its behaviour to match what 'limit' means in Dynamo parlance. For more info, see:

- https://github.com/scanamo/scanamo/pull/996
- https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Limit

Note, this is more to confirm the source of the issue for now. A better long-term fix is to create a secondary index on the deleted field and then query against that to avoid the scans here.