### PR TITLE
Remove `public.amigo.gutools.co.uk`

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -109,23 +109,6 @@ Object {
       },
       "Type": "AWS::SSM::Parameter",
     },
-    "AmigoCname": Object {
-      "Properties": Object {
-        "Name": "public.amigo.gutools.co.uk",
-        "RecordType": "CNAME",
-        "ResourceRecords": Array [
-          Object {
-            "Fn::GetAtt": Array [
-              "LoadBalancerAmigoC3017FAF",
-              "DNSName",
-            ],
-          },
-        ],
-        "Stage": "PROD",
-        "TTL": 3600,
-      },
-      "Type": "Guardian::DNS::RecordSet",
-    },
     "AmigoDataBucket": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
@@ -381,10 +364,7 @@ dpkg -i /tmp/amigo.deb",
     "CertificateAmigoE1AF5E0C": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
-        "DomainName": "public.amigo.gutools.co.uk",
-        "SubjectAlternativeNames": Array [
-          "amigo.gutools.co.uk",
-        ],
+        "DomainName": "amigo.gutools.co.uk",
         "Tags": Array [
           Object {
             "Key": "App",
@@ -789,34 +769,6 @@ dpkg -i /tmp/amigo.deb",
         "Protocol": "HTTPS",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
-    },
-    "ListenerAmigoredirectRule5D74B08F": Object {
-      "Properties": Object {
-        "Actions": Array [
-          Object {
-            "RedirectConfig": Object {
-              "Host": "amigo.gutools.co.uk",
-              "StatusCode": "HTTP_301",
-            },
-            "Type": "redirect",
-          },
-        ],
-        "Conditions": Array [
-          Object {
-            "Field": "host-header",
-            "HostHeaderConfig": Object {
-              "Values": Array [
-                "public.amigo.gutools.co.uk",
-              ],
-            },
-          },
-        ],
-        "ListenerArn": Object {
-          "Ref": "ListenerAmigo0180B42C",
-        },
-        "Priority": 1,
-      },
-      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
     },
     "LoadBalancerAmigoC3017FAF": Object {
       "Properties": Object {


### PR DESCRIPTION
> **Note**
> Only to be merged once comms have been sent.

## What does this change?
Remove the `public.amigo.gutools.co.uk` CNAME as we've reverted to `amigo.gutools.co.uk`.

The removed resources include (for CODE and PROD):
  - The 301 redirect from `public.amigo.gutools.co.uk` to `amigo.gutools.co.uk`
  - The TLS certificate for `public.amigo.gutools.co.uk`
  - The CNAME for `public.amigo.gutools.co.uk`