### PR TITLE
update aws_rds_root_cert_ca role to load new certificate bundle

### DIFF
--- a/roles/aws-rds-root-cert-ca/tasks/main.yml
+++ b/roles/aws-rds-root-cert-ca/tasks/main.yml
@@ -1,12 +1,20 @@
 ---
-- name: get aws RDS root CA certificate
+- name: get RDS CA certificate bundle
   get_url: url={{certificate_source}}{{certificate_name}}.pem dest=/tmp/{{certificate_name}}.pem
 
-- name: convert pem to der format
-  command: openssl x509 -outform der -in /tmp/{{certificate_name}}.pem -out /tmp/{{certificate_name}}.der
+- name: create directory for cert files
+  file:
+    path: /tmp/rds_certs/
+    state: directory
+- name: split bundle into individual files
+  command: csplit -sz /tmp/{{certificate_name}}.pem  -f /tmp/rds_certs/rds_cert_ '/-BEGIN CERTIFICATE-/' '{*}'
 
-- name: create new truststore
-  command: keytool -import -alias rds-root -keystore "{{truststore_dir}}{{truststore_name}}" -file /tmp/{{certificate_name}}.der -storepass "{{aws_rds_truststore_password | mandatory}}" -noprompt
+- name: add certificates to a new trust store
+  shell: |
+      for cert in /tmp/rds_certs/rds_cert_*; do
+          keytool -importcert -file $cert -alias $cert -keystore {{truststore_dir}}{{truststore_name}} -storepass "{{aws_rds_truststore_password | mandatory}}" -noprompt
+          rm $cert
+          done
 
-- name: import default truststore into new one
+- name: import default trust store into the new one
   command: keytool -importkeystore -srckeystore "{{truststore_dir}}cacerts" -srcstorepass "{{castore_password}}" -destkeystore "{{truststore_dir}}{{truststore_name}}" -deststorepass "{{aws_rds_truststore_password | mandatory}}"

--- a/roles/aws-rds-root-cert-ca/vars/main.yml
+++ b/roles/aws-rds-root-cert-ca/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-certificate_source: https://s3.amazonaws.com/rds-downloads/
-certificate_name: rds-ca-2019-root
+certificate_source: https://truststore.pki.rds.amazonaws.com/global/
+certificate_name: global-bundle
 truststore_dir: /usr/lib/ssl/certs/java/
 truststore_name: aws-rds-cacerts


### PR DESCRIPTION
## What does this change?
This PR updates the aws_rds_root_cert_ca to support new rds certificates which come in bundles instead of single files.

Looking at the [documentation on using ssl in RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) it looks like now instead of a single certificate there's bundles. The current code assumes the file that it gets from AWS contains a single certificate so if we try to use the new urls it would only load the first one.

A good side effect of loading the certificate in bundles is that it includes the deprecated certificate as well so applications that use it would work with either, which makes migrating with minimal downtime easier.

## How to test
 
For a first test we can sign in to an instance that uses this role and find the generated trust store file (by default `/usr/lib/ssl/certs/java/aws-rds-cacerts`) and list the certificates in it with something like  the keytool cli command `keytool -list -keystore ./[FILE_NAME_HERE]-rfc. This should list the certificates from the selected bundle.

Of course the real test is to just redeploy an instance using this role and being able to connect to rds database using any of the certificates in the bundle.

## What is the value of this?

RDS is deprecating a certificate soon which is still in use in databases, so we need to change it. 


