### PR TITLE
`aws-tools` Role Uses Latest `awscli`

### DIFF
--- a/roles/aws-tools/tasks/install-pip-aws-cli-Debian.yml
+++ b/roles/aws-tools/tasks/install-pip-aws-cli-Debian.yml
@@ -3,4 +3,4 @@
   apt: name=python3-pip state=present
 
 - name: Install latest AWS CLI
-  command: pip3 install -I awscli==1.19.12
+  command: pip3 install awscli


### PR DESCRIPTION
Changes the `awscli` install step to always install the latest version. Essentially the inverse change to https://github.com/guardian/amigo/pull/549 where the `awscli` was pinned to a specific version due to a lack of support for Python 3.4/3.5

Attempts to solve a problem where the awscli was failing to install correctly. The problem was fixed in a recent version of the `awscli`: https://github.com/aws/aws-cli/issues/8036#issuecomment-1640932993

Alternative to #1231 
