### PR TITLE
Kong admin port protection

### DIFF
--- a/roles/kong-v1_5/files/kong-1.5.1.conf
+++ b/roles/kong-v1_5/files/kong-1.5.1.conf
@@ -23,7 +23,7 @@
 
 anonymous_reports = off          # Send anonymous usage data such as error
 proxy_listen = 0.0.0.0:8000
-admin_listen = 0.0.0.0:8001
+admin_listen = 127.0.0.1:8101
 mem_cache_size = 256m            # Size of the in-memory cache for database
 pg_host = POSTGRES_HOST          # The PostgreSQL host to connect to. This value is over-written on instance startup with the correct value.
 pg_user = POSTGRES_USERNAME      # The username to authenticate if required.  This value is over-written on instance startup with the correct value.

--- a/roles/kong-v1_5/files/protect-admin-port/healthcheck-index.html
+++ b/roles/kong-v1_5/files/protect-admin-port/healthcheck-index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<h3>:+1: it works</h3>
+</body>
+</html>

--- a/roles/kong-v1_5/files/protect-admin-port/nginx.conf
+++ b/roles/kong-v1_5/files/protect-admin-port/nginx.conf
@@ -16,6 +16,9 @@ http {
     listen 0.0.0.0:8001;
 
     access_log /var/log/protect-admin-port/access.log;
+    location /healthcheck {
+        root /var/www;
+    }
     location / {
       auth_basic "admin";
       auth_basic_user_file "/etc/protect-admin-port/users";

--- a/roles/kong-v1_5/files/protect-admin-port/nginx.conf
+++ b/roles/kong-v1_5/files/protect-admin-port/nginx.conf
@@ -1,0 +1,25 @@
+worker_processes auto;
+daemon off;
+
+pid /dev/null;
+error_log /var/log/protect-admin-port/error.log notice;
+
+worker_rlimit_nofile 1048576;
+
+events {
+    worker_connections 1048576;
+    multi_accept on;
+}
+
+http {
+  server {
+    listen 0.0.0.0:8001;
+
+    access_log /var/log/protect-admin-port/access.log;
+    location / {
+      auth_basic "admin";
+      auth_basic_user_file "/etc/protect-admin-port/users";
+      proxy_pass http://localhost:8101;
+    }
+  }
+}

--- a/roles/kong-v1_5/files/protect-admin-port/protect-admin-port.service
+++ b/roles/kong-v1_5/files/protect-admin-port/protect-admin-port.service
@@ -3,7 +3,6 @@ Description=Proxy Kong's admin port
 After=syslog.target network.target remote-fs.target nss-lookup.target
 
 [Service]
-ExecStartPre=/bin/bash /usr/local/bin/protect-admin-port-prepare.sh
 ExecStart=/usr/local/openresty/nginx/sbin/nginx -p /var/lib/protect-admin-port -c /etc/protect-admin-port/nginx.conf
 ExecStop=/bin/kill -s QUIT $MAINPID
 

--- a/roles/kong-v1_5/files/protect-admin-port/protect-admin-port.service
+++ b/roles/kong-v1_5/files/protect-admin-port/protect-admin-port.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Proxy Kong's admin port
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+ExecStartPre=/bin/bash /usr/local/bin/protect-admin-port-prepare.sh
+ExecStart=/usr/local/openresty/nginx/sbin/nginx -p /var/lib/protect-admin-port -c /etc/protect-admin-port/nginx.conf
+ExecStop=/bin/kill -s QUIT $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/kong-v1_5/tasks/main.yml
+++ b/roles/kong-v1_5/tasks/main.yml
@@ -66,7 +66,7 @@
   apt:
     name:
       - apache2-utils
-  state: latest
+    state: latest
 
 - name: Install protect-admin-port nginx configuration
   copy: src=protect-admin-port/nginx.conf dest=/etc/protect-admin-port/nginx.conf

--- a/roles/kong-v1_5/tasks/main.yml
+++ b/roles/kong-v1_5/tasks/main.yml
@@ -74,14 +74,17 @@
 - name: Install protect-admin-port nginx configuration
   copy: src=protect-admin-port/nginx.conf dest=/etc/protect-admin-port/nginx.conf
 
+- name: Fix up configuration permissions
+  file: path=/etc/protect-admin-port owner={{kong_user}} mode=u=rX,g=rX,o= recurse=yes
+
 - name: Install protect-admin-port service
   copy: src=protect-admin-port/protect-admin-port.service dest=/etc/systemd/system/protect-admin-port.service
 
 - name: Prepare protect-admin-port healthcheck
-  file: path=/var/www owner={{kong_user}}  state=directory
+  file: path=/var/www/healthcheck owner={{kong_user}}  state=directory
 
 - name: Install protect-admin-port healthcheck
-  copy: src=protect-admin-port/healthcheck-index.html dest=/var/www/healthcheck-index.html
+  copy: src=protect-admin-port/healthcheck-index.html dest=/var/www/healthcheck/index.html
 
 - name: Fix up permissions
   #here X means "execute (enter) if directory, nothing if file"

--- a/roles/kong-v1_5/tasks/main.yml
+++ b/roles/kong-v1_5/tasks/main.yml
@@ -61,3 +61,21 @@
     dest: /lib/systemd/system/logrotate.timer
     regexp: AccuracySec=(.*)$
     line: AccuracySec=5m
+
+- name: Install htpasswd tool
+  apt:
+    name:
+      - apache2-utils
+  state: latest
+
+- name: Install protect-admin-port nginx configuration
+  copy: src=protect-admin-port/nginx.conf dest=/etc/protect-admin-port/nginx.conf
+
+- name: Install protect-admin-port service
+  copy: src=protect-admin-port/protect-admin-port.service dest=/etc/systemd/system/protect-admin-port.service
+
+- name: Set up protect-admin-port working area
+  file: path=/var/lib/protect-admin-port owner={{kong_user}} recurse=yes state=directory
+
+- name: Set up protect-admin-port logging area
+  file: path=/var/log/protect-admin-port owner={{kong_user}} recurse=yes state=directory

--- a/roles/kong-v1_5/tasks/main.yml
+++ b/roles/kong-v1_5/tasks/main.yml
@@ -74,6 +74,14 @@
 - name: Install protect-admin-port service
   copy: src=protect-admin-port/protect-admin-port.service dest=/etc/systemd/system/protect-admin-port.service
 
+- name: Prepare protect-admin-port healthcheck
+  file: path=/var/www owner={{kong_user}}  state=directory
+- name: Install protect-admin-port healthcheck
+  copy: src=protect-admin-port/healthcheck-index.html dest=/var/www/healthcheck-index.html
+- name: Fix up permissions
+  #here X means "execute (enter) if directory, nothing if file"
+  file: path=/var/www owner={{kong_user}} mode=u=rX,g=rX,o=rX recurse=yes
+
 - name: Set up protect-admin-port working area
   file: path=/var/lib/protect-admin-port owner={{kong_user}} recurse=yes state=directory
 

--- a/roles/kong-v1_5/tasks/main.yml
+++ b/roles/kong-v1_5/tasks/main.yml
@@ -68,6 +68,9 @@
       - apache2-utils
     state: latest
 
+- name: Prepare configuration area
+  file: path=/etc/protect-admin-port state=directory
+
 - name: Install protect-admin-port nginx configuration
   copy: src=protect-admin-port/nginx.conf dest=/etc/protect-admin-port/nginx.conf
 
@@ -76,8 +79,10 @@
 
 - name: Prepare protect-admin-port healthcheck
   file: path=/var/www owner={{kong_user}}  state=directory
+
 - name: Install protect-admin-port healthcheck
   copy: src=protect-admin-port/healthcheck-index.html dest=/var/www/healthcheck-index.html
+
 - name: Fix up permissions
   #here X means "execute (enter) if directory, nothing if file"
   file: path=/var/www owner={{kong_user}} mode=u=rX,g=rX,o=rX recurse=yes


### PR DESCRIPTION
## What does this change?

Adds extra configuration to apply a secondary reverse-proxy for Kong's admin endpoint. The endpoint is still firewall protected in deployment (through the use of Security Groups); this is part of an infrastructure rationalisation and defence-in-depth measure agreed with Infosec.

In addition to the existing Security Group configuration which blocks the port to everything except known SGs, we are adding a basic auth challenge which will be set from Secrets Manager (and ultimately auto-rotated, we hope)

## How to test

Once the instance is built, it will have an extra service called protect-admin-port and associated configuration. The Kong configuration is modified to shift the admin port to 8101, localhost only, and protect-admin-port sets up a simple authenticating nginx proxy to protect it.

The user secret is set at instance start time and will later be rotatable.

## How can we measure success?

Improved backend security in CAPI

