### PR TITLE
docs(cdk-base): fix missing IAM action kinesis:PutRecords

### DIFF
--- a/roles/cdk-base/README.md
+++ b/roles/cdk-base/README.md
@@ -39,6 +39,7 @@ Resources:
 EC2 instances must have the following IAM permissions:
 - `kinesis:DescribeStream` scoped to the Kinesis stream above
 - `kinesis:PutRecord` scoped to the Kinesis stream above
+- `kinesis:PutRecords` scoped to the Kinesis stream above
 - `ec2:DescribeTags`
 - `ec2:DescribeInstances`
 
@@ -75,6 +76,7 @@ Resources:
           Action:
           - kinesis:DescribeStream
           - kinesis:PutRecord
+          - kinesis:PutRecords
           Resource: !Sub 'arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${LoggingStreamName}'
         - Effect: Allow
           Resource: '*'


### PR DESCRIPTION
When working on https://github.com/guardian/editorial-tools-platform/pull/703 / https://github.com/guardian/targeting/pull/183 nothing was shipping to ELK and we noticed the following in td-agent-bit's own log output... 
![image](https://github.com/guardian/devx-logs/assets/19289579/83ed3c2b-d26d-4492-a77d-3f38a87bcdc3)
...turns out we were missing `kinesis:PutRecords` in our IAM policy.

This PR corrects the documentation to cover all required IAM actions.