### PR TITLE
Add Google Auth

### DIFF
--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -5,15 +5,22 @@ import play.api.libs.ws.WSClient
 import play.api.mvc._
 
 import scala.concurrent.ExecutionContext
+import com.gu.googleauth.GoogleGroupChecker
 
-class Login(val authConfig: GoogleAuthConfig, override val wsClient: WSClient, components: ControllerComponents)(implicit executionContext: ExecutionContext) extends AbstractController(components) with LoginSupport {
+class Login(
+  val authConfig: GoogleAuthConfig,
+  override val wsClient: WSClient,
+  components: ControllerComponents,
+  requiredGoogleGroups: Set[String],
+  groupChecker: GoogleGroupChecker,
+)(implicit executionContext: ExecutionContext) extends AbstractController(components) with LoginSupport {
 
   def loginAction = Action.async { implicit request =>
     startGoogleLogin()
   }
 
   def oauth2Callback = Action.async { implicit request =>
-    processOauth2Callback()
+    processOauth2Callback(requiredGoogleGroups, groupChecker)
   }
 
   override val failureRedirectTarget: Call = routes.Login.loginAction()

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,8 @@
 import com.gu.riffraff.artifact.BuildInfo
-import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import com.typesafe.sbt.packager.archetypes.systemloader.ServerLoader.Systemd
 
 import java.time.format.DateTimeFormatter
 import java.time.{ ZoneId, ZonedDateTime }
-import scalariform.formatter.preferences._
 
 name := "amigo"
 version := "1.0-latest"

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -14,7 +14,7 @@ const stageAgnosticProps = {
 const amigoCodeProps: AmigoProps = {
   ...stageAgnosticProps,
   stage: "CODE",
-  domainName: "amigo.code.dev-gutools.co.uk",
+  domainName: "public.amigo.code.dev-gutools.co.uk",
 };
 
 new AmigoStack(app, "AMIgo-CODE", amigoCodeProps);
@@ -22,7 +22,7 @@ new AmigoStack(app, "AMIgo-CODE", amigoCodeProps);
 export const amigoProdProps: AmigoProps = {
   ...stageAgnosticProps,
   stage: "PROD",
-  domainName: "amigo.gutools.co.uk",
+  domainName: "public.amigo.gutools.co.uk",
 };
 
 new AmigoStack(app, "AMIgo-PROD", amigoProdProps);

--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -93,7 +93,7 @@ Object {
   "Resources": Object {
     "AmigoCname": Object {
       "Properties": Object {
-        "Name": "amigo.gutools.co.uk",
+        "Name": "public.amigo.gutools.co.uk",
         "RecordType": "CNAME",
         "ResourceRecords": Array [
           Object {
@@ -341,6 +341,12 @@ unzip -d /opt/packer /tmp/packer_*_linux_arm64.zip
 echo 'export PATH=\${!PATH}:/opt/packer' > /etc/profile.d/packer.sh
 wget -P /tmp https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_arm64/session-manager-plugin.deb
 dpkg -i /tmp/session-manager-plugin.deb
+mkdir /amigo
+aws --region eu-west-1 s3 cp s3://",
+                Object {
+                  "Ref": "DistributionBucketName",
+                },
+                "/deploy/PROD/amigo/conf/amigo-service-account-cert.json /amigo/
 aws --region eu-west-1 s3 cp s3://",
                 Object {
                   "Ref": "DistributionBucketName",
@@ -357,7 +363,7 @@ dpkg -i /tmp/amigo.deb",
     "CertificateAmigoE1AF5E0C": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
-        "DomainName": "amigo.gutools.co.uk",
+        "DomainName": "public.amigo.gutools.co.uk",
         "Tags": Array [
           Object {
             "Key": "App",

--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -30,6 +30,8 @@ Object {
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuSecurityGroup",
+      "GuHttpsEgressSecurityGroup",
+      "GuStringParameter",
     ],
     "gu:cdk:version": "47.3.0",
   },
@@ -53,6 +55,10 @@ Object {
       "Default": "/account/services/anghammarad.topic.arn",
       "Description": "SSM parameter containing the ARN of the Anghammarad SNS topic",
       "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "ClientId": Object {
+      "Description": "Google OAuth client ID",
+      "Type": "String",
     },
     "DistributionBucketName": Object {
       "Default": "/account/services/artifact.bucket",
@@ -500,6 +506,27 @@ dpkg -i /tmp/amigo.deb",
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
+    "GuHttpsEgressSecurityGroupAmigofromAMIgoIdpaccessAmigo4AAB847A9000B7BF2D1B": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupAmigo28861996",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "IdpaccessAmigo3AA037D6",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
     "GuHttpsEgressSecurityGroupAmigofromAMIgoLoadBalancerAmigoSecurityGroup730D090E90006200512B": Object {
       "Properties": Object {
         "Description": "Load balancer to target",
@@ -584,6 +611,67 @@ dpkg -i /tmp/amigo.deb",
       },
       "Type": "AWS::IAM::Policy",
     },
+    "IdpaccessAmigo3AA037D6": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "amigo",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/amigo",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "IdpaccessAmigotoAMIgoGuHttpsEgressSecurityGroupAmigo34A5A8389000691E1B98": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupAmigo28861996",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "IdpaccessAmigo3AA037D6",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "InstanceRoleAmigo75944747": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
@@ -645,6 +733,26 @@ dpkg -i /tmp/amigo.deb",
         ],
         "DefaultActions": Array [
           Object {
+            "AuthenticateOidcConfig": Object {
+              "AuthenticationRequestExtraParams": Object {
+                "hd": "guardian.co.uk",
+              },
+              "AuthorizationEndpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+              "ClientId": Object {
+                "Ref": "ClientId",
+              },
+              "ClientSecret": "{{resolve:secretsmanager:/PROD/deploy/amigo/client-secret:SecretString:::}}",
+              "Issuer": "https://accounts.google.com",
+              "OnUnauthenticatedRequest": "authenticate",
+              "Scope": "openid",
+              "TokenEndpoint": "https://oauth2.googleapis.com/token",
+              "UserInfoEndpoint": "https://openidconnect.googleapis.com/v1/userinfo",
+            },
+            "Order": 1,
+            "Type": "authenticate-oidc",
+          },
+          Object {
+            "Order": 2,
             "TargetGroupArn": Object {
               "Ref": "TargetGroupAmigoB9501F07",
             },
@@ -678,6 +786,12 @@ dpkg -i /tmp/amigo.deb",
           Object {
             "Fn::GetAtt": Array [
               "RestrictedIngressSecurityGroupAmigoF34D371D",
+              "GroupId",
+            ],
+          },
+          Object {
+            "Fn::GetAtt": Array [
+              "IdpaccessAmigo3AA037D6",
               "GroupId",
             ],
           },

--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -506,7 +506,7 @@ dpkg -i /tmp/amigo.deb",
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "GuHttpsEgressSecurityGroupAmigofromAMIgoIdpaccessAmigo4AAB847A9000B7BF2D1B": Object {
+    "GuHttpsEgressSecurityGroupAmigofromAMIgoIdPaccessAmigo4AE1B4709000BF8805C1": Object {
       "Properties": Object {
         "Description": "Load balancer to target",
         "FromPort": 9000,
@@ -519,7 +519,7 @@ dpkg -i /tmp/amigo.deb",
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "IdpaccessAmigo3AA037D6",
+            "IdPaccessAmigo15F4FC41",
             "GroupId",
           ],
         },
@@ -611,7 +611,7 @@ dpkg -i /tmp/amigo.deb",
       },
       "Type": "AWS::IAM::Policy",
     },
-    "IdpaccessAmigo3AA037D6": Object {
+    "IdPaccessAmigo15F4FC41": Object {
       "Properties": Object {
         "GroupDescription": "Allow all outbound HTTPS traffic",
         "SecurityGroupEgress": Array [
@@ -651,7 +651,7 @@ dpkg -i /tmp/amigo.deb",
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "IdpaccessAmigotoAMIgoGuHttpsEgressSecurityGroupAmigo34A5A8389000691E1B98": Object {
+    "IdPaccessAmigotoAMIgoGuHttpsEgressSecurityGroupAmigo34A5A83890007FBC5E83": Object {
       "Properties": Object {
         "Description": "Load balancer to target",
         "DestinationSecurityGroupId": Object {
@@ -663,7 +663,7 @@ dpkg -i /tmp/amigo.deb",
         "FromPort": 9000,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "IdpaccessAmigo3AA037D6",
+            "IdPaccessAmigo15F4FC41",
             "GroupId",
           ],
         },
@@ -741,7 +741,7 @@ dpkg -i /tmp/amigo.deb",
               "ClientId": Object {
                 "Ref": "ClientId",
               },
-              "ClientSecret": "{{resolve:secretsmanager:/PROD/deploy/amigo/client-secret:SecretString:::}}",
+              "ClientSecret": "{{resolve:secretsmanager:/PROD/deploy/amigo/clientSecret:SecretString:::}}",
               "Issuer": "https://accounts.google.com",
               "OnUnauthenticatedRequest": "authenticate",
               "Scope": "openid",
@@ -791,7 +791,7 @@ dpkg -i /tmp/amigo.deb",
           },
           Object {
             "Fn::GetAtt": Array [
-              "IdpaccessAmigo3AA037D6",
+              "IdPaccessAmigo15F4FC41",
               "GroupId",
             ],
           },

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -3,7 +3,7 @@ import { AccessScope } from "@guardian/cdk/lib/constants";
 import type { AppIdentity, GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuDistributionBucketParameter, GuStack, GuStringParameter } from "@guardian/cdk/lib/constructs/core";
 import { GuCname } from "@guardian/cdk/lib/constructs/dns";
-import {GuHttpsEgressSecurityGroup, GuSecurityGroup, GuVpc} from "@guardian/cdk/lib/constructs/ec2";
+import { GuHttpsEgressSecurityGroup, GuSecurityGroup, GuVpc } from "@guardian/cdk/lib/constructs/ec2";
 import {
   GuAllowPolicy,
   GuAnghammaradSenderPolicy,
@@ -12,12 +12,12 @@ import {
   GuSSMRunCommandPolicy,
 } from "@guardian/cdk/lib/constructs/iam";
 import { GuS3Bucket } from "@guardian/cdk/lib/constructs/s3";
-import {Duration, SecretValue} from "aws-cdk-lib";
+import { Duration, SecretValue } from "aws-cdk-lib";
 import type { App } from "aws-cdk-lib";
 import { InstanceClass, InstanceSize, InstanceType, Peer, Port } from "aws-cdk-lib/aws-ec2";
+import { ListenerAction, UnauthenticatedAction } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { Effect, Policy, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import type { Bucket } from "aws-cdk-lib/aws-s3";
-import {ListenerAction, UnauthenticatedAction} from "aws-cdk-lib/aws-elasticloadbalancingv2";
 
 const packerVersion = "1.6.6";
 
@@ -256,18 +256,19 @@ export class AmigoStack extends GuStack {
       resourceRecord: guPlayApp.loadBalancer.loadBalancerDnsName,
     });
 
-    const securityGroup = new GuHttpsEgressSecurityGroup(this, "Idp-access", {
+    // Ensure LB can egress to 443 (for Google endpoints) for OIDC flow.
+    const albEgressSg = new GuHttpsEgressSecurityGroup(this, "IdP-access", {
       app: AmigoStack.app.app,
       vpc: guPlayApp.vpc,
     });
 
-    guPlayApp.loadBalancer.addSecurityGroup(securityGroup);
+    guPlayApp.loadBalancer.addSecurityGroup(albEgressSg);
 
     const clientId = new GuStringParameter(this, "ClientId", {
       description: "Google OAuth client ID",
     });
 
-    guPlayApp.listener.addAction("DefaultAction", {
+    guPlayApp.listener.addAction("Google Auth", {
       action: ListenerAction.authenticateOidc({
         authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
         issuer: "https://accounts.google.com",
@@ -279,9 +280,7 @@ export class AmigoStack extends GuStack {
 
         userInfoEndpoint: "https://openidconnect.googleapis.com/v1/userinfo",
         clientId: clientId.valueAsString,
-        clientSecret: SecretValue.secretsManager(
-          `/${this.stage}/deploy/amigo/client-secret`
-        ),
+        clientSecret: SecretValue.secretsManager(`/${this.stage}/deploy/amigo/clientSecret`),
         next: ListenerAction.forward([guPlayApp.targetGroup]),
       }),
     });

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -213,13 +213,9 @@ export class AmigoStack extends GuStack {
         "Keeping the same resource for simplicity. We would otherwise have to update the stack when there are no ongoing bakes, i.e. when the security group isn't in use.",
     });
 
-    const artifactPath = [
-      GuDistributionBucketParameter.getInstance(this).valueAsString,
-      this.stack,
-      this.stage,
-      AmigoStack.app.app,
-      "amigo_1.0-latest_all.deb",
-    ].join("/");
+    const distBucket = GuDistributionBucketParameter.getInstance(this).valueAsString;
+
+    const artifactPath = [distBucket, this.stack, this.stage, AmigoStack.app.app, "amigo_1.0-latest_all.deb"].join("/");
 
     const guPlayApp = new GuPlayApp(this, {
       ...AmigoStack.app,
@@ -232,6 +228,10 @@ export class AmigoStack extends GuStack {
         "echo 'export PATH=${!PATH}:/opt/packer' > /etc/profile.d/packer.sh",
         "wget -P /tmp https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_arm64/session-manager-plugin.deb",
         "dpkg -i /tmp/session-manager-plugin.deb",
+
+        "mkdir /amigo",
+        `aws --region eu-west-1 s3 cp s3://${distBucket}/${this.stack}/${this.stage}/${AmigoStack.app.app}/conf/amigo-service-account-cert.json /amigo/`,
+
         `aws --region eu-west-1 s3 cp s3://${artifactPath} /tmp/amigo.deb`,
         "dpkg -i /tmp/amigo.deb",
       ].join("\n"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 // sbt-native-packager cannot be updated to >1.9.9 until Play supports scala-xml 2
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.9")  // scala-steward:off
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")


### PR DESCRIPTION
TODOs:

* [x] upload cert to S3
* [x] add cert path to SSM
* [x] add google group to SSM
* [x] add 'impersonatedUser' to SSM
* [x] add client secret to Secrets Manager
* [x] add WAF

## What does this change?

Introduce Google auth so that people can access the app behind a public DNS.

Note, the Google Project credentials have usage type set to 'Internal' to limit users to members of the guardian org. A group check has also been introduced to further limit access to P+E devs.

## How to test

Usual approach of CODE/IP allowlist.