### PR TITLE
Extend ruby-gems role to allow installation of specific versions 

### DIFF
--- a/roles/ruby-gems/tasks/main.yml
+++ b/roles/ruby-gems/tasks/main.yml
@@ -1,7 +1,22 @@
 ---
+- name: Fail when neither gems or ruby_gems are defined
+  fail:
+    msg: Define gems to install or disable this role
+  when: gems is not defined and version_gems is not defined
+
 - name: Install ruby gems
   gem:
     name: "{{ item }}"
     state: latest
     user_install: no
   with_items: "{{ gems }}"
+  when: gems is defined
+
+- name: Install ruby gems with specific versions
+  gem:
+    name: "{{ item.name }}"
+    state: installed
+    version: "{{ item.version }}"
+    user_install: no
+  with_items: "{{ version_gems }}"
+  when: version_gems is defined


### PR DESCRIPTION
## What does this change?

Previously the ruby-gems role took a single parameter `gems` which is a list of gems to install. This change adds the `version_gems` parameter, which takes a dictionary containing names and specific versions to install:

version_gems:
  - name: some-ruby-gem
    version: 1.2.3
  - name: another-ruby-gem
    version: 5.3.4

Two new tasks have been added to this role; one to install gems with specific versions, and another to fail if no gems are provided as a parameter. The latter task was added to preserve the behaviour of the role failing if `gems` is not provided - the logic is to fail if neither `gems` or `version_gems` are provided. 

The two tasks installing versions are conditional, depending on whether `gems` or `version_gems` were provided, or both. 

## How to test

Deploy on CODE and install gems with both `gems` and `version_gems` parameters, check what happens if the parameters contain common gems, or what happens if the first task installs gems configured in `version_gems` as dependencies of the gems in `gems`. 

## What is the value of this?

We needed to get a specific version of `fluentd-plugin-elasticsearch` to match our ElasticSearch cluster. I checked if putting the version in the package name would work, like "fluentd-plugin-elasticsearch==1.2.3" as that works for apt packages, but it fails. 

This change shouldn't impact any existing uses of ruby-gems - the existing behaviour of the role has been preserved. 

## Have we considered potential risks?

We'll intentionally not be running with the latest versions of packages, and should consider the potential security implication. This functionality should only be used in specific circumstances where the latest version can't be used. 