### PR TITLE
Change kong log purging frequency to hourly

### DIFF
--- a/roles/kong-v1_5/files/kong.logrotate
+++ b/roles/kong-v1_5/files/kong.logrotate
@@ -1,5 +1,5 @@
 /usr/local/kong/logs/*.log {
-	daily
+	hourly
 	size 100M
 	missingok
 	rotate 4

--- a/roles/kong-v1_5/tasks/main.yml
+++ b/roles/kong-v1_5/tasks/main.yml
@@ -49,3 +49,15 @@
 - name: Install truncation script crontab
   cron: name="truncate ratelimiting_metrics table" minute=0 hour=*/2
         user={{kong_user}} job="/usr/local/kong/truncate-ratelimiting_metrics.sh"
+
+- name: Update logrotate master timer frequency
+  lineinfile:
+    dest: /lib/systemd/system/logrotate.timer
+    regexp: OnCalendar=(.*)$
+    line: OnCalendar=hourly
+
+- name: Update logrotate master timer window
+  lineinfile:
+    dest: /lib/systemd/system/logrotate.timer
+    regexp: AccuracySec=(.*)$
+    line: AccuracySec=5m


### PR DESCRIPTION
## What does this change?

- Update the Kong role to make logrotate run hourly (within a +/- 5min window)
- Update the Kong logrotate rule to also run hourly

This is to alleviate a problem which we believe occurred due to disk pressure on the node. Since Kong is 3rd party software, we cannot directly push logs to Elasticsearch and must read them from disk via Logstash.

## How to test

Check that the build works. Once you have a build, check that the logrotate process is still set up correctly and is now running every hour, round about `:00` minutes.

## How can we measure success?

Improved Kong reliability

## Have we considered potential risks?

This simply modifies existing configurations for logrotate and the resulting configuration has been independently tested to work.  This makes "official" a temporary fix which was put into Kong earlier (https://github.com/guardian/content-api/pull/2714)
