### PR TITLE
fix!: Make `configure-aws-kinesis-agent` fail fast

### DIFF
--- a/roles/aws-kinesis-agent/files/configure-aws-kinesis-agent
+++ b/roles/aws-kinesis-agent/files/configure-aws-kinesis-agent
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Fail fast. See https://explainshell.com/explain?cmd=set+-e.
+set -e
+
 region=$1
 kinesis_stream=$2
 file=$3


### PR DESCRIPTION
## What does this change?
Add `set -e` to the configure script means it'll exit at the first non-zero exit code. That is, it fails fast.

This means if we're unable to create the configuration JSON file, then we fail, and don't attempt to start the systemd process.

## How to test
TBD.

## What is the value of this?
Improved DX.

Currently, if the JSON file building fails, we still start the service. However, as the service has bad config, it won't do anything useful.

This change should make it easier to triage issues, as we'll see the service didn't even start.

## Have we considered potential risks?
TBD.

> **Note**
> If this change adds, updates or removes a role or recipe please note that in your PR and assign appropriate reviewers for the team that will be impacted by those changes.
