### PR TITLE
Apply weekly updates to Dependabot and improve scala-steward.conf

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,18 @@
 version: 2
 updates:
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: 'monthly'
+      interval: "weekly"
     commit-message:
       prefix: "chore(deps): "
-  - package-ecosystem: 'npm'
-    directory: '/cdk'
+    groups:
+      all:
+        pattern: "*"
+  - package-ecosystem: "npm"
+    directory: "/cdk"
     schedule:
-      interval: 'monthly'
+      interval: "weekly"
     commit-message:
       prefix: "chore(deps): "
     # The version of AWS CDK libraries must match those from @guardian/cdk.
@@ -18,3 +21,6 @@ updates:
       - dependency-name: "aws-cdk"
       - dependency-name: "aws-cdk-lib"
       - dependency-name: "constructs"
+    groups:
+      all:
+        pattern: "*"

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,7 @@
 pullRequests.frequency = "7 days"
+commits.message = "chore(deps): Bump ${artifactName} from ${currentVersion} to ${nextVersion}" # Designed to match Dependabot format.
+updates.ignore = [ { groupId = "com.typesafe.akka" }, {groupId = "com.lightbend.akka"} ] # Temp ignore Akka to avoid licence fees while we evaluate Pekko.
 
 pullRequests.grouping = [
-  { name = "all", "title" = "Scala Steward weekly dependency updates", "filter" = [{"group" = "*"}] }
+  { name = "all", "title" = "chore(deps): Weekly dependency updates (Scala Steward)", "filter" = [{"group" = "*"}] }
 ]


### PR DESCRIPTION
This is an alternative to https://github.com/guardian/amigo/pull/1233. See that card for the full comparison.

## What does this change?

Dependabot now supports grouping:

https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

As Scala Steward also supports grouping, we can potentially achieve our RFC aims without using additional tooling.

There are some limitations though:

* applies per 'update' so can't group across action dep bumps and npm dep bumps here
* can't easily configure the PR titles
* grouping means we do not raise separate PRs per dep so diagnosing failed CI runs may be more difficult (as there will be multiple deps updated in the grouped PR)

On the plus side, we do not need to ignore temporary individual PRs which makes it easier to reduce PR (Announcer) noise.

## How to test

Merge and see.

## What is the value of this?

Reduced PRs and prove pattern for other repos too.