### PR TITLE
Scalafmt fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ Universal / javaOptions ++= Seq(
 )
 
 lazy val root = (project in file("."))
+  .aggregate(imageCopier)
   .enablePlugins(
     PlayScala,
     RiffRaffArtifact,

--- a/script/ci
+++ b/script/ci
@@ -8,4 +8,4 @@ set -e
  ./script/ci
 )
 
-sbt clean scalafmtCheckAll compile test riffRaffUpload
+sbt clean scalafmtSbtCheck scalafmtCheckAll compile test riffRaffUpload


### PR DESCRIPTION
https://github.com/guardian/amigo/pull/944 introduced Scalafmt. This PR fixes two related issues:

1) we did not check SBT files
2) more importantly, because the SBT projects were not [aggregated](https://www.scala-sbt.org/1.x/docs/offline/Multi-Project.html#Aggregation) Image Copier was not formatted or checked at CI time - so we fix this here

Note, the lack of aggregation means that Image Copier could be failing tests without CI telling us (presumably a long-standing issue). Aggregation fixes this too.