### PR TITLE
chore(deps): Bump anghammarad-client from 1.2.0 to 1.7.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.16" % Test,
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test,
   "fun.mike" % "diff-match-patch" % "0.0.2",
-  "com.gu" %% "anghammarad-client" % "1.2.0"
+  "com.gu" %% "anghammarad-client" % "1.7.5"
 )
 routesGenerator := InjectedRoutesGenerator
 routesImport += "models._"


### PR DESCRIPTION
## What does this change?
Updates the version of [anghammarad](https://github.com/guardian/anghammarad) being used.

## How to test
CI passing should suffice.

## What is the value of this?
This helps address a vulnerability in a transitive dependency.

## Have we considered potential risks?
N/A