### PR TITLE
Fix frequency definition - requires @ prefix

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -3,7 +3,7 @@
 # and is part of a test implementation of
 # https://docs.google.com/document/d/1FIfovh2p08lWkXk3i83H4TAxf5V3Jj0j7wEUEe09Wcs/edit.
 
-pullRequests.frequency = "asap"
+pullRequests.frequency = "@asap"
 commits.message = "chore(deps): Bump ${artifactName} from ${currentVersion} to ${nextVersion}" # Designed to match Dependabot format.
 updates.ignore = [ { groupId = "com.typesafe.akka" }, {groupId = "com.lightbend.akka"} ] # Temp ignore Akka to avoid licence fees while we evaluate Pekko.
 pullRequests.customLabels = [ "dependencies" ]


### PR DESCRIPTION
Hopefully fixes the Scala Steward definition. Good error reporting from SS helps here:

<img width="842" alt="Screenshot 2023-07-27 at 09 29 09" src="https://github.com/guardian/amigo/assets/858402/935eba80-a942-48f1-910a-f80d634ad0cb">
