### PR TITLE
Adds a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,18 @@
 ## What does this change?
 
-<!-- Screenshots may be helpful to demonstrate -->
+<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
+
+## How to test
+
+<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
 
 ## What is the value of this?
 
 <!-- Why are these changes being made? -->
 
-## How has this been tested?
+## Have we considered potential risks?
 
-<!-- Why are these changes being made? -->
+<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
 
---- 
-
-If this change adds, updates or removes a role or recipe please note that in your PR and assign appropriate reviewers for the team that will be impacted by those changes.
+> **Note**
+> If this change adds, updates or removes a role or recipe please note that in your PR and assign appropriate reviewers for the team that will be impacted by those changes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## What does this change?
+
+<!-- Screenshots may be helpful to demonstrate -->
+
+## What is the value of this?
+
+<!-- Why are these changes being made? -->
+
+## How has this been tested?
+
+<!-- Why are these changes being made? -->
+
+--- 
+
+If this change adds, updates or removes a role or recipe please note that in your PR and assign appropriate reviewers for the team that will be impacted by those changes.


### PR DESCRIPTION
## What does this change?

Adds a PR template for AMIgo, including a note that if you're modifying a role/recipe to note who it's impacting and get them to review it.  This change will override the default org template and removes some of the less relevant sections for AMIgo. The intention is to make the review processes for AMIgo PRs clearer and quicker.

## How to test

Read the PR template, see if it is clearer how reviews should be conducted.

## How can we measure success?

Recipe & role PRs get assigned a reviewer faster, and get merged faster consequently.

## Have we considered potential risks?

We could make it more confusing!
