### PR TITLE
cdk-base: Add option to not automatically start fluentbit

### DIFF
--- a/roles/cdk-base/README.md
+++ b/roles/cdk-base/README.md
@@ -114,5 +114,6 @@ as this allows tag lookup without requiring remote AWS API calls at runtime._
     Set this to `false` if you do not want log shipping to start automatically.
     This is useful if you will add or change the log shipping config supplied by
     `devx-logs`. If you have set this to `false` you are now responsible for
-    starting `td-agent-bit.service` in your user data script, and if you fail to do
-    so logs will not be shipped.
+    starting `td-agent-bit.service` in your user data script
+    (by running `systemctl start td-agent-bit.service` after all config files
+    have been created), and if you fail to do so logs will not be shipped.

--- a/roles/cdk-base/README.md
+++ b/roles/cdk-base/README.md
@@ -106,3 +106,13 @@ Resources:
 _While not required, it is strongly recommended to [enable tag metadata on your
 instance](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-launchtemplatedata-metadataoptions.html#cfn-ec2-launchtemplate-launchtemplatedata-metadataoptions-instancemetadatatags)
 as this allows tag lookup without requiring remote AWS API calls at runtime._
+
+## Options
+
+- `start_fluentbit`: boolean, default `true`
+
+    Set this to `false` if you do not want log shipping to start automatically.
+    This is useful if you will add or change the log shipping config supplied by
+    `devx-logs`. If you have set this to `false` you are now responsible for
+    starting `td-agent-bit.service` in your user data script, and if you fail to do
+    so logs will not be shipped.

--- a/roles/cdk-base/defaults/main.yml
+++ b/roles/cdk-base/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 dist_bucket: amigo-data
+start_fluentbit: true

--- a/roles/cdk-base/tasks/main.yml
+++ b/roles/cdk-base/tasks/main.yml
@@ -35,6 +35,7 @@
     chmod +x /var/lib/cloud/scripts/per-instance/02-$NAME
   when:
     - ansible_os_family == "Debian"
+    - start_fluentbit
 
 - name: Remove syslog output
   shell: |


### PR DESCRIPTION
## What does this change?

Adds an option to the cdk-base role to _not_ automatically start fluentbit on instance start

## How to test

Create a recipe using this role with `start_fluentbit: false` in the custom variables. Does the instance automatically start sending logs, or does it wait for a command (either from a logged in dev or the user data script) to start?

## What is the value of this?

Currently if you want or need to add extra fluentbit config at instance start time (ie. in user data script) you must `systemctl restart td-agent-bit.service`, which means that the cloud-init logs up to that point will be resent from the start, meaning some logs are sent twice! If instead we never add the start-fluentbit script, we can start it when we have the full config in place, and still benefit from `devx-logs`!

## Have we considered potential risks?

Is a user of this option has a user data script that fails before it reaches a step which starts `td-agent-bit.service`, no logs will ever be shipped from that instance. This is called out in the README, and feels like an acceptable risk since users have explicitly opted into the behaviour, presumably to customise log shipping behaviour.

## Testing

- [x] Tested in CODE
