### PR TITLE
fix: Resolve Riff-Raff warning

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -24,6 +24,5 @@ deployments:
   imagecopier:
     type: aws-s3
     parameters:
-      bucket: deploy-tools-dist
       cacheControl: public, max-age=600
       publicReadAcl: false


### PR DESCRIPTION
## What does this change?
Remove an explicit S3 bucket name to resolve the Riff-Raff warning:

> Explicit bucket name in riff-raff.yaml. Prefer to use bucketSsmLookup=true, removing private information from VCS.

<details>
<summary>Screenshot from Riff-Raff</summary>

![image](https://user-images.githubusercontent.com/836140/219379236-e3d952f0-f0b0-43ee-897d-905908801b67.png)
</details>

Riff-Raff will now use the bucket that's stored in the SSM Parameter `/account/services/artifact.bucket`. I've confirmed the value of this Parameter is correct via:

```sh
aws ssm get-parameter \
  --name /account/services/artifact.bucket \
  --profile deployTools \
  --region eu-west-1
```

## How to test
Deploy it? The warning should not be seen.