### PR TITLE
`aws-tools` Role Uses `awscli` v1.29.8

### DIFF
--- a/roles/aws-tools/tasks/install-pip-aws-cli-Debian.yml
+++ b/roles/aws-tools/tasks/install-pip-aws-cli-Debian.yml
@@ -3,4 +3,4 @@
   apt: name=python3-pip state=present
 
 - name: Install latest AWS CLI
-  command: pip3 install -I awscli==1.19.12
+  command: pip3 install -I awscli==1.29.8


### PR DESCRIPTION
This is the current latest version of the awscli.

Attempts to solve a problem where the awscli was failing to install correctly. The problem was fixed in a recent version of the awscli: https://github.com/aws/aws-cli/issues/8036#issuecomment-1640932993

The awscli was previously pinned to a specific version due to a lack of support for Python 3.4/3.5: https://github.com/guardian/amigo/pull/549

Alternative to #1232 
