### PR TITLE
Bump java for the image copier

### DIFF
--- a/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
+++ b/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
@@ -232,7 +232,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "java8",
+        "Runtime": "java11",
         "Tags": Array [
           Object {
             "Key": "gu:cdk:version",

--- a/cdk/lib/image-copier-lambda.ts
+++ b/cdk/lib/image-copier-lambda.ts
@@ -40,7 +40,7 @@ export class ImageCopierLambda extends GuStack {
 
     const copierLambda = new Function(this, "ImageCopierLambda", {
       description: "Lambda for copying and encrypting AMIgo baked AMIs",
-      runtime: Runtime.JAVA_8,
+      runtime: Runtime.JAVA_11,
       memorySize: 512,
       handler: "com.gu.imageCopier.LambdaEntrypoint::run",
       timeout: Duration.seconds(30),


### PR DESCRIPTION
Co-author: @tjsilver 
## What does this change?

Java runtime has been bumped to java 8

## How to test

Deploy the stackset to one account. Trigger a bake and verify the image copier runs successfully when the bake completes

## What is the value of this?

We have a department wide SLO to update our runtimes from java 8 to java 11