### PR TITLE
chore(deps): Bump various dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,8 +108,8 @@ libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "auth" % awsV2SdkVersion,
   "software.amazon.awssdk" % "regions" % awsV2SdkVersion,
   "com.gu" % "kinesis-logback-appender" % "2.1.1",
-  "org.scalatest" %% "scalatest-flatspec" % "3.2.15" % Test,
-  "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.15" % Test,
+  "org.scalatest" %% "scalatest-flatspec" % "3.2.16" % Test,
+  "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.16" % Test,
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test,
   "fun.mike" % "diff-match-patch" % "0.0.2",
   "com.gu" %% "anghammarad-client" % "1.2.0"

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
-  "org.scanamo" %% "scanamo" % "1.0.0-M24",
+  "org.scanamo" %% "scanamo" % "1.0.0-M26",
   "com.beachape" %% "enumeratum" % "1.7.2",
   // Pin akka version until Play updates its own akka dependency
   "com.typesafe.akka" %% "akka-actor-typed" % "2.6.19", // scala-steward:off

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ val jacksonVersion = "2.15.1"
 val circeVersion = "0.14.5"
 
 // These can live in the same codebase, see: https://aws.amazon.com/blogs/developer/aws-sdk-for-java-2-x-released/
-val awsV1SdkVersion = "1.12.459"
+val awsV1SdkVersion = "1.12.472"
 val awsV2SdkVersion = "2.20.56"
 
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,7 @@ val circeVersion = "0.14.5"
 
 // These can live in the same codebase, see: https://aws.amazon.com/blogs/developer/aws-sdk-for-java-2-x-released/
 val awsV1SdkVersion = "1.12.472"
-val awsV2SdkVersion = "2.20.56"
+val awsV2SdkVersion = "2.20.69"
 
 libraryDependencies ++= Seq(
   ws,

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ scalacOptions ++= Seq(
   "-Xfatal-warnings"
 )
 
-val jacksonVersion = "2.15.0"
+val jacksonVersion = "2.15.1"
 val circeVersion = "0.14.5"
 
 // These can live in the same codebase, see: https://aws.amazon.com/blogs/developer/aws-sdk-for-java-2-x-released/

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.8.3


### PR DESCRIPTION
## What does this change?
Manually bumps various dependencies whilst our Scala Steward integration appears to be a little broken. Hoping this'll reduce the noise created by https://github.com/guardian/actions-prnouncer 🤞🏽.

| Module      | From      | To        |
|-------------|-----------|-----------|
| Jackson     | 2.15.0    | 2.15.1    |
| AWS SDK v1  | 1.12.458  | 1.12.473  |
| AWS SDK v2  | 2.20.56   | 2.20.69   |
| Scanamo     | 1.0.0-M24 | 1.0.0-M26 |
| scalatest-* | 3.2.15    | 3.2.16    |
| sbt | 1.8.2    | 1.8.3    |

## How to test
- [Deploy to CODE](https://riffraff.gutools.co.uk/deployment/view/9b4a5a51-7758-44cb-a428-7d738505bc1b)
- Can an AMI be baked? ([spoiler: yes it can!](https://amigo.code.dev-gutools.co.uk/recipes/akash-test/bakes/6))

---
Closes #1164.
Closes #1167.
Closes #1168.
Closes #1169.
Closes #1171.
Closes #1173.
Closes #1174.
Closes #1175.
Closes #1176.