### PR TITLE
Allow bakes to run for longer before marking them as TimedOut

### DIFF
--- a/app/housekeeping/TimeOutLongRunningBakes.scala
+++ b/app/housekeeping/TimeOutLongRunningBakes.scala
@@ -8,7 +8,7 @@ import services.Loggable
 
 // This house keeping job is to mitigate against Amigo bakes that have failed, but have not reported as such.
 // As a result of this, the EC2 instance used for the bake would not be terminated, incurring unnecessary costs.
-// The solution is to update the status (in the database) of running bakes that were launched over an hour ago to TimedOut
+// The solution is to update the status (in the database) of running bakes that were launched over 2 hours ago to TimedOut
 // and terminate the EC2 instance associated with them respectively.
 class TimeOutLongRunningBakes(
     bakesRepo: BakesRepo,
@@ -57,7 +57,7 @@ class TimeOutLongRunningBakes(
   }
 
   override def housekeep(): Unit =
-    runHouseKeeping(earliestStartedAt = DateTime.now.minusHours(1))
+    runHouseKeeping(earliestStartedAt = DateTime.now.minusHours(2))
 }
 
 object TimeOutLongRunningBakes {


### PR DESCRIPTION
## What does this change?

This PR makes AMIgo's housekeeping (which tidies up bakes that are presumed to be stuck) a little more patient. Currently it marks bakes as `TimedOut` after ~1 hour, but we have at least one [recipe](https://amigo.gutools.co.uk/recipes/ubuntu-jammy-datascience-python-ner-cuda) which regularly takes longer than this to bake.

## How to test

We are just changing a timeout value here, so I haven't done any testing.

## What is the value of this?

After this change is merged we should stop sending spam alerts to @michel-ds. 

## Have we considered potential risks?

The feedback loop for bakes which are 'stuck' will be longer. As most bakes run overnight I don't think this is a particularly problematic risk. This will also cost us a bit of extra money, but the hourly pricing for [the EC2 instances that we're using](https://github.com/guardian/amigo/blob/b44d6db5fca946e4306000e6a4b06d773e5ebe4e/app/packer/PackerBuildConfigGenerator.scala#L36-L43) is very cheap, so I don't think this is a big problem.