### PR TITLE
Use arm64-jammy-java11-deploy-infrastructure as the AMI

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -13,7 +13,7 @@ deployments:
     app: amigo
     parameters:
       amiTags:
-        Recipe: arm64-focal-java11-deploy-infrastructure
+        Recipe: arm64-jammy-java11-deploy-infrastructure
         AmigoStage: PROD
       amiEncrypted: true
       templateStagePaths:


### PR DESCRIPTION
## What does this change?

Move to use https://amigo.gutools.co.uk/recipes/arm64-jammy-java11-deploy-infrastructure.

This will allow us to:

- Move AMIgo to 22.04 to extend the EOL even further than https://github.com/guardian/amigo/pull/1017
- Test whether the new `arm64-jammy-java11-deploy-infrastructure` image is working as expected, following https://github.com/guardian/amigo/pull/1066

## How to test

Deploy this PR to the CODE environment and check the EC2 instances with the new AMI are successfully brought into service & that we can access the AMIgo UI.

See: [no deployment yet]

## How can we measure success?

Can we use the jammy AMI to successfully deploy AMIgo?

## Have we considered potential risks?

AMIgo is not deployable with Jammy base AMIs, we'll revert.