### PR TITLE
Set custom `serverUrl` on agent

### DIFF
--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -50,7 +50,7 @@
     owner: teamcity
 - name: download agent
   get_url:
-    url: https://teamcity.gutools.co.uk/update/buildAgent.zip
+    url: https://communications.teamcity.gutools.co.uk/update/buildAgent.zip
     dest: /tmp/buildAgent.zip
 - name: unzip buildagent
   unarchive:
@@ -59,6 +59,11 @@
     owner: teamcity
 - name: set home path for agent
   shell: echo 'env.home=/opt/teamcity' >> /opt/teamcity/buildAgent/conf/buildAgent.properties
+
+# By default, the server injects this URL to the agents, setting it to the value of the server URL.
+# We explicitly set `serverUrl` on the agent to override this, as the server's URL has an `authenticate-oidc` flow attached to it, which agents cannot pass.
+- name: set serverUrl for agent
+  shell: echo 'serverUrl=https:/communications.teamcity.gutools.co.uk/' >> /opt/teamcity/buildAgent/conf/buildAgent.properties
 - name: make agent executable
   file:
     path: /opt/teamcity/buildAgent/bin/agent.sh


### PR DESCRIPTION
## What does this change?
Establish a new domain name for TeamCity agent/server communication. See https://github.com/guardian/deploy-tools-platform/pull/663 for more background and reasoning.

## How to test
- Deploy to CODE
- Bake the `teamcity-agent` recipe
- Following [these instructions](https://github.com/guardian/deploy-tools-platform/blob/b190a9a1df6b3e5032d41a6785eae51aecd156f5/docs/testing-teamcity-agent-amis.md) to test the baked AMI.