### PR TITLE
Upgrade packer to latest

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -334,7 +334,7 @@ Object {
               "",
               Array [
                 "#!/bin/bash -ev
-wget -P /tmp https://releases.hashicorp.com/packer/1.8.4/packer_1.8.4_linux_arm64.zip
+wget -P /tmp https://releases.hashicorp.com/packer/1.8.5/packer_1.8.5_linux_arm64.zip
 mkdir /opt/packer
 unzip -d /opt/packer /tmp/packer_*_linux_arm64.zip
 echo 'export PATH=\${!PATH}:/opt/packer' > /etc/profile.d/packer.sh

--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -334,7 +334,7 @@ Object {
               "",
               Array [
                 "#!/bin/bash -ev
-wget -P /tmp https://releases.hashicorp.com/packer/1.6.6/packer_1.6.6_linux_arm64.zip
+wget -P /tmp https://releases.hashicorp.com/packer/1.8.4/packer_1.8.4_linux_arm64.zip
 mkdir /opt/packer
 unzip -d /opt/packer /tmp/packer_*_linux_arm64.zip
 echo 'export PATH=\${!PATH}:/opt/packer' > /etc/profile.d/packer.sh

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -19,7 +19,7 @@ import { ListenerAction, UnauthenticatedAction } from "aws-cdk-lib/aws-elasticlo
 import { Effect, Policy, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import type { Bucket } from "aws-cdk-lib/aws-s3";
 
-const packerVersion = "1.6.6";
+const packerVersion = "1.8.4";
 
 export interface AmigoProps extends GuStackProps {
   domainName: string;
@@ -222,7 +222,7 @@ export class AmigoStack extends GuStack {
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
       userData: [
         "#!/bin/bash -ev",
-        `wget -P /tmp https://releases.hashicorp.com/packer/${packerVersion}/packer_1.6.6_linux_arm64.zip`,
+        `wget -P /tmp https://releases.hashicorp.com/packer/${packerVersion}/packer_${packerVersion}_linux_arm64.zip`,
         "mkdir /opt/packer",
         "unzip -d /opt/packer /tmp/packer_*_linux_arm64.zip",
         "echo 'export PATH=${!PATH}:/opt/packer' > /etc/profile.d/packer.sh",

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -19,7 +19,7 @@ import { ListenerAction, UnauthenticatedAction } from "aws-cdk-lib/aws-elasticlo
 import { Effect, Policy, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import type { Bucket } from "aws-cdk-lib/aws-s3";
 
-const packerVersion = "1.8.4";
+const packerVersion = "1.8.5";
 
 export interface AmigoProps extends GuStackProps {
   domainName: string;


### PR DESCRIPTION
## What does this change?

Upgrade to v1.8.5. Older versions were running afoul of https://github.com/hashicorp/packer/issues/11733 when building images for ubuntu 22.04, eg. https://amigo.gutools.co.uk/recipes/editorial-tools-jammy-java8/bakes/1

This upgrade changed the default location Packer used for its cache directory. Instead of `${PWD}/.packer_cache` it switched to using `${HOME}/.cache/packer`. This shouldn't really have been a problem except that for reasons lost to history the AMIgo box specifies `/home/amigo` as home in `/etc/passwd` but this does not exist and packer was unable to create it.

We fix this by setting `$PACKER_CACHE_DIR` when executing packer and using isolated temp directories which are cleaned up along with the config and ansible files.

## How to test

 - [x] Baking a 22.04 image succeeds in CODE.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Teams can move to the latest Ubuntu LTS.
