### PR TITLE
Use the focal-java11 base image for the service AMI

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -13,7 +13,7 @@ deployments:
     app: amigo
     parameters:
       amiTags:
-        Recipe: arm64-bionic-java11-deploy-infrastructure
+        Recipe: arm64-focal-java11-deploy-infrastructure
         AmigoStage: PROD
       amiEncrypted: true
       templateStagePaths:


### PR DESCRIPTION
## What does this change?

Move to use https://amigo.gutools.co.uk/recipes/arm64-focal-java11-deploy-infrastructure.

This will allow us to:

- Move AMIable to 20.04 to avoid the 18.04 EOL
- Test whether the new `arm64-focal-java11-deploy-infrastructure` image is working as expected

## How to test

Deploy this PR to the CODE environment and check the EC2 instances with the new AMI are successfully brought into service & that we can access the AMIgo UI.

## How can we measure success?

Can we use the focal AMI to successfully deploy AMIable?

## Have we considered potential risks?

AMIable is not deployable with Focal base AMIs, we'll revert.