### PR TITLE
Whisper.cpp: remove large model, parameterise git commit id to work from

### DIFF
--- a/roles/whisper-cpp/defaults/main.yml
+++ b/roles/whisper-cpp/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 target_dir: /opt/whisper
+whisper_cpp_commit_hash: 9f8bbd3feee603f9ada479fa9c39c03acf2cc6e1

--- a/roles/whisper-cpp/tasks/main.yml
+++ b/roles/whisper-cpp/tasks/main.yml
@@ -11,12 +11,13 @@
     mkdir -p {{ target_dir }}
     cd {{ target_dir }}
     echo "cloning"
-    git clone --depth 1 --branch v1.4.0 --quiet https://github.com/ggerganov/whisper.cpp.git
+    git clone --quiet https://github.com/ggerganov/whisper.cpp.git
     cd whisper.cpp
-    echo "downloading model"
-    bash models/download-ggml-model.sh medium > /dev/null
-    bash models/download-ggml-model.sh small > /dev/null
-    bash models/download-ggml-model.sh base > /dev/null
+    git reset --hard {{ whisper_cpp_commit_hash }}
+    echo "downloading models"
+    bash models/download-ggml-model.sh medium >
+    bash models/download-ggml-model.sh small >
+    bash models/download-ggml-model.sh base >
     echo "compiling"
     make
     cd {{ target_dir }}

--- a/roles/whisper-cpp/tasks/main.yml
+++ b/roles/whisper-cpp/tasks/main.yml
@@ -15,9 +15,9 @@
     cd whisper.cpp
     git reset --hard {{ whisper_cpp_commit_hash }}
     echo "downloading models"
-    bash models/download-ggml-model.sh medium >
-    bash models/download-ggml-model.sh small >
-    bash models/download-ggml-model.sh base >
+    bash models/download-ggml-model.sh medium
+    bash models/download-ggml-model.sh small
+    bash models/download-ggml-model.sh base
     echo "compiling"
     make
     cd {{ target_dir }}


### PR DESCRIPTION
## What does this change?
Our whisper.cpp build timed out. This PR aims to help the situation by:
 - removing the 'large' model (over 3 GB) - it's unlikely we'll be able to use this model in production any time soon
 - not throwing away the output from the downloads (so we can see where they fail)

In addition, given that new features to whisper.cpp are being added a lot faster than they are doing releases, I've changed our checkout behaviour so that we fetch the whole repo then reset to  a specific commit ID. This way we can either pin to a certain release or jump to the latest if we see something promising in recent changes to whisper.cpp 

This needs a quick test on amigo CODE prior to merging
