### PR TITLE
feat: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,3 @@
-
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -9,9 +8,9 @@ updates:
       prefix: "chore(deps): "
     labels:
       - "dependencies"
-	groups:
-	  all:
-	    patterns: "*"
+    groups:
+      all:
+        patterns: ["*"]
 
   - package-ecosystem: "npm"
     directory: "/cdk"
@@ -27,20 +26,6 @@ updates:
       - dependency-name: "constructs"
     labels:
       - "dependencies"
-	groups:
-	  all:
-	    patterns: "*"
-
-
-  - package-ecosystem: "go"
-    directory: "/cdk/node_modules/aws-cdk/test/integ/cli/sam_cdk_integ_app/src/go/GoFunctionConstruct"
-	schedule:
-	  interval: "weekly"
-	commit-message:
-	  prefix: "chore(deps): "
-	labels:
-	  - "dependencies"
-	groups:
-	  all:
-	    patterns: "*"
-
+    groups:
+      all:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,22 @@
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore(deps): "
     labels:
       - "dependencies"
+	groups:
+	  all:
+	    patterns: "*"
+
   - package-ecosystem: "npm"
     directory: "/cdk"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore(deps): "
     # The version of AWS CDK libraries must match those from @guardian/cdk.
@@ -22,3 +27,20 @@ updates:
       - dependency-name: "constructs"
     labels:
       - "dependencies"
+	groups:
+	  all:
+	    patterns: "*"
+
+
+  - package-ecosystem: "go"
+    directory: "/cdk/node_modules/aws-cdk/test/integ/cli/sam_cdk_integ_app/src/go/GoFunctionConstruct"
+	schedule:
+	  interval: "weekly"
+	commit-message:
+	  prefix: "chore(deps): "
+	labels:
+	  - "dependencies"
+	groups:
+	  all:
+	    patterns: "*"
+

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,9 +1,0 @@
-# This file overrides
-# https://github.com/guardian/scala-steward-public-repos/blob/main/scala-steward.conf
-# and is part of a test implementation of
-# https://docs.google.com/document/d/1FIfovh2p08lWkXk3i83H4TAxf5V3Jj0j7wEUEe09Wcs/edit.
-
-pullRequests.frequency = "@asap"
-commits.message = "chore(deps): Bump ${artifactName} from ${currentVersion} to ${nextVersion}" # Designed to match Dependabot format.
-updates.ignore = [ { groupId = "com.typesafe.akka" }, {groupId = "com.lightbend.akka"} ] # Temp ignore Akka to avoid licence fees while we evaluate Pekko.
-pullRequests.customLabels = [ "dependencies" ]


### PR DESCRIPTION
This PR reconfigures our dependency management configuration using this script:

https://github.com/guardian/configure-dependency-management

The previous approach attempted to use the `combine-prs` action to consolidate individual PRs from Dependabot and Scala Steward. The benefit to this was (in theory):

* a single grouped PR, which is easier to review/manage
* while running updates against individual PRs first to isolate any CI errors

Unfortunately, the approach has some issues:

1. combine-prs doesn't have any way to close the individual PRs, leaving a lot of manual work (see: https://github.com/github/combine-prs/issues/25)
2. Scala Steward combines the central configuration with our own, which means grouping is always applied anyway

Another issue is that individual PRs need to be regularly updated against changes to `main` to benefit from the isolated CI runs. We had no mechanism for this.

The approach in this PR simplifies things by relying on the in-built grouping of Dependabot and Scala Steward instead. It's not perfect, but I think it is the best approach in terms of outcome and simplicity.

*This PR was created by [a script](https://github.com/guardian/configure-dependency-management) to configure Dependabot. Please review and merge if appropriate.*