### PR TITLE
Mark up URLs as URLs to get clickable links and avoid odd formatting

### DIFF
--- a/roles/browser-testing/README.md
+++ b/roles/browser-testing/README.md
@@ -5,7 +5,7 @@ This feature installs Google Chrome, Chromedriver and the virtual frame buffer, 
 The install script does the following:
  - Installs Xvfb
  - Installs the version of Google Chrome specified by `chrome_version` (installs latest if blank) and associated packages
-   <br/>_see https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable for available options_
+   <br/>_see <https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable> for available options_
  - Installs  Chromedriver version specified by `chromedriver_version` (installs latest if blank)
-   <br/>_see version numbers for entries ending in `/chromedriver_linux64.zip` from https://chromedriver.storage.googleapis.com/_
+   <br/>_see version numbers for entries ending in `/chromedriver_linux64.zip` from <https://chromedriver.storage.googleapis.com/>_
  - Creates and enables an Xvfb service


### PR DESCRIPTION

## What does this change?

The link for `chrome_version` has an underscore in it, which conflicts with the other underscores on the line, ending the italics early

<img width="850" alt="image" src="https://user-images.githubusercontent.com/10963046/213207021-a6e6b73d-7a14-487c-8ca4-43629133c20d.png">

(Github markdown works correctly for this case; it notices that the link is a link and treats it as such; so the diff claims that there are no differences. I _think_ this will make Amigo's markdown parser behave the same)