### PR TITLE
Add required dependencies for aws-efs

### DIFF
--- a/roles/aws-efs/meta/main.yml
+++ b/roles/aws-efs/meta/main.yml
@@ -4,4 +4,9 @@ dependencies:
     packages: 
       - git
       - binutils
+      - rustc
+      - cargo
+      - pkg-config
+      - openssl
+      - libssl-dev
 

--- a/roles/aws-efs/tasks/main.yml
+++ b/roles/aws-efs/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Install rust
-  shell: |
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    source $HOME/.cargo/env
-  when: ansible_os_family == "Debian"
 
 - name: Ensure build directory is present
   file:

--- a/roles/aws-efs/tasks/main.yml
+++ b/roles/aws-efs/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Install rust
+  shell: |
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    source $HOME/.cargo/env
+  when: ansible_os_family == "Debian"
 
 - name: Ensure build directory is present
   file:


### PR DESCRIPTION
## What does this change?
efs utils now has a [dependency on rust](https://github.com/aws/efs-utils?tab=readme-ov-file#on-other-linux-distributions), and various other libraries which are added as part of this change

## How to test
Tested on Amigo CODE  here https://amigo.code.dev-gutools.co.uk/recipes/investigations-ocrmypdf