### PR TITLE
Fix to allow Scala Steward to monitor dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,6 +105,14 @@ libraryDependencies ++= Seq(
 routesGenerator := InjectedRoutesGenerator
 routesImport += "models._"
 
+/*
+ * This is required for Scala Steward to run until SBT plugins all migrated to scala-xml 2.
+ * See https://github.com/scala-steward-org/scala-steward/blob/13d63e8ae98a714efcdac2c7af18f004130512fa/project/plugins.sbt#L16-L19
+ */
+libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+)
+
 lazy val imageCopier = (project in file("imageCopier"))
     .enablePlugins(JavaAppPackaging)
   .settings(


### PR DESCRIPTION
Recent Scala Steward runs have been failing because of incompatibilities between versions of scala-xml.

Eg. https://github.com/guardian/scala-steward-public-repos/actions/runs/3378212621/jobs/5608120855#step:5:140
![image](https://user-images.githubusercontent.com/1722550/199519474-721f32d1-53cd-469a-9824-ec8908fc6b6d.png)

