### PR TITLE
Update cdk-base documentation

### DIFF
--- a/roles/cdk-base/README.md
+++ b/roles/cdk-base/README.md
@@ -5,7 +5,7 @@ practices rely on.
 
 At the moment this means the following:
 - fetch instance tags and store under `/etc/config` (via [`instance-tag-discovery`](https://github.com/guardian/instance-tag-discovery))
-- ship cloud-init logs to a Kinesis stream (via [`devx-logs`](https://github.com/guardian/devx-logs))
+- ship `cloud-init-output` and application logs to a Kinesis stream (via [`devx-logs`](https://github.com/guardian/devx-logs))
 
 ## Requirements
 ℹ If you are using [`@guardian/cdk`](http://github.com/guardian/cdk) version 41.1.0 or greater, these requirements are met automatically.

--- a/roles/cdk-base/README.md
+++ b/roles/cdk-base/README.md
@@ -1,8 +1,5 @@
 # CDK Base
 
-**Note: this role is experimental. It is safe to use but the precise behaviour 
-and required tags are still subject to change.**
-
 This role includes boot tasks that the Guardian's EC2 CDK patterns and best 
 practices rely on.
 


### PR DESCRIPTION
## What does this change?

`cdk-base` has been adopted by a [significant number of recipes ](https://amigo.gutools.co.uk/roles#cdk-base) and we are now [recommending/supporting](https://github.com/guardian/recommendations/pull/118) it as a stable method for shipping logs. Consequently this PR updates some documentation that was added whilst this tooling was still being developed.
