### PR TITLE
Nt/tjs/bump housekeeping

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val root = (project in file("."))
     riffRaffManifestProjectName := s"tools::${name.value}",
     riffRaffPackageType := (Debian / packageBin).value,
     riffRaffArtifactResources ++= Seq(
-      (imageCopier / Universal / packageBin).value -> "imagecopier/imagecopier.zip",
+      (imageCopier / Universal / packageBin).value -> "imagecopier/image-copier.zip",
       baseDirectory.value / "cdk/cdk.out/AMIgo-CODE.template.json" -> "cloudformation/AMIgo-CODE.template.json",
       baseDirectory.value / "cdk/cdk.out/AMIgo-PROD.template.json" -> "cloudformation/AMIgo-PROD.template.json"
     ),

--- a/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
+++ b/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
@@ -52,7 +52,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "java8",
+        "Runtime": "java11",
         "Tags": Array [
           Object {
             "Key": "gu:cdk:version",

--- a/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
+++ b/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
@@ -30,7 +30,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": "deploy-tools-dist",
-          "S3Key": "cdk/TEST/imagecopier/imagecopier.zip",
+          "S3Key": "cdk/TEST/imagecopier/image-copier.zip",
         },
         "Description": "Lambda for housekeeping AMIgo baked AMIs in other accounts",
         "Environment": Object {
@@ -210,7 +210,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": "deploy-tools-dist",
-          "S3Key": "cdk/TEST/imagecopier/imagecopier.zip",
+          "S3Key": "cdk/TEST/imagecopier/image-copier.zip",
         },
         "Description": "Lambda for copying and encrypting AMIgo baked AMIs",
         "Environment": Object {

--- a/cdk/lib/image-copier-lambda.ts
+++ b/cdk/lib/image-copier-lambda.ts
@@ -80,7 +80,7 @@ export class ImageCopierLambda extends GuStack {
 
     const housekeepingLambda = new Function(this, "HousekeepingLambda", {
       description: "Lambda for housekeeping AMIgo baked AMIs in other accounts",
-      runtime: Runtime.JAVA_8,
+      runtime: Runtime.JAVA_11,
       memorySize: 512,
       handler: "com.gu.imageCopier.LambdaEntrypoint::housekeeping",
       timeout: Duration.seconds(30),

--- a/cdk/lib/image-copier-lambda.ts
+++ b/cdk/lib/image-copier-lambda.ts
@@ -49,7 +49,7 @@ export class ImageCopierLambda extends GuStack {
         KMS_KEY_ARN: kmsKeyArn,
         ENCRYPTED_TAG_VALUE: "true",
       },
-      code: Code.fromBucket(functionCodeBucket, `${this.stack}/${this.stage}/imagecopier/imagecopier.zip`),
+      code: Code.fromBucket(functionCodeBucket, `${this.stack}/${this.stage}/imagecopier/image-copier.zip`),
       initialPolicy: [
         loggingPolicy,
         new PolicyStatement({
@@ -89,7 +89,7 @@ export class ImageCopierLambda extends GuStack {
         KMS_KEY_ARN: kmsKeyArn,
         ENCRYPTED_TAG_VALUE: "true",
       },
-      code: Code.fromBucket(functionCodeBucket, `${this.stack}/${this.stage}/imagecopier/imagecopier.zip`),
+      code: Code.fromBucket(functionCodeBucket, `${this.stack}/${this.stage}/imagecopier/image-copier.zip`),
       initialPolicy: [
         loggingPolicy,
         new PolicyStatement({


### PR DESCRIPTION
## What does this change?

- Upgrades the java runtime from 8 to 11
- Changes the name of the image copier lambda zip to force an update