### PR TITLE
Migrate from Akka to Pekko

### DIFF
--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -1,6 +1,7 @@
 package components
 
-import akka.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => UntypedActorSystem}
 import com.amazonaws.{
   AmazonClientException,
   AmazonWebServiceRequest,
@@ -198,10 +199,12 @@ class AppComponents(context: Context, identity: AppIdentity)
   val amiMetadataLookup: AmiMetadataLookup = new AmiMetadataLookup(ec2Client)
 
   val prism = new Prism(wsClient)
+  val pekkoActorSystem = UntypedActorSystem.create("pekko")
+
   val prismAgents = new PrismData(
     prism,
     applicationLifecycle,
-    actorSystem.scheduler,
+    pekkoActorSystem.scheduler,
     environment
   )
 

--- a/app/controllers/BakeController.scala
+++ b/app/controllers/BakeController.scala
@@ -1,6 +1,5 @@
 package controllers
 
-import akka.stream.scaladsl.Source
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
 import com.gu.googleauth.{AuthAction, GoogleAuthConfig}
 import data._

--- a/app/event/Behaviours.scala
+++ b/app/event/Behaviours.scala
@@ -1,8 +1,7 @@
 package event
 
-import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
-import akka.stream.Materializer
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
 import data.{BakeLogs, Bakes, Dynamo}
 import event.BakeEvent._
 import models.{AmiId, Bake, BakeStatus, NotificationConfig}

--- a/app/event/EventBus.scala
+++ b/app/event/EventBus.scala
@@ -1,6 +1,6 @@
 package event
 
-import akka.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.ActorSystem
 
 trait EventBus {
 

--- a/app/services/PrismData.scala
+++ b/app/services/PrismData.scala
@@ -1,6 +1,6 @@
 package services
 
-import akka.actor.{Cancellable, Scheduler}
+import org.apache.pekko.actor.{Cancellable, Scheduler}
 import models.AmiId
 import org.joda.time.DateTime
 import play.api.inject.ApplicationLifecycle

--- a/build.sbt
+++ b/build.sbt
@@ -88,8 +88,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
   "org.scanamo" %% "scanamo" % "1.0.0-M26",
   "com.beachape" %% "enumeratum" % "1.7.3",
-  // Pin akka version until Play updates its own akka dependency
-  "com.typesafe.akka" %% "akka-actor-typed" % "2.6.19", // scala-steward:off
+  "org.apache.pekko" %% "pekko-actor-typed" % "1.0.0",
   "com.gu" %% "simple-configuration-ssm" % "1.5.8",
   "com.gu.play-secret-rotation" %% "play-v28" % "0.37",
   "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "0.37",


### PR DESCRIPTION
~~*UPDATE: the build is now failing as Pekko have pulled the release-candidate 1 that was published. We're at the cutting edge folks! See https://lists.apache.org/thread/0jl8qm0owv7r81v89pnc0o00ys9d6x37. They plan to redo the release in a couple of days so will bump then. On the positive side, the test to CODE worked! I was able to successfully bake an image, and the housekeeping jobs were running.*~~ Pekko have now release a v1. 🎉 

## What does this change?

Migrates from Akka to [Pekko](https://pekko.apache.org/). This is a test to better understand the process and evaluate Pekko's readiness.

## How to test

Deploy to CODE and build some things. Also check the logs for any errors.

## What is the value of this?

Akka have introduced licensing changes and we therefore want to migate away from it by Sept 2023. The clearest migration path is to use Pekko instead. Pekko is an Apache-incubated fork and is intended to be a drop-in replacement for Akka, albeit with some [minor changes required](https://pekko.apache.org/docs/pekko/current/project/migration-guides.html).
