### PR TITLE
fix: Update GitHub SSH-RSA key fingerprint

### DIFF
--- a/roles/teamcity-agent/tasks/main.yml
+++ b/roles/teamcity-agent/tasks/main.yml
@@ -156,10 +156,11 @@
 
 # IP address from `dig +short github.com`
 # Public key from `ssh-keyscan -t rsa github.com`
+# See https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
 - name: add github.com to ssh_known_hosts
   known_hosts:
     name: github.com
     hash_host: false
-    key: github.com,140.82.121.3 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+    key: github.com,140.82.121.3 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
     path: /etc/ssh/ssh_known_hosts
     state: present


### PR DESCRIPTION
## What does this change?
On 23 March 2023, [GitHub updated their key](https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/). In this change we update the signature (added in #391) to ensure we don't see warnings. The new value is taken from [official documentation on GitHub’s SSH public key fingerprints](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints).

## How to test
It's tricky. In theory, we should also be seeing [the warning message](https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/#what-you-can-do) on builds, with the agents failing to verify the host key. However, I've run a few builds this morning, and cannot see evidence of this. Maybe there's some propagation happening still?

We _could_ perform the same [test in #391](https://github.com/guardian/amigo/pull/391/commits/aa4dac70f98358dc93e7ae26e4e2534ef161fa2f), I guess. However a bake of the TeamCity recipe takes over an hour, meaning the test will take at least 2 hours (running two bakes). To shortcut this, to test, we can simply run `ssh-keyscan -t rsa github.com` to verify the updated value.

## What is the value of this?
Continued smooth operation of builds in TeamCity.