### PR TITLE
Vary the version of fluentbit installed with the OS version

### DIFF
--- a/roles/cdk-base/meta/main.yml
+++ b/roles/cdk-base/meta/main.yml
@@ -1,4 +1,12 @@
 ---
 dependencies:
   - aws-tools
-  - fluentbit
+  - role: fluentbit
+    ubuntu_version: bionic
+    when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int == 18
+  - role: fluentbit
+    ubuntu_version: focal
+    when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int == 20
+  - role: fluentbit
+    ubuntu_version: jammy
+    when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int == 22

--- a/roles/cdk-base/tasks/main.yml
+++ b/roles/cdk-base/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Fail when we attempt to install on a distro above 22.04 (no available fluentbit version)
+  fail:
+    msg: No version of fluentbit specified for distros above 22.04 (please add one)!
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int > 22
+
 - name: Setup target directory
   file:
     path: /var/lib/cloud/scripts/per-instance


### PR DESCRIPTION
## What does this change?

This change conditionally installs the correct version of fluentbit for the underlying OS release.

Currently some of our focal (20.04) images are using the bionic (18.04) build of fluentbit, and this role does not at all on jammy (22.04) as the bionic build tries to use a version of libssl unavailable on jammy. 

## How to test

Bake an AMI in AMIgo CODE that uses this new recipe with each underlying OS version (18,20,22). Use the new bake in the CODE environment for a service that uses this recipe and ensure that logs are still being shipped to logs.gutools.

Deployed: https://riffraff.gutools.co.uk/deployment/view/7b075c1a-83c8-4711-b281-442d14b0dad4

Testing in:
- [x] https://github.com/guardian/amiable/pull/450: [Logs shipped](https://logs.gutools.co.uk/goto/797b5f50-c1a0-11ed-8e6f-f38f6146f9ea).
- [x] https://github.com/guardian/prism/pull/566: [Logs shipped](https://logs.gutools.co.uk/goto/a9f4edd0-c1a1-11ed-8e6f-f38f6146f9ea)
- [x] https://github.com/guardian/prism/pull/567 [Logs shipped](https://logs.gutools.co.uk/goto/c29f35b0-c1a2-11ed-a413-c75421180356)

## What is the value of this?

This change will put the correct version of fluentbit on our bionic based recipes, and hopefully unlock jammy builds that use the cdk-base role (which depends on the fluentbit role). This will allow us to bake AMIs that get security updates for longer into the future!

## Have we considered potential risks?

This will change the version of fluentbit installed in existing recipes to match the correct one for the OS, this has not been tested yet, hence the importance of trying the role in recipes based on all possible OS versions (18,20,22).