### PR TITLE
Remove java8 dependency from browser testing role

### DIFF
--- a/roles/browser-testing/meta/main.yml
+++ b/roles/browser-testing/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - apt

--- a/roles/browser-testing/meta/main.yml
+++ b/roles/browser-testing/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - java8


### PR DESCRIPTION
## What does this change?

Removes the dependency from the role itself, enabling us to specify the java version in the AMI recipe through one of the associated roles instead.

This role is used in a recipe for the production monitoring tool, which uses chromedriver for automated browser testing. For context, we are in the process of updating [prodmon to play 3,](https://github.com/guardian/editorial-tools-production-monitoring/pull/331) which has required an update to java 11. 

## How to test

Once we've updated the existing recipe to use java 8 and created one for java 11, we'll need to try to deploy the updated branch of prodmon to verify this is all working as intended. 

## Have we considered potential risks?

The next scheduled bakes for the recipes which use this role are next Tuesday, giving ample time to respond to any issues. 

