### PR TITLE
Bump to Scala 2.13.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ import scalariform.formatter.preferences._
 
 name := "amigo"
 version := "1.0-latest"
-scalaVersion := "2.13.9"
+scalaVersion := "2.13.10"
 
 Universal / javaOptions ++= Seq(
   s"-Dpidfile.path=/dev/null",
@@ -108,7 +108,7 @@ routesImport += "models._"
 lazy val imageCopier = (project in file("imageCopier"))
     .enablePlugins(JavaAppPackaging)
   .settings(
-    scalaVersion := "2.13.9",
+    scalaVersion := "2.13.10",
     Universal / topLevelDirectory := None,
     Universal / packageName := normalizedName.value,
     libraryDependencies ++= Seq(


### PR DESCRIPTION
To address https://github.com/scala/bug/issues/12650 (though no specific evidence this project is vulnerable) and also test out Nori for a wider bump across repos.