### PR TITLE
Add "Name: Packer Builder" tag when launching packer instances

### DIFF
--- a/app/housekeeping/utils/PackerEC2Client.scala
+++ b/app/housekeeping/utils/PackerEC2Client.scala
@@ -57,12 +57,14 @@ class PackerEC2Client(underlying: AmazonEC2, amigoStage: String) {
   }
 
   def getRunningPackerInstances(): List[Instance] = {
+
     val request = new DescribeInstancesRequest()
       .withFilters(
         // These filters correspond to the tags added in packer.PackerBuildConfigGenerator
         new Filter("tag:AmigoStage", List(amigoStage).asJava),
         new Filter("tag:Stage", List(PackerBuildConfigGenerator.stage).asJava),
         new Filter("tag:Stack", List(PackerBuildConfigGenerator.stack).asJava),
+        new Filter("tag:Name", List("Packer Builder").asJava),
         new Filter("instance-state-name", List("running", "stopped").asJava)
       )
 

--- a/app/housekeeping/utils/PackerEC2Client.scala
+++ b/app/housekeeping/utils/PackerEC2Client.scala
@@ -59,10 +59,10 @@ class PackerEC2Client(underlying: AmazonEC2, amigoStage: String) {
   def getRunningPackerInstances(): List[Instance] = {
     val request = new DescribeInstancesRequest()
       .withFilters(
+        // These filters correspond to the tags added in packer.PackerBuildConfigGenerator
         new Filter("tag:AmigoStage", List(amigoStage).asJava),
         new Filter("tag:Stage", List(PackerBuildConfigGenerator.stage).asJava),
         new Filter("tag:Stack", List(PackerBuildConfigGenerator.stack).asJava),
-        new Filter("tag:Name", List("Packer Builder").asJava),
         new Filter("instance-state-name", List("running", "stopped").asJava)
       )
 

--- a/app/packer/PackerBuildConfigGenerator.scala
+++ b/app/packer/PackerBuildConfigGenerator.scala
@@ -54,6 +54,7 @@ object PackerBuildConfigGenerator {
         bake.recipe.baseImage.linuxDist.getOrElse(Ubuntu).loginName,
       ssh_interface = "session_manager",
       run_tags = Map(
+        "Name" -> "Packer Builder",
         "Stage" -> stage,
         "AmigoStage" -> amigoStage,
         "Stack" -> stack,


### PR DESCRIPTION
## What does this change?

This change adds a "Name: Packer Builder" tag when launching packer EC2 instances.

## How to test

Deployed in CODE this should tag instances as expected and terminate any EC2 instances with the appropriate tags that have not been stopped in the last hour.

See: https://riffraff.gutools.co.uk/deployment/view/2144a848-363d-4d49-9799-6b4770e4ffe7

In CODE new instances are properly tagged:

<img width="314" alt="Screenshot 2023-03-15 at 13 53 55" src="https://user-images.githubusercontent.com/953792/225329960-16d1a67f-303a-411a-acf4-8b5a9cde5add.png">

## What is the value of this?

The `DeleteLongRunningEC2Instances` housekeeping task which should terminate packer instances that have failed to be properly terminated is not working as the `Name` tag has not been added. 

This is because the aws packer plugin [no longer adds the Name tag itself](https://github.com/hashicorp/packer-plugin-amazon/blob/5d4e6b1680d345dfa0bf66f84a39e61057b3b098/docs-partials/builder/common/AMIConfig-not-required.mdx?plain=1#L44).

This change will save money on EC2 instance costs & developer time manually cleaning up.