### PR TITLE
Upgrade all dependencies to Play 3

### DIFF
--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -75,7 +75,6 @@ import scala.language.postfixOps
 import java.io.FileInputStream
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import scala.util.Try
-import com.gu.googleauth.GoogleServiceAccount
 import com.gu.googleauth.GoogleGroupChecker
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.api.client

--- a/build.sbt
+++ b/build.sbt
@@ -90,9 +90,9 @@ libraryDependencies ++= Seq(
   "com.beachape" %% "enumeratum" % "1.7.3",
   "org.apache.pekko" %% "pekko-actor-typed" % "1.0.1",
   "com.gu" %% "simple-configuration-ssm" % "1.6.4",
-  "com.gu.play-secret-rotation" %% "play-v29" % "0.40",
-  "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "0.40",
-  "com.gu.play-googleauth" %% "play-v29" % "2.3.0",
+  "com.gu.play-secret-rotation" %% "play-v30" % "6.0.8",
+  "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "6.0.8",
+  "com.gu.play-googleauth" %% "play-v30" % "3.0.6",
   // Pin play-bootstrap because it is tied to the bootstrap version
   "com.adrianhurt" %% "play-bootstrap" % "1.6.1-P28-B3", // scala-steward:off
   "org.quartz-scheduler" % "quartz" % "2.3.2",


### PR DESCRIPTION
## What does this change?

Updates all of our dependencies to versions that use Play 3. Right now we have both Akka and Pekko in our dependency tree which isn't ideal.

Before:

<img width="615" alt="image" src="https://github.com/guardian/amigo/assets/21217225/af3f55fd-b859-4ee4-8cad-47bb3590e844">

After:

<img width="587" alt="image" src="https://github.com/guardian/amigo/assets/21217225/237a3e1b-72be-4a1b-a516-db5861477188">