### PR TITLE
Use HTTPS S3 urls to download CloudWatchMonitoring scripts

### DIFF
--- a/roles/cloud-watch-monitoring/tasks/main.yml
+++ b/roles/cloud-watch-monitoring/tasks/main.yml
@@ -3,5 +3,5 @@
   apt: name=unzip state=present
 
 - name: Download scripts
-  unarchive: src="http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip" dest=/usr/local/ copy=no
+  unarchive: src="https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip" dest=/usr/local/ copy=no
 

--- a/roles/usage-monitoring-agent/files/monitoring.sh
+++ b/roles/usage-monitoring-agent/files/monitoring.sh
@@ -28,7 +28,7 @@ function install_cloudwatch_client() {
   local __resultvar=$1
   local CLOUDWATCH_CLIENT_VERSION="1.2.1"
   apt-get install -y libwww-perl libdatetime-perl unzip
-  wget http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-${CLOUDWATCH_CLIENT_VERSION}.zip
+  wget https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-${CLOUDWATCH_CLIENT_VERSION}.zip
   unzip CloudWatchMonitoringScripts-${CLOUDWATCH_CLIENT_VERSION}.zip
   mv aws-scripts-mon ${INSTALL_LOCATION}
   rm CloudWatchMonitoringScripts-${CLOUDWATCH_CLIENT_VERSION}.zip


### PR DESCRIPTION
## What does this change?

This changes is motivated by Editorial tools bakes failing because HTTP endpoints now return 403 for this resource.

But HTTPS is A Good Thing, so we probably should have been doing this anyway.

I haven't seen any notification from AWS of this change.

## How to test

Minor change, testing almost not required.  But triggering a bake of any of the recently failed ed tools recipes should verify the fix.