### PR TITLE
Fix for hardened logrotate setup

### DIFF
--- a/roles/kong-v1_5/files/kong.logrotate
+++ b/roles/kong-v1_5/files/kong.logrotate
@@ -5,6 +5,7 @@
 	rotate 4
 	compress
 	delaycompress
+	copytruncate
 	notifempty
 	nocreate
 	postrotate

--- a/roles/kong-v1_5/tasks/main.yml
+++ b/roles/kong-v1_5/tasks/main.yml
@@ -19,6 +19,9 @@
 - name: Configure Kong log rotation
   copy: src=kong.logrotate dest=/etc/logrotate.d/kong
 
+- name: Configure logrotate access permissions
+  lineinfile: dest=/lib/systemd/system/logrotate.service line=ReadWritePaths=/usr/local/kong/logs
+
 - name: Create /usr/local/kong directory
   file: path=/usr/local/kong state=directory
 


### PR DESCRIPTION
## What does this change?

Ubuntu 20.04 hardens the logrotate setup, preventing it from writing to most system locations. Unfortuntely, Kong keeps its logs under /usr/local/kong/logs so this must be explicitly allowed in the unit file.

## How to test

Build on CODE and check that the files have the right contents (the `ReadWritePaths` should be added to `logrotate.service`).  Leave it overnight to check that the log files do, in fact, rotate correctly

## How can we measure success?

Reliable log warehousing from Kong

## Have we considered potential risks?

n/a

