### PR TITLE
Remove explicit bucket name

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -6,7 +6,6 @@ deployments:
   amigo:
     type: autoscaling
     parameters:
-      bucket: deploy-tools-dist
     dependencies:
       - cloudformation
   cloudformation:
@@ -25,6 +24,5 @@ deployments:
   imagecopier:
     type: aws-s3
     parameters:
-      bucket: deploy-tools-dist
       cacheControl: public, max-age=600
       publicReadAcl: false


### PR DESCRIPTION
## What does this change?

It's no longer needed and this will remove the riff-raff warning.

<img width="1180" alt="Screenshot 2022-10-25 at 12 40 12" src="https://user-images.githubusercontent.com/953792/197764055-1af23e78-dfc7-4701-8acd-c521772e98a6.png">
