### PR TITLE
Create SSM parameter with ALB arn (for WAF configuration)

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -90,6 +90,25 @@ Object {
     },
   },
   "Resources": Object {
+    "AlbSsmParam485C1D52": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Description": "The arn of the ALB for amigo-PROD. N.B. this parameter is created via cdk",
+        "Name": "/infosec/waf/services/PROD/amigo-alb-arn",
+        "Tags": Object {
+          "Stack": "deploy",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/amigo",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "LoadBalancerAmigoC3017FAF",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
     "AmigoCname": Object {
       "Properties": Object {
         "Name": "public.amigo.gutools.co.uk",

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -18,6 +18,7 @@ import { InstanceClass, InstanceSize, InstanceType, Peer, Port } from "aws-cdk-l
 import { ListenerAction, UnauthenticatedAction } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { Effect, Policy, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import type { Bucket } from "aws-cdk-lib/aws-s3";
+import { ParameterDataType, ParameterTier, StringParameter } from "aws-cdk-lib/aws-ssm";
 
 const packerVersion = "1.8.5";
 
@@ -262,6 +263,16 @@ export class AmigoStack extends GuStack {
     });
 
     guPlayApp.loadBalancer.addSecurityGroup(albEgressSg);
+
+    // This parameter is used by https://github.com/guardian/waf
+    new StringParameter(this, "AlbSsmParam", {
+      parameterName: `/infosec/waf/services/${this.stage}/amigo-alb-arn`,
+      description: `The arn of the ALB for amigo-${this.stage}. N.B. this parameter is created via cdk`,
+      simpleName: false,
+      stringValue: guPlayApp.loadBalancer.loadBalancerArn,
+      tier: ParameterTier.STANDARD,
+      dataType: ParameterDataType.TEXT,
+    });
 
     const clientId = new GuStringParameter(this, "ClientId", {
       description: "Google OAuth client ID",


### PR DESCRIPTION
## What does this change?

This PR adds the ALB's ARN to parameter store so that it can be used/looked up by `cdk` stacks in https://github.com/guardian/waf.

See https://trello.com/c/Gf4wbq5Y/1716-configure-wafs-for-all-services-in-their-own-repository

Related: https://github.com/guardian/grafana/pull/216

## How to test

[Deploy to `CODE`](https://public.riffraff.gutools.co.uk/deployment/view/66cb5180-2703-425b-9b0b-39517c15f168) to confirm that the parameter is created as expected.

## How can we measure success?

This allows us to move forwards with the work to define a separate WAF for AMIgo via a different repository.