### PR TITLE
Unblock bakes for recipes based on ARM ubuntu-bionic (18.04 LTS)

### DIFF
--- a/app/ansible/PlaybookGenerator.scala
+++ b/app/ansible/PlaybookGenerator.scala
@@ -16,17 +16,17 @@ object PlaybookGenerator {
       |      ansible.builtin.dpkg_selections:
       |        name: grub-efi-arm64
       |        selection: hold
-      |      when: ansible_facts['distribution_major_version'] == "18"
+      |      when: ansible_facts['distribution_major_version'] == "18" and ansible_facts['architecture'] == "aarch64"
       |    - name: Prevent apt from upgrading grub-efi-arm64-bin
       |      ansible.builtin.dpkg_selections:
       |        name: grub-efi-arm64-bin
       |        selection: hold
-      |      when: ansible_facts['distribution_major_version'] == "18"
+      |      when: ansible_facts['distribution_major_version'] == "18" and ansible_facts['architecture'] == "aarch64"
       |    - name: Prevent apt from upgrading grub-efi-arm64-signed
       |      ansible.builtin.dpkg_selections:
       |        name: grub-efi-arm64-signed
       |        selection: hold
-      |      when: ansible_facts['distribution_major_version'] == "18"
+      |      when: ansible_facts['distribution_major_version'] == "18" and ansible_facts['architecture'] == "aarch64"
       |  vars:
       |${allVars.map { case (k, v) => s"    $k: $v" }.mkString("\n")}
       |  roles:

--- a/app/ansible/PlaybookGenerator.scala
+++ b/app/ansible/PlaybookGenerator.scala
@@ -11,6 +11,22 @@ object PlaybookGenerator {
       |
       |- hosts: all
       |  become: yes
+      |  pre_tasks:
+      |    - name: Prevent apt from upgrading grub-efi-arm64
+      |      ansible.builtin.dpkg_selections:
+      |        name: grub-efi-arm64
+      |        selection: hold
+      |      when: ansible_facts['distribution_major_version'] == "18"
+      |    - name: Prevent apt from upgrading grub-efi-arm64-bin
+      |      ansible.builtin.dpkg_selections:
+      |        name: grub-efi-arm64-bin
+      |        selection: hold
+      |      when: ansible_facts['distribution_major_version'] == "18"
+      |    - name: Prevent apt from upgrading grub-efi-arm64-signed
+      |      ansible.builtin.dpkg_selections:
+      |        name: grub-efi-arm64-signed
+      |        selection: hold
+      |      when: ansible_facts['distribution_major_version'] == "18"
       |  vars:
       |${allVars.map { case (k, v) => s"    $k: $v" }.mkString("\n")}
       |  roles:

--- a/test/ansible/PlaybookGeneratorSpec.scala
+++ b/test/ansible/PlaybookGeneratorSpec.scala
@@ -58,6 +58,22 @@ class PlaybookGeneratorSpec extends AnyFlatSpec with Matchers {
         |
         |- hosts: all
         |  become: yes
+        |  pre_tasks:
+        |    - name: Prevent apt from upgrading grub-efi-arm64
+        |      ansible.builtin.dpkg_selections:
+        |        name: grub-efi-arm64
+        |        selection: hold
+        |      when: ansible_facts['distribution_major_version'] == "18"
+        |    - name: Prevent apt from upgrading grub-efi-arm64-bin
+        |      ansible.builtin.dpkg_selections:
+        |        name: grub-efi-arm64-bin
+        |        selection: hold
+        |      when: ansible_facts['distribution_major_version'] == "18"
+        |    - name: Prevent apt from upgrading grub-efi-arm64-signed
+        |      ansible.builtin.dpkg_selections:
+        |        name: grub-efi-arm64-signed
+        |        selection: hold
+        |      when: ansible_facts['distribution_major_version'] == "18"
         |  vars:
         |    var1: value1
         |    var2: value2

--- a/test/ansible/PlaybookGeneratorSpec.scala
+++ b/test/ansible/PlaybookGeneratorSpec.scala
@@ -63,17 +63,17 @@ class PlaybookGeneratorSpec extends AnyFlatSpec with Matchers {
         |      ansible.builtin.dpkg_selections:
         |        name: grub-efi-arm64
         |        selection: hold
-        |      when: ansible_facts['distribution_major_version'] == "18"
+        |      when: ansible_facts['distribution_major_version'] == "18" and ansible_facts['architecture'] == "aarch64"
         |    - name: Prevent apt from upgrading grub-efi-arm64-bin
         |      ansible.builtin.dpkg_selections:
         |        name: grub-efi-arm64-bin
         |        selection: hold
-        |      when: ansible_facts['distribution_major_version'] == "18"
+        |      when: ansible_facts['distribution_major_version'] == "18" and ansible_facts['architecture'] == "aarch64"
         |    - name: Prevent apt from upgrading grub-efi-arm64-signed
         |      ansible.builtin.dpkg_selections:
         |        name: grub-efi-arm64-signed
         |        selection: hold
-        |      when: ansible_facts['distribution_major_version'] == "18"
+        |      when: ansible_facts['distribution_major_version'] == "18" and ansible_facts['architecture'] == "aarch64"
         |  vars:
         |    var1: value1
         |    var2: value2


### PR DESCRIPTION
## What does this change?

We believe that any AMI based on the [ARM ubuntu-bionic (18.04 LTS) base image](https://public.amigo.gutools.co.uk/base-images/ARM%20ubuntu-bionic%20(18.04%20LTS)) which was baked after 30th January is unusable.

We believe that these broken AMIs (and/or bake failures) are linked to the latest release of `grub-efi-arm64*` packages, which were [made available on the 30th](https://launchpad.net/ubuntu/+source/grub2-unsigned/2.06-2ubuntu14). For more details see [this doc](https://docs.google.com/document/d/1sw2yktIeQjWjzhLRJ9J7V0Up7K4_N4SullSuoufqM00/edit#).

This PR unblocks bakes for these recipes by [temporarily 'holding'](https://stackoverflow.com/a/63983134) (i.e. preventing upgrades for) the affected packages.

## How to test

To test this I have:

* Confirmed that the conditional logic in the Ansible playbook works as expected by:
  * Confirmed that these packages are not upgraded on [Ubuntu 18 (ARM)](https://public.amigo.code.dev-gutools.co.uk/recipes/jw-test/bakes/19)[^1].
  * Confirmed that these [`pre_tasks`](https://www.redhat.com/sysadmin/ansible-pretasks-posttasks) are _skipped_ on [Ubuntu 18 (amd64)](https://public.amigo.code.dev-gutools.co.uk/recipes/jw-test-different-18-base/bakes/3) and [Ubuntu 20 (ARM)](https://public.amigo.code.dev-gutools.co.uk/recipes/jw-test-20-base/bakes/2)[^2]. 
* [Deployed `AMIable-CODE`](https://public.riffraff.gutools.co.uk/deployment/view/2f649399-ab47-46bc-a9c6-3f0eb395f5fc?verbose=1) to use an AMI baked by `AMIgo-CODE` (i.e. an [AMI built using this change](https://public.amigo.code.dev-gutools.co.uk/recipes/arm64-bionic-java8-deploy-infrastructure/bakes/6)) and confirmed that the deployment works as expected[^3].

## What is the value of this?

* A [number of recipes](https://public.amigo.gutools.co.uk/base-images/ubuntu-bionic%20(18.04%20LTS)) will be able to produce working AMIs again.

## Have we considered potential risks?

Yes, we will need to remember to re-test / revert this PR when a) new versions of the `grub-efi-arm64*` packages are released or b) a new source AMI is made available. Perhaps we should create a card for this?

That said, teams should be planning to migrate away from Ubuntu 18 before 30th April 2023 (when it becomes unsupported) anyway.

[^1]: Bake logs for this include: `The following packages have been kept back: grub-efi-arm64 grub-efi-arm64-bin grub-efi-arm64-signed`
[^2]: Bake logs for this indicate that `pre_tasks` are being skipped as expected.
[^3]: Deployment logs for this show: `[13:29:17] Parameter AMIAmiable has changed from ami-0b160a62e49d569c6 to ami-0fea03d2c73cfb4c4` (which is the AMI that we want to test).