### PR TITLE
Add `java21corretto` role

### DIFF
--- a/roles/java21corretto/README.md
+++ b/roles/java21corretto/README.md
@@ -1,0 +1,9 @@
+# Java 21 Corretto
+
+Corretto is an openjdk-based Java distribution, published by Amazon, with
+various performance and other changes to better suit AWS.
+
+It is the recommended Java distribution to use at the Guardian.
+
+This role installs the JDK and also modifies the default DNS cache control to
+cache for 60s instead of forever.

--- a/roles/java21corretto/meta/main.yml
+++ b/roles/java21corretto/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - role: apt
+    when: ansible_os_family == "Debian"

--- a/roles/java21corretto/spec/java21corretto_spec.rb
+++ b/roles/java21corretto/spec/java21corretto_spec.rb
@@ -1,0 +1,3 @@
+describe command('java -version') do
+  its(:stdout) { should match /java version "21\..*/ }
+end

--- a/roles/java21corretto/tasks/main.yml
+++ b/roles/java21corretto/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Add AWS Corretto signing key
+  apt_key:
+    url: "https://apt.corretto.aws/corretto.key"
+    state: present
+
+- name: Add AWS Corretto repo
+  apt_repository:
+    repo: "deb https://apt.corretto.aws stable main"
+    state: present
+
+- name: Install Java 21 Corretto JDK
+  apt:
+    name:
+      - java-21-amazon-corretto-jdk
+    state: latest
+  when: ansible_os_family == "Debian"
+
+## This modifies the JVM's DNS cache TTL, changing it from the default of INFINITY to 60
+## seconds. See this issue for full details: https://github.com/guardian/amigo/issues/238
+- name: Change JVM DNS cache TTL
+  replace:
+    path: /usr/lib/jvm/java21-amazon-corretto/conf/security/java.security
+    regexp: "#networkaddress.cache.ttl=.*"
+    replace: "networkaddress.cache.ttl=60"
+    backup: yes
+  when: ansible_os_family == "Debian"


### PR DESCRIPTION
## What does this change?

Adds a new Amigo role because of one the dependencies that we use in our project requires JRE 21, which is the latest  long-term support release.

Note that this will be used for a CODE-only service - in production we'll be running the application in a container using the [`amazoncorretto:21`](https://hub.docker.com/_/amazoncorretto/) image.
