### PR TITLE
Make filebeat role support ARM

### DIFF
--- a/roles/filebeat/tasks/main.yml
+++ b/roles/filebeat/tasks/main.yml
@@ -2,5 +2,10 @@
 - name: Add Elastic repository key
   apt_key: url=https://artifacts.elastic.co/GPG-KEY-elasticsearch state=present
 
-- name: Ensure Filebeat is installed
+- name: Ensure Filebeat is installed (arm)
+  apt: deb=https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{ version }}-arm64.deb state=present
+  when: ansible_architecture == "aarch64"
+
+- name: Ensure Filebeat is installed (amd)
   apt: deb=https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{ version }}-amd64.deb state=present
+  when: ansible_architecture == "x86_64"


### PR DESCRIPTION
## What does this change?

This change adds a task to the filebeat role to install the ARM version of filebeat if architecture is aarch64. It also adds a condition to the existing task, so that builds only install their respective versions. 

## How to test

- [x] Deploy on ```CODE``` and check AMI including filebeat role works on arm.

## What is the value of this?

Cost reduction benefits around AWS graviton instances.

## Have we considered potential risks?

Behavior of role has been preserved, so this shouldn't impact existing uses. 