### PR TITLE
Configure Dependabot for @guardian/automerge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      time: "09:30"
+      timezone: "Europe/London"
     commit-message:
       prefix: "chore(deps): "
     labels:
       - "dependencies"
-    groups:
-      all:
-        patterns: ["*"]
 
   - package-ecosystem: "npm"
     directory: "/cdk"
     schedule:
       interval: "weekly"
+      time: "09:30"
+      timezone: "Europe/London"
     commit-message:
       prefix: "chore(deps): "
     # The version of AWS CDK libraries must match those from @guardian/cdk.
@@ -26,6 +27,3 @@ updates:
       - dependency-name: "constructs"
     labels:
       - "dependencies"
-    groups:
-      all:
-        patterns: ["*"]


### PR DESCRIPTION
(A test of @guardian/automerge.)

* stop batching Dependabot PRs
* schedule Dependabot to ensure it runs during our working hours

Following this change, and once we have manually added the automerge Github App to this repo, we should see bot-raised PRs automatically merged in provided status checks pass.

Obviously this adds some risk but CI passing should give us confidence here. And PRs are only merged in during weekdays and between 9-5.

@see https://github.com/guardian/automerge

