### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,6 @@ If the Multipass VM is timing out, try deleting and then re-running the script:
 
 You should also disconnect from the VPN too if using it.
 
-*Previously Vagrant was used but Virtualbox, which is used under the hood,
-doesn't support M1/arm64 macs unfortunately.*
-
 ### Running the full app
 
 Load the `deployTools` credentials using Janus, then execute [`./script/server`](./script/server). This will run the 


### PR DESCRIPTION
## What does this change?

Documentation change only to remove to point about previously using Vagrant.  Vagrant works on M1/arm64 if you use the QEMU backend.  So this message is a little confusing. I think it makes more sense to remove it that to clarify.