### PR TITLE
Add secondary index for 'deleted' to avoid scanning

### DIFF
--- a/app/data/Bakes.scala
+++ b/app/data/Bakes.scala
@@ -94,16 +94,11 @@ object Bakes extends Loggable {
       .exec()
   }
 
-  def findDeleted(limit: Int = 1000)(implicit dynamo: Dynamo): List[Bake.DbModel] = {
+  def findDeleted(limit: Int = 10)(implicit dynamo: Dynamo): List[Bake.DbModel] = {
     val res = table
-      .filter("deleted" === true)
-
-      // Note, this is a Dynamo limit so it doesn't do what you think!
-      // See:
-      // * https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Limit
-      // * https://github.com/scanamo/scanamo/pull/996 (possible source of break when Scanamo was updated)
-      .limit(limit)
-      .scan()
+      .index("DeletedIndex")
+      .limit(10)
+      .query("deleted" === true)
       .exec()
 
     res.foreach {

--- a/app/data/Dynamo.scala
+++ b/app/data/Dynamo.scala
@@ -66,7 +66,14 @@ class Dynamo(val client: DynamoDbClient, stage: String) extends Loggable {
         .attributeDefinitions(generateAttributeDefinition("recipeId", ScalarAttributeType.S), generateAttributeDefinition("buildNumber", ScalarAttributeType.N))
         .tableName(tableName("bakes"))
         .provisionedThroughput(generateProvisionedThroughtput(1L, 1L))
-        .build())
+        .globalSecondaryIndexes(
+          GlobalSecondaryIndex.builder()
+            .indexName("DeletedIndex")
+            .keySchema(generateKeySchemaElement("deleted", KeyType.HASH))
+            .projection(Projection.builder().projectionType("ALL").build())
+            .provisionedThroughput(generateProvisionedThroughtput(1L, 1L))
+            .build()
+        ).build())
 
     val bakeLogs = table[BakeLog](
       CreateTableRequest.builder()


### PR DESCRIPTION
**Update: this doesn't work as boolean attributes cannot be used as partition keys :(. **

**TODO: test on CODE.**

Scanning for deleted items requires a table scan and has been the source of a recent subtle bug:

https://github.com/guardian/amigo/pull/846

This commit adds a secondary index for deleted so that it becomes easy to query for where deleted=true.

Note, we will need to add the index manually as the existing code only creates the table (and any indexes) if it does not yet exist.

The estimated cost for the secondary index is < $1/month so negligable.