### PR TITLE
feat(teamcity-agent): Download build agent from machine accessible domain

### DIFF
--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -50,7 +50,14 @@
     owner: teamcity
 - name: download agent
   get_url:
-    url: https://teamcity.gutools.co.uk/update/buildAgent.zip
+    # https://teamcity.gutools.co.uk has an `authenticate-oidc` flow attached to it, which machines cannot pass through.
+    # https://communications.teamcity.gutools.co.uk is our machine-to-machine domain.
+    # Note: When the agent is running, it gets the URL via the Cloud Profile and NOT via `serverUrl` in `buildAgent.properties`.
+    #
+    # See:
+    #   - https://www.jetbrains.com/help/teamcity/configure-agent-installation.html#General+Agent+Configuration
+    #   - https://www.jetbrains.com/help/teamcity/agent-cloud-profile.html#Specifying+Profile+Settings
+    url: https://communications.teamcity.gutools.co.uk/update/buildAgent.zip
     dest: /tmp/buildAgent.zip
 - name: unzip buildagent
   unarchive:


### PR DESCRIPTION
## What does this change?
The changes in #1003 did not work (and were reverted in #1006); the agents were not using the updated URL.

It turns out TeamCity agents started via a Cloud Profile get their server URL via the [Cloud Profile](https://www.jetbrains.com/help/teamcity/agent-cloud-profile.html#Specifying+Profile+Settings), rather than [`buildAgent.properties`](https://www.jetbrains.com/help/teamcity/configure-agent-installation.html#General+Agent+Configuration).

## How to test
1. Deploy to CODE.
2. Bake the `teamcity-agent` recipe.
3. Update the server URL in the Cloud Profile.
4. Following [these instructions](https://github.com/guardian/deploy-tools-platform/blob/ae5bd6aa921962576561ae6ffc5002a7ac470414/docs/testing-teamcity-agent-amis.md) to test the baked AMI.
5. SSM SSH onto the agent.
6. Observe the agent's logs, specifically events from `.agent.AmazonPropertiesUpdater` and `buildServer.AGENT.registration`, they should reference the URL from 3.
7. Run a build on the agent.