### PR TITLE
fix: Update GitHub usage link

### DIFF
--- a/app/views/showRecipe.scala.html
+++ b/app/views/showRecipe.scala.html
@@ -67,7 +67,7 @@
         <p><b>This recipe is not used</b></p>
       }
       <p>
-        <a href="@(s"https://github.com/search?q=${helper.urlEncode(s"""org:guardian "${recipe.id}" filename:riff-raff.yaml""")}&type=code")">
+        <a href="@(s"https://github.com/search?q=${helper.urlEncode(s"""org:guardian "${recipe.id}" NOT is:archived""")}&type=code")">
           Search GitHub for usage
         </a>
       </p>


### PR DESCRIPTION
## What does this change?
Updates the link added in #383:
  - Do not scope to `riff-raff.yaml` file, to cater for cases where this is [auto-generated](https://github.com/guardian/cdk/blob/d50157ceb5f89cfa1b25cbe09d6da5cbd1d58edf/src/experimental/riff-raff-yaml-file/README.md)
  - Do not include archived repositories

## How to test
N/A

## What is the value of this?
More exhaustive search on GitHub.

## Have we considered potential risks?
N/A