### PR TITLE
chore(deps): Correct Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,11 @@ updates:
       interval: 'monthly'
     commit-message:
       prefix: "chore(deps): "
-
+  - package-ecosystem: 'npm'
+    schedule:
+      interval: 'monthly'
+    commit-message:
+      prefix: "chore(deps): "
     # The version of AWS CDK libraries must match those from @guardian/cdk.
     # We'd never be able to update them here independently, so just ignore them.
     ignore:


### PR DESCRIPTION
## What does this change?
Corrects the configuration added in #1203 - the ignore rules should be in the NPM `package-ecosystem`.

See https://github.com/guardian/cdk-playground/blob/main/.github/dependabot.yml as a comparison.