### PR TITLE
Remove limit from delete query

### DIFF
--- a/app/data/Bakes.scala
+++ b/app/data/Bakes.scala
@@ -94,15 +94,9 @@ object Bakes extends Loggable {
       .exec()
   }
 
-  def findDeleted(limit: Int = 1000)(implicit dynamo: Dynamo): List[Bake.DbModel] = {
+  def findDeleted()(implicit dynamo: Dynamo): List[Bake.DbModel] = {
     val res = table
       .filter("deleted" === true)
-
-      // Note, this is a Dynamo limit so it doesn't do what you think!
-      // See:
-      // * https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Limit
-      // * https://github.com/scanamo/scanamo/pull/996 (possible source of break when Scanamo was updated)
-      .limit(limit)
       .scan()
       .exec()
 


### PR DESCRIPTION
The Ops team recently observed a significant increase in AWS spend, which Cost Explorer analysis narrowed down to increased EBS usage.

The cause was an Amigo bug, following a Scanamo (Dynamodb client library) upgrade, which prevented the EBS cleanup job from running successfully.

An initial fix can be found here: https://github.com/guardian/amigo/pull/846.

This PR tweaks the fix to remove the limit entirely. This ensures the job does not miss any EBS volumes that should be deleted.  Specifically, it removes the 'limit' on the delete query to ensure we return and process all deleted bakes. The downside to this fix is that our processing job is unbounded, but in practice AMI numbers are low (100s not 1000s) so this shouldn't be a problem - though the initial deploy might cause an initial larger cleanup.

Note, the job itself does not delete the volumes but sends a notification to housekeeping lambdas, which run in our AWS accounts, to do this work.

A fuller explanation of the precise issue is provided below...

---

Initial cause: Scanamo's 'limit' behaviour changed to more closely match Dynamo's own limit behaviour. Typically in relational database, 'limit' is applied to the result set *after* any queries or filters are applied. However, Dynamo applies limits before filters.

This can result in some items with delete=true never being processed.

E.g. with a scan and:

filter: deleted=true
limit: 10

Imagine there are 11 items in the table and only one has deleted set to true. Our scan is limited to 10 items by the limit, and only *then* is the filter applied. If the item with delete=true is never retrieved in the initial 10 it will be ignored forever!

## Why not use a query instead?

Scans in Dynamo are not that desirable; queries are more efficient when retrieving a subset of records. The standard way therefore to do things would be to create a global secondary index and use `deleted` as the sort key. However, partition keys (hash, sort) cannot be of the boolean type. We could change the data model here but that would be a much larger PR. 

Other approaches exist, such as sparse indexes (see e.g. [here](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-indexes-general-sparse-indexes.html)) but they also require larger data model changes.