### PR TITLE
Remove download of large whisper model from whisper role

### DIFF
--- a/roles/whisper-cpp/tasks/main.yml
+++ b/roles/whisper-cpp/tasks/main.yml
@@ -14,7 +14,6 @@
     git clone --depth 1 --branch v1.4.0 --quiet https://github.com/ggerganov/whisper.cpp.git
     cd whisper.cpp
     echo "downloading model"
-    bash models/download-ggml-model.sh large > /dev/null
     bash models/download-ggml-model.sh medium > /dev/null
     bash models/download-ggml-model.sh small > /dev/null
     bash models/download-ggml-model.sh base > /dev/null


### PR DESCRIPTION
## What does this change?
Removes the download of large whisper model from whisper role so that we only download base, small, medium

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## Why
We've decided not to use this model for the moment. This should help us avoid bakes timing out.