### PR TITLE
cloud-watch-agent-logs

### DIFF
--- a/roles/cloud-watch-agent-logs/README.md
+++ b/roles/cloud-watch-agent-logs/README.md
@@ -1,15 +1,13 @@
-### Deprecated - use cloud-watch-agent-logs, which uses the newer "unified" agent.
-
-This role will install the [cloudwatch](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html) agent.
+This role uses the [unified cloudwatch agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/UseCloudWatchUnifiedAgent.html) for logging.
 
 It also provide a utility script to configure your logs in `/opt/cloudwatch-logs/configure-logs`
 The arguments are:
- - an id, to distinguish between log file (for instance `application` and `gc`)
- - the stack
- - the stage
- - the app
- - the full path to the log
- - an optional date format, see "datetime_format" [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html)
+- an id, to distinguish between log file (for instance `application` and `gc`)
+- the stack
+- the stage
+- the app
+- the full path to the log
+- an optional date format, see "datetime_format" [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html)
 
 
 Here's an example user data that makes use of it:

--- a/roles/cloud-watch-agent-logs/files/configure-logs
+++ b/roles/cloud-watch-agent-logs/files/configure-logs
@@ -11,8 +11,6 @@ conf_file=/opt/cloudwatch-logs/$app-$id.json
 
 cat > $conf_file <<__END__
 {
-  "agent": {
-  },
   "logs": {
     "logs_collected": {
       "files": {

--- a/roles/cloud-watch-agent-logs/files/configure-logs
+++ b/roles/cloud-watch-agent-logs/files/configure-logs
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+id=$1
+stack=$2
+stage=$3
+app=$4
+file=$5
+#optional date format parameter
+date_format=${6:-%Y-%m-%d %H:%M:%S}
+conf_file=/opt/cloudwatch-logs/$app-$id.json
+
+cat > $conf_file <<__END__
+{
+  "agent": {
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "$file",
+            "log_group_name": "$stack-$app-$stage",
+            "log_stream_name": "$stack-$app-$stage-$id-{instance_id}",
+            "timezone": "UTC",
+            "timestamp_format": "$date_format"
+          }
+        ]
+      }
+    },
+    "log_stream_name": "$stack-$app-$stage-$id-{instance_id}"
+  }
+}
+__END__
+
+amazon-cloudwatch-agent-ctl -a fetch-config -c file:$conf_file
+amazon-cloudwatch-agent-ctl -a start

--- a/roles/cloud-watch-agent-logs/meta/main.yml
+++ b/roles/cloud-watch-agent-logs/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - aws-cloud-watch-agent

--- a/roles/cloud-watch-agent-logs/tasks/main.yml
+++ b/roles/cloud-watch-agent-logs/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Create opt directory
+  file: path=/opt/cloudwatch-logs/ state=directory mode=0755
+
+- name: copy ec2 configuration script
+  copy:
+    src: configure-logs
+    dest: /opt/cloudwatch-logs/
+    mode: 0754


### PR DESCRIPTION
The existing [`cloud-watch-logs`](https://github.com/guardian/amigo/tree/main/roles/cloud-watch-logs) role uses a deprecated cloudwatch agent. This involves running an aws python script restricted to older versions of python. It fails on ubuntu Jammy.

This PR adds a new `cloud-watch-agent-logs` role which uses the new "unified" cloudwatch agent. This uses the existing `aws-cloud-watch-agent` role, and just provides a shell script for configuring logging. This script takes the same params as the old `cloud-watch-logs` script.