### PR TITLE
Apply docker postinstall steps when installing dockerAdd ubuntu user to docker user group

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -34,6 +34,14 @@
     update_cache: yes
     state: present
 
+# See https://docs.docker.com/engine/install/linux-postinstall/ for why we're doing these steps
 - name: Create docker group
   group:
     name: docker
+
+- name: Add ubuntu user to docker group
+  user:
+      name: ubuntu
+      groups: docker
+      append: yes
+  when: ansible_distribution == "Ubuntu"


### PR DESCRIPTION
## What does this change?
On linux some extra steps have to be taken after installing docker so that it can be run by a non-root user. These are documented here https://docs.docker.com/engine/install/linux-postinstall/

Our role already did the thing of creating the docker group (step 1 of above docs) but didn't add the ubuntu user to that group (step 2). This PR resolves that. 

## How to test

Tested in this build https://amigo.code.dev-gutools.co.uk/recipes/investigations-ocrmypdf/bakes/30

Output:

```
[2024-02-07 12:09:02] investigations-ocrmypdf: TASK [docker : Add ubuntu user to docker group] ********************************
[2024-02-07 12:09:03] investigations-ocrmypdf: changed: [127.0.0.1] => {"append": true, "changed": true, "comment": "Ubuntu", "group": 1000, "groups": "docker", "home": "/home/ubuntu", "move_home": false, "name": "ubuntu", "shell": "/bin/bash", "state": "present", "uid": 1000}
```