### PR TITLE
(whisper cpp role) Use parameter to determine which whisper models are downloaded

### DIFF
--- a/roles/whisper-cpp/README.md
+++ b/roles/whisper-cpp/README.md
@@ -1,0 +1,26 @@
+# Whisper.cpp role
+This role aims to download, compile and install [whisper.cpp](https://github.com/ggerganov/whisper.cpp).
+
+Whisper.cpp is a transcription service. There are a number of different models that can be used with whisper.cpp, with
+different accuracy/performance tradeoffs. You can configure which models are baked into your AMI using the following parameters:
+
+## whisper_models
+This determines which standard whisper models are downloaded. You can find the full list of available models 
+[here](https://github.com/ggerganov/whisper.cpp/tree/master/models#available-models).
+
+Example: `whisper_models: [small, base.en]`
+
+## whisper_distilled_model_paths
+[distil-whisper](https://github.com/huggingface/distil-whisper) is a more performant version of whisper. To understand the
+tradeoffs with using distil whisper see [github](https://github.com/huggingface/distil-whisper), 
+[hugging face](https://huggingface.co/distil-whisper/distil-medium.en) and the [whisper.cpp models section](https://github.com/ggerganov/whisper.cpp/tree/master/models#distilled-models)
+
+Generating the urls to download distilled models is a little tricky so you have to provide a full path. In a vague nod
+towards security, the https://huggingface.co/distil-whisper/ prefix of the url is hard coded - you'll need to provide the
+rest in a parameter
+
+Example: `whisper_distilled_model_paths: ['distil-medium.en/resolve/main/ggml-medium-32-2.en.bin']`
+
+## whisper_cpp_commit_hash
+This is nothing to do with models. It should ideally be set to the commit hash of a 
+[recent whisper.cpp release](https://github.com/ggerganov/whisper.cpp/releases)

--- a/roles/whisper-cpp/defaults/main.yml
+++ b/roles/whisper-cpp/defaults/main.yml
@@ -4,3 +4,5 @@ whisper_cpp_commit_hash: 9f8bbd3feee603f9ada479fa9c39c03acf2cc6e1
 whisper_models:
   - medium
   - small
+whisper_distilled_model_paths:
+  - 'distil-medium.en/resolve/main/ggml-medium-32-2.en.bin'

--- a/roles/whisper-cpp/defaults/main.yml
+++ b/roles/whisper-cpp/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 target_dir: /opt/whisper
 whisper_cpp_commit_hash: 9f8bbd3feee603f9ada479fa9c39c03acf2cc6e1
+whisper_models:
+  - medium
+  - small

--- a/roles/whisper-cpp/tasks/main.yml
+++ b/roles/whisper-cpp/tasks/main.yml
@@ -5,12 +5,13 @@
     - build-essential
     state: present
 
-- name: Clone and compile whisper.cpp
+- name: Clone whisper, clone and compile whisper.cpp
   shell: |
     set -e
     mkdir -p {{ target_dir }}
     cd {{ target_dir }}
     echo "cloning"
+    git clone --quiet https://github.com/openai/whisper
     git clone --quiet https://github.com/ggerganov/whisper.cpp.git
     cd whisper.cpp
     git reset --hard {{ whisper_cpp_commit_hash }}
@@ -25,6 +26,13 @@
     chown ubuntu ./ --recursive
     exit 0
   loop: "{{ whisper_models }}"
+
+- name: Download and convert medium distilled model
+  shell: |
+    cd {{ target_dir }}/whisper.cpp/models
+    git clone https://huggingface.co/distil-whisper/distil-medium.en
+    python3 ./convert-h5-to-ggml.py ./distil-medium.en/ {{ target_dir }}/whisper .
+    mv ggml-model.bin ggml-medium.en-distil.bin
 
 - name: Install whisper.cpp
   shell: |

--- a/roles/whisper-cpp/tasks/main.yml
+++ b/roles/whisper-cpp/tasks/main.yml
@@ -16,13 +16,11 @@
     git reset --hard {{ whisper_cpp_commit_hash }}
     echo "compiling"
     make
-    cd {{ target_dir }}
     exit 0
 
 - name: Download models and set permissions
   shell: |
-    cd {{ target_dir }}
-    cd whisper.cpp
+    cd {{ target_dir }}/whisper.cpp
     bash models/download-ggml-model.sh {{ item }}
     chown ubuntu ./ --recursive
     exit 0

--- a/roles/whisper-cpp/tasks/main.yml
+++ b/roles/whisper-cpp/tasks/main.yml
@@ -14,15 +14,19 @@
     git clone --quiet https://github.com/ggerganov/whisper.cpp.git
     cd whisper.cpp
     git reset --hard {{ whisper_cpp_commit_hash }}
-    echo "downloading models"
-    bash models/download-ggml-model.sh medium
-    bash models/download-ggml-model.sh small
-    bash models/download-ggml-model.sh base
     echo "compiling"
     make
     cd {{ target_dir }}
+    exit 0
+
+- name: Download models and set permissions
+  shell: |
+    cd {{ target_dir }}
+    cd whisper.cpp
+    bash models/download-ggml-model.sh {{ item }}
     chown ubuntu ./ --recursive
     exit 0
+  loop: "{{ whisper_models }}"
 
 - name: Install whisper.cpp
   shell: |

--- a/roles/whisper-cpp/tasks/main.yml
+++ b/roles/whisper-cpp/tasks/main.yml
@@ -11,7 +11,6 @@
     mkdir -p {{ target_dir }}
     cd {{ target_dir }}
     echo "cloning"
-    git clone --quiet https://github.com/openai/whisper
     git clone --quiet https://github.com/ggerganov/whisper.cpp.git
     cd whisper.cpp
     git reset --hard {{ whisper_cpp_commit_hash }}
@@ -27,14 +26,12 @@
     exit 0
   loop: "{{ whisper_models }}"
 
-- name: Download and convert medium distilled model
+- name: Download distilled models
   shell: |
     set -e
-    cd {{ target_dir }}/whisper.cpp/models
-    git clone https://huggingface.co/distil-whisper/distil-medium.en
-    pip3 install torch numpy transformers
-    python3 ./convert-h5-to-ggml.py ./distil-medium.en/ {{ target_dir }}/whisper .
-    mv ggml-model.bin ggml-medium.en-distil.bin
+    cd {{ target_dir }}/whisper.cpp
+    wget https://huggingface.co/distil-whisper/{{ item }} -P ./models
+  loop: "{{ whisper_distilled_model_paths }}"
 
 - name: Install whisper.cpp
   shell: |

--- a/roles/whisper-cpp/tasks/main.yml
+++ b/roles/whisper-cpp/tasks/main.yml
@@ -29,8 +29,10 @@
 
 - name: Download and convert medium distilled model
   shell: |
+    set -e
     cd {{ target_dir }}/whisper.cpp/models
     git clone https://huggingface.co/distil-whisper/distil-medium.en
+    pip3 install torch numpy transformers
     python3 ./convert-h5-to-ggml.py ./distil-medium.en/ {{ target_dir }}/whisper .
     mv ggml-model.bin ggml-medium.en-distil.bin
 


### PR DESCRIPTION
## What does this change?
We're doing a lot of experimentation with different whisper models at the moment and having to modify the role every time is getting a bit tedious. This change parameterises the names of the models which are downloaded when baking an AMI with the whisper role.

## How to test

There's a bake currently in progress [here](https://amigo.code.dev-gutools.co.uk/recipes/investigations-ocrmypdf/bakes/13) - let's see if it works....

