### PR TITLE
Revert "Non-AWS dependency updates"

### DIFF
--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -167,7 +167,7 @@ class AppComponents(context: Context, identity: AppIdentity)
   val elkLoggingStream = configuration.get[Option[String]]("elk.loggingStream")
   val elkLogging = new ElkLogging(identity, elkLoggingStream, awsCredsForV2)
 
-  implicit val dynamo: Dynamo = {
+  implicit val dynamo = {
     val dynamoClient: DynamoDbClient = DynamoDbClient
       .builder()
       .credentialsProvider(awsCredsForV2)
@@ -261,9 +261,7 @@ class AppComponents(context: Context, identity: AppIdentity)
     ActorSystem[BakeEvent](Behaviours.guardian(eventListeners), "EventBus")
   }
 
-  implicit val eventBus: ActorSystemWrapper = new ActorSystemWrapper(
-    eventBusActorSystem
-  )
+  implicit val eventBus = new ActorSystemWrapper(eventBusActorSystem)
 
   val googleAuthConfig = GoogleAuthConfig(
     clientId = mandatoryConfig("google.clientId"),
@@ -275,7 +273,7 @@ class AppComponents(context: Context, identity: AppIdentity)
     antiForgeryChecker = AntiForgeryChecker(secretStateSupplier)
   )
 
-  implicit val packerConfig: PackerConfig = PackerConfig(
+  implicit val packerConfig = PackerConfig(
     stage = stage,
     vpcId = configuration.get[Option[String]]("packer.vpcId"),
     subnetId = configuration.get[Option[String]]("packer.subnetId"),

--- a/app/data/DynamoFormats.scala
+++ b/app/data/DynamoFormats.scala
@@ -5,7 +5,7 @@ import org.joda.time.DateTime
 
 object DynamoFormats {
 
-  implicit val dateTimeFormat: DynamoFormat[DateTime] =
+  implicit val dateTimeFormat =
     DynamoFormat.coercedXmap[DateTime, String, IllegalArgumentException](
       DateTime.parse,
       _.toString

--- a/app/event/BakeEvent.scala
+++ b/app/event/BakeEvent.scala
@@ -22,44 +22,43 @@ object BakeEvent {
 
   def unapply(event: BakeEvent): Option[BakeId] = Some(event.bakeId)
 
-  implicit val eventIdExtractor: EventIdExtractor[BakeEvent] =
+  implicit val eventIdExtractor =
     EventIdExtractor[BakeEvent](e => Some(e.eventId))
 
-  implicit val eventDataExtractor: EventDataExtractor[BakeEvent] =
-    EventDataExtractor[BakeEvent]({ event =>
-      val json = event match {
-        case Log(_, log) =>
-          JsObject(
-            Seq(
-              "eventType" -> JsString("log"),
-              "timestamp" -> JsString(
-                log.timestamp.toString("YYYY-MM-dd HH:mm:ss")
-              ),
-              "log" -> JsObject(
-                Seq(
-                  "level" -> JsString(log.logLevel),
-                  "number" -> JsNumber(log.logNumber),
-                  "messageHtml" -> JsString(log.messageHtml.toString)
-                )
+  implicit val eventDataExtractor = EventDataExtractor[BakeEvent]({ event =>
+    val json = event match {
+      case Log(_, log) =>
+        JsObject(
+          Seq(
+            "eventType" -> JsString("log"),
+            "timestamp" -> JsString(
+              log.timestamp.toString("YYYY-MM-dd HH:mm:ss")
+            ),
+            "log" -> JsObject(
+              Seq(
+                "level" -> JsString(log.logLevel),
+                "number" -> JsNumber(log.logNumber),
+                "messageHtml" -> JsString(log.messageHtml.toString)
               )
             )
           )
-        case AmiCreated(_, amiId) =>
-          JsObject(
-            Seq(
-              "eventType" -> JsString("ami-created"),
-              "amiId" -> JsString(amiId.value)
-            )
+        )
+      case AmiCreated(_, amiId) =>
+        JsObject(
+          Seq(
+            "eventType" -> JsString("ami-created"),
+            "amiId" -> JsString(amiId.value)
           )
-        case PackerProcessExited(_, exitCode) =>
-          JsObject(
-            Seq(
-              "eventType" -> JsString("packer-process-exited"),
-              "exitCode" -> JsNumber(exitCode)
-            )
+        )
+      case PackerProcessExited(_, exitCode) =>
+        JsObject(
+          Seq(
+            "eventType" -> JsString("packer-process-exited"),
+            "exitCode" -> JsNumber(exitCode)
           )
-      }
-      json.toString()
-    })
+        )
+    }
+    json.toString()
+  })
 
 }

--- a/app/models/BakeStatus.scala
+++ b/app/models/BakeStatus.scala
@@ -17,7 +17,7 @@ object BakeStatus extends Enum[BakeStatus] {
   case object TimedOut extends BakeStatus
   case object DeletionScheduled extends BakeStatus
 
-  implicit val dynamoFormat: DynamoFormat[BakeStatus] = {
+  implicit val dynamoFormat = {
     def fromString(s: String): Either[DynamoReadError, BakeStatus] =
       Either.fromOption(
         withNameOption(s),

--- a/app/models/CustomisedRole.scala
+++ b/app/models/CustomisedRole.scala
@@ -39,21 +39,18 @@ object ListParamValue {
   def of(params: String*) = ListParamValue(params.map(SingleParamValue).toList)
 }
 object ParamValue {
-  implicit val format: DynamoFormat[ParamValue] =
-    DynamoFormat.xmap[ParamValue, String](
-      fastparse
-        .parse(_, CustomisedRole.paramValue(_))
-        .fold(
-          (_, _, _) =>
-            Left(
-              TypeCoercionError(
-                new RuntimeException("Unable to read ParamValue")
-              )
-            ),
-          (pv, _) => Right(pv)
-        ),
-      _.quoted
-    )
+  implicit val format = DynamoFormat.xmap[ParamValue, String](
+    fastparse
+      .parse(_, CustomisedRole.paramValue(_))
+      .fold(
+        (_, _, _) =>
+          Left(
+            TypeCoercionError(new RuntimeException("Unable to read ParamValue"))
+          ),
+        (pv, _) => Right(pv)
+      ),
+    _.quoted
+  )
 }
 
 object CustomisedRole {
@@ -97,7 +94,6 @@ object CustomisedRole {
     }
   }
 
-  implicit val format: DynamoFormat[CustomisedRole] =
-    implicitly[DynamoFormat[CustomisedRole]]
+  implicit val format = implicitly[DynamoFormat[CustomisedRole]]
 
 }

--- a/app/models/packer/PackerBuildConfig.scala
+++ b/app/models/packer/PackerBuildConfig.scala
@@ -1,6 +1,6 @@
 package models.packer
 
-import play.api.libs.json._
+import play.api.libs.json.Json
 
 /** Case class representation of a Packer json file
   */
@@ -11,6 +11,5 @@ case class PackerBuildConfig(
 )
 
 object PackerBuildConfig {
-  implicit val jsonWrites: Writes[PackerBuildConfig] =
-    Json.writes[PackerBuildConfig]
+  implicit val jsonWrites = Json.writes[PackerBuildConfig]
 }

--- a/app/models/packer/PackerProvisionerConfig.scala
+++ b/app/models/packer/PackerProvisionerConfig.scala
@@ -2,7 +2,7 @@ package models.packer
 
 import java.nio.file.{Files, Path}
 
-import play.api.libs.json._
+import play.api.libs.json.Json
 
 import scala.jdk.CollectionConverters._
 
@@ -19,8 +19,7 @@ case class PackerProvisionerConfig(
 )
 
 object PackerProvisionerConfig {
-  implicit val jsonWrites: Writes[PackerProvisionerConfig] =
-    Json.writes[PackerProvisionerConfig]
+  implicit val jsonWrites = Json.writes[PackerProvisionerConfig]
 
   def fileCopy(source: Path, destination: String) = PackerProvisionerConfig(
     `type` = "file",

--- a/app/models/packer/PackerVariablesConfig.scala
+++ b/app/models/packer/PackerVariablesConfig.scala
@@ -2,7 +2,7 @@ package models.packer
 
 import models.Bake
 import org.joda.time.format.DateTimeFormat
-import play.api.libs.json._
+import play.api.libs.json.Json
 
 case class PackerVariablesConfig(
     recipe: String,
@@ -12,8 +12,7 @@ case class PackerVariablesConfig(
 )
 
 object PackerVariablesConfig {
-  implicit val jsonWrites: Writes[PackerVariablesConfig] =
-    Json.writes[PackerVariablesConfig]
+  implicit val jsonWrites = Json.writes[PackerVariablesConfig]
 
   val format = DateTimeFormat.forPattern("yyyy/MM/dd_HH-mm-ss")
   def apply(bake: Bake): PackerVariablesConfig = {

--- a/app/prism/RecipeUsage.scala
+++ b/app/prism/RecipeUsage.scala
@@ -2,7 +2,7 @@ package prism
 
 import data.{Bakes, Dynamo, PackageList, Recipes}
 import models.{AmiId, Bake, BakeId, Recipe, RecipeId}
-import play.api.libs.json._
+import play.api.libs.json.Json
 import prism.Prism.{Image, Instance, LaunchConfiguration}
 import services.PrismData
 
@@ -19,7 +19,7 @@ case class BakeUsage(
 case class SimpleBakeUsage(bakeId: BakeId, packageListS3Location: String)
 
 object SimpleBakeUsage {
-  implicit val writes: Writes[SimpleBakeUsage] = Json.writes[SimpleBakeUsage]
+  implicit val writes = Json.writes[SimpleBakeUsage]
 
   def fromBakeUsage(
       bakeUsage: BakeUsage,

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import java.time.{ZoneId, ZonedDateTime}
 
 name := "amigo"
 version := "1.0-latest"
-scalaVersion := "2.13.11"
+scalaVersion := "2.13.10"
 
 Universal / javaOptions ++= Seq(
   s"-Dpidfile.path=/dev/null",
@@ -120,7 +120,7 @@ routesImport += "models._"
 lazy val imageCopier = (project in file("imageCopier"))
   .enablePlugins(JavaAppPackaging)
   .settings(
-    scalaVersion := "2.13.11",
+    scalaVersion := "2.13.10",
     Universal / topLevelDirectory := None,
     Universal / packageName := normalizedName.value,
     libraryDependencies ++= Seq(

--- a/test/prism/PrismSpec.scala
+++ b/test/prism/PrismSpec.scala
@@ -4,7 +4,7 @@ import models.AmiId
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.{Configuration, Environment}
-import play.api.http.{DefaultFileMimeTypes, DefaultFileMimeTypesProvider}
+import play.api.http.DefaultFileMimeTypesProvider
 import play.api.http.HttpConfiguration.HttpConfigurationProvider
 import play.api.mvc.{Action, Results}
 import play.api.test.WsTestClient
@@ -24,10 +24,9 @@ class PrismSpec extends AnyFlatSpec with Matchers {
     Configuration.load(environment),
     environment
   ).get
-  implicit val fileMimeTypes: DefaultFileMimeTypes =
-    new DefaultFileMimeTypesProvider(
-      httpConfiguration.fileMimeTypes
-    ).get
+  implicit val fileMimeTypes = new DefaultFileMimeTypesProvider(
+    httpConfiguration.fileMimeTypes
+  ).get
 
   val controllerComponents = stubControllerComponents()
 


### PR DESCRIPTION
Reverts guardian/amigo#1191 as it's causing some NPE to be thrown, and a [deployment failure](https://riffraff.gutools.co.uk/deployment/view/f3333c2c-0292-41e5-8937-964781311b53?verbose=true). As observed in the cloud-init logs:

```log
Failed to start application due to java.lang.NullPointerException
```