### PR TITLE
Remove scheduled and branch runs of snyk

### DIFF
--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -1,14 +1,9 @@
 name: Snyk
 
 on:
-  schedule:
-    - cron: '0 6 * * *'
   push:
     branches:
       - main
-  pull_request:   
-    branches-ignore:
-      - dependency-updates
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What does this change?

Snyk no longer runs every day at 6am. This is unnecessary as it submits the same set of dependencies every day until somebody updates the repo, wasting action minutes.

I've also removed the pull request trigger, as we only want to know about vulnerabilities on the main branch. As well as this, we know a project is reliably integrated if the commit hash from the most recent workflow run matches what is on the head of main. Running this workflow on branches means that this will almost never be the case
## How to test

Verify the workflow finishes successfully

## How can we measure success?

Amigo will show up as reliably integrated on grafana