### PR TITLE
Add the bucket param for imagecopier deployment

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -24,5 +24,6 @@ deployments:
   imagecopier:
     type: aws-s3
     parameters:
+      bucket: deploy-tools-dist
       cacheControl: public, max-age=600
       publicReadAcl: false


### PR DESCRIPTION
## What does this change?

**This fixes the currently broken PROD deployment.**

The `aws-s3` deployment type which does not auto-lookup the bucket value in SSM, a previous change (https://github.com/guardian/amigo/pull/8790) removed the explicit. bucket name, this re-adds it to fix the issue.

This has been [tested in CODE](https://riffraff.gutools.co.uk/deployment/view/dc3aa1d5-1e9d-4acd-829c-4c78293259bf).