### PR TITLE
chore(deps): Ignore AWS CDK libraries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
       interval: 'monthly'
     commit-message:
       prefix: "chore(deps): "
+
+    # The version of AWS CDK libraries must match those from @guardian/cdk.
+    # We'd never be able to update them here independently, so just ignore them.
+    ignore:
+      - dependency-name: "aws-cdk"
+      - dependency-name: "aws-cdk-lib"
+      - dependency-name: "constructs"


### PR DESCRIPTION
## What does this change?
The version of AWS CDK libraries must match those from @guardian/cdk. We'd never be able to update them here independently, so just ignore them.

When bumping GuCDK, we can get the matching AWS CDK library versions via:

```sh
npm info @guardian/cdk@latest peerDependencies version
```