### PR TITLE
fix: Fix `java.security` path in `java21corretto` role

### DIFF
--- a/roles/java21corretto/tasks/main.yml
+++ b/roles/java21corretto/tasks/main.yml
@@ -20,7 +20,7 @@
 ## seconds. See this issue for full details: https://github.com/guardian/amigo/issues/238
 - name: Change JVM DNS cache TTL
   replace:
-    path: /usr/lib/jvm/java21-amazon-corretto/conf/security/java.security
+    path: /usr/lib/jvm/java-21-amazon-corretto/conf/security/java.security
     regexp: "#networkaddress.cache.ttl=.*"
     replace: "networkaddress.cache.ttl=60"
     backup: yes


### PR DESCRIPTION
## What does this change?

Fixes a typo in the `java.security` path

## Why?
I accidentally missed a `-`, so the bake is failing with this message:

```
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "Path /usr/lib/jvm/java21-amazon-corretto/conf/security/java.security does not exist !", "rc": 257}
```

## How to test
Deployed to CODE Amigo and the installation succeeded. Note how the step didn't fail:
```
 changed: [127.0.0.1] => {"backup_file": "/usr/lib/jvm/java-21-amazon-corretto/conf/security/java.security.39338.2023-12-11@18:31:25~", "changed": true, "msg": "1 replacements made"}
```
