### PR TITLE
Confirm the crashes of Amigo instances are due to resource issues by testing a larger instance - increase the instance to T4G.XLARGE

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -312,7 +312,7 @@ Object {
         "ImageId": Object {
           "Ref": "AMIAmigo",
         },
-        "InstanceType": "t4g.small",
+        "InstanceType": "t4g.xlarge",
         "MetadataOptions": Object {
           "HttpTokens": "required",
         },

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -222,7 +222,7 @@ export class AmigoStack extends GuStack {
 
     const guPlayApp = new GuPlayApp(this, {
       ...AmigoStack.app,
-      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.XLARGE),
       userData: [
         "#!/bin/bash -ev",
         `wget -P /tmp https://releases.hashicorp.com/packer/${packerVersion}/packer_${packerVersion}_linux_arm64.zip`,


### PR DESCRIPTION
## What does this change?
Increase the size of the EC2 instance used by Amigo from T4G.SMALL to T4G.XLARGE.

Background:
EC2 instances have been crashing with regularity. It looks like these crashes correspond to scheduled bakes.
While AWS does not provide any out-of-the box memory tracking metrics, it does seem likely from the logs that the EC2 instance is stalling due to lack of memory.
By increasing the size of the Amigo instance to a very large size instance, we can eliminate the possibility of memory issues occurring. 
If we run this larger size for a week, and no crashes occur, we know the problem is resource availability. We can then look at trying smaller sizes until we get the smallest size that remains stable.

## How to test
This is a test.
To check this change has taken effect, after deployment of this build, get the id of the stack policy from the Amigo ASG.
Once this is done, check the details of this stack policy and make sure the instance size is set to T4G.XLARGE.

## What is the value of this?
This change will help us determine the cause of frequently occurring crashes of the Amigo EC2 instance.


## Have we considered potential risks?

This larger instance will incur a greater cost than the T4G.SMALL instance.
The main risk is if we forget to review the size after the test and it stays set to T4G.XLARGE. The impact of this would be that we were spending more money than perhaps we could be.
