### PR TITLE
Bump logback-classic to 1.4.14

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,6 +103,8 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sts" % awsV1SdkVersion,
   "com.amazonaws" % "aws-java-sdk-kinesis" % awsV1SdkVersion,
   "net.logstash.logback" % "logstash-logback-encoder" % "7.4",
+  // Transient dependency of Play. No newer version of Play with this vulnerability fixed.
+  "ch.qos.logback" % "logback-classic" % "1.4.14",
   "software.amazon.awssdk" % "dynamodb" % awsV2SdkVersion,
   "software.amazon.awssdk" % "auth" % awsV2SdkVersion,
   "software.amazon.awssdk" % "regions" % awsV2SdkVersion,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps logback-classic to 1.4.14. Resolving 4 high vulnerabilities.