### PR TITLE
Add docs that `aws-inspector` is not required for Ubuntu 20

### DIFF
--- a/roles/aws-inspector/README.md
+++ b/roles/aws-inspector/README.md
@@ -1,4 +1,3 @@
 # AWS Inspector
 
-This role will install the [AWS Inspector] (https://aws.amazon.com/documentation/inspector/) agent.
-
+This role will install the [AWS Inspector](https://aws.amazon.com/documentation/inspector/) agent. This role is not required for any images based on Ubuntu 20 (Focal).


### PR DESCRIPTION
## What does this change?

- Updates the README for the `aws-inspector` role to include that it is not required for images based on Ubuntu 20