### PR TITLE
Add launch template support to AMIgo

### DIFF
--- a/app/prism/Prism.scala
+++ b/app/prism/Prism.scala
@@ -8,8 +8,11 @@ import services.Loggable
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class Prism(ws: WSClient, val baseUrl: String = "https://prism.gutools.co.uk")(
-    implicit ec: ExecutionContext
+class Prism(
+    ws: WSClient,
+    val baseUrl: String = "https://prism.gutools.co.uk"
+)(implicit
+    ec: ExecutionContext
 ) extends Loggable {
   import Prism._
 
@@ -22,6 +25,9 @@ class Prism(ws: WSClient, val baseUrl: String = "https://prism.gutools.co.uk")(
 
   def findAllLaunchConfigurations(): Future[Seq[LaunchConfiguration]] =
     findAll[LaunchConfiguration]("/launch-configurations")
+
+  def findAllLaunchTemplates(): Future[Seq[LaunchTemplate]] =
+    findAll[LaunchTemplate]("/launch-templates")
 
   def findCopiedImages(): Future[Seq[Image]] =
     findAll[Image]("/images?tags.CopiedFromAMI!=")
@@ -66,6 +72,11 @@ object Prism {
       imageId: AmiId,
       awsAccount: AWSAccount
   )
+  case class LaunchTemplate(
+      name: String,
+      imageId: AmiId,
+      awsAccount: AWSAccount
+  )
   case class Image(
       imageId: AmiId,
       ownerId: String,
@@ -90,6 +101,12 @@ object Prism {
     ((JsPath \ "name").read[String] and
       (JsPath \ "imageId").read[String].map(AmiId.apply) and
       (JsPath \ "meta").read[AWSAccount])(LaunchConfiguration.apply _)
+  implicit val launchTemplateReads: Reads[LaunchTemplate] =
+    ((JsPath \ "name").read[String] and
+      (JsPath \ "imageId").read[String].map(AmiId.apply) and
+      (JsPath \ "meta").read[AWSAccount])(LaunchTemplate.apply _)
+  implicit val launchTemplatesReads: Reads[Seq[LaunchTemplate]] =
+    dataReads[LaunchTemplate](dataPath = "data", "asg-launch-templates")
   implicit val launchConfigurationsReads: Reads[Seq[LaunchConfiguration]] =
     dataReads[LaunchConfiguration](dataPath = "data", "launch-configurations")
   implicit val imageReads: Reads[Image] =

--- a/app/prism/Prism.scala
+++ b/app/prism/Prism.scala
@@ -27,7 +27,7 @@ class Prism(
     findAll[LaunchConfiguration]("/launch-configurations")
 
   def findAllLaunchTemplates(): Future[Seq[LaunchTemplate]] =
-    findAll[LaunchTemplate]("/launch-templates")
+    findAll[LaunchTemplate]("/active-launch-template-versions")
 
   def findCopiedImages(): Future[Seq[Image]] =
     findAll[Image]("/images?tags.CopiedFromAMI!=")
@@ -106,7 +106,7 @@ object Prism {
       (JsPath \ "imageId").read[String].map(AmiId.apply) and
       (JsPath \ "meta").read[AWSAccount])(LaunchTemplate.apply _)
   implicit val launchTemplatesReads: Reads[Seq[LaunchTemplate]] =
-    dataReads[LaunchTemplate](dataPath = "data", "asg-launch-templates")
+    dataReads[LaunchTemplate](dataPath = "data", "active-launch-template-versions")
   implicit val launchConfigurationsReads: Reads[Seq[LaunchConfiguration]] =
     dataReads[LaunchConfiguration](dataPath = "data", "launch-configurations")
   implicit val imageReads: Reads[Image] =

--- a/app/prism/Prism.scala
+++ b/app/prism/Prism.scala
@@ -106,7 +106,10 @@ object Prism {
       (JsPath \ "imageId").read[String].map(AmiId.apply) and
       (JsPath \ "meta").read[AWSAccount])(LaunchTemplate.apply _)
   implicit val launchTemplatesReads: Reads[Seq[LaunchTemplate]] =
-    dataReads[LaunchTemplate](dataPath = "data", "active-launch-template-versions")
+    dataReads[LaunchTemplate](
+      dataPath = "data",
+      "active-launch-template-versions"
+    )
   implicit val launchConfigurationsReads: Reads[Seq[LaunchConfiguration]] =
     dataReads[LaunchConfiguration](dataPath = "data", "launch-configurations")
   implicit val imageReads: Reads[Image] =

--- a/app/prism/RecipeUsage.scala
+++ b/app/prism/RecipeUsage.scala
@@ -150,6 +150,7 @@ object RecipeUsage {
     recipeUsage.copy(
       launchConfigurations =
         recipeUsage.launchConfigurations.filter(_.imageId == amiId),
+      launchTemplates = recipeUsage.launchTemplates.filter(_.imageId == amiId),
       instances = recipeUsage.instances.filter(_.imageId == amiId),
       bakeUsage = recipeUsage.bakeUsage.filter(bu =>
         bu.amiId == amiId || bu.viaCopy.exists(i => i.imageId == amiId)

--- a/app/views/fragments/usagesColumn.scala.html
+++ b/app/views/fragments/usagesColumn.scala.html
@@ -3,7 +3,7 @@
     usage: prism.RecipeUsage
 )
 
-<td class="recipe-usage" title="Used in @usage.instances.size instance@if(usage.instances.size != 1) {s} and @usage.launchConfigurations.size launch configuration@if(usage.launchConfigurations.size != 1) {s}">
+<td class="recipe-usage" title="Used in @usage.instances.size instance@if(usage.instances.size != 1) {s}, @usage.launchConfigurations.size launch configuration@if(usage.launchConfigurations.size != 1) {s}  and @usage.launchTemplates.size launch configuration@if(usage.launchTemplates.size != 1) {s}">
     <a href="@routes.RecipeController.showUsages(recipe.id)">
         <img src="@routes.Assets.versioned("images/computer.svg")" width="16" alt="Instances" />
         <span>@usage.instances.size</span>

--- a/app/views/fragments/usagesColumn.scala.html
+++ b/app/views/fragments/usagesColumn.scala.html
@@ -3,7 +3,7 @@
     usage: prism.RecipeUsage
 )
 
-<td class="recipe-usage" title="Used in @usage.instances.size instance@if(usage.instances.size != 1) {s}, @usage.launchConfigurations.size launch configuration@if(usage.launchConfigurations.size != 1) {s}  and @usage.launchTemplates.size launch configuration@if(usage.launchTemplates.size != 1) {s}">
+<td class="recipe-usage" title="Used in @usage.instances.size instance@if(usage.instances.size != 1) {s}, @usage.launchConfigurations.size launch configuration@if(usage.launchConfigurations.size != 1) {s} and @usage.launchTemplates.size launch configuration@if(usage.launchTemplates.size != 1) {s}">
     <a href="@routes.RecipeController.showUsages(recipe.id)">
         <img src="@routes.Assets.versioned("images/computer.svg")" width="16" alt="Instances" />
         <span>@usage.instances.size</span>

--- a/app/views/fragments/usagesColumn.scala.html
+++ b/app/views/fragments/usagesColumn.scala.html
@@ -8,6 +8,6 @@
         <img src="@routes.Assets.versioned("images/computer.svg")" width="16" alt="Instances" />
         <span>@usage.instances.size</span>
         <img src="@routes.Assets.versioned("images/spanner.svg")" width="14" alt="Launch Configurations" />
-        <span>@usage.launchConfigurations.size</span>
+        <span>@{usage.launchConfigurations.size + usage.launchTemplates.size}</span>
     </a>
 </td>

--- a/app/views/showUsage.scala.html
+++ b/app/views/showUsage.scala.html
@@ -60,6 +60,13 @@
                                    (in @launchConfiguration.awsAccount.accountName)
                                </li>
                            }
+                            @usage.launchTemplates.map { launchTemplate =>
+                                <li class="list-unstyled">
+                                    <img src="@routes.Assets.versioned("images/spanner.svg")" width="14" alt="Launch Configurations" />
+                                    <a href="@prismBaseUrl/asg-launch-templates?name=@launchTemplate.name">@launchTemplate.name</a>
+                                    (in @launchTemplate.awsAccount.accountName)
+                                </li>
+                            }
                         </ul>
                     </td>
                     <td class="absolute-container">

--- a/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
+++ b/test/housekeeping/MarkOldUnusedBakesForDeletionSpec.scala
@@ -79,14 +79,14 @@ class MarkOldUnusedBakesForDeletionSpec extends AnyFlatSpec with Matchers {
   def getBakes(recipeId: RecipeId): Iterable[Bake] =
     Iterable(oldBake1, oldBake2, newBake1, newBake2)
   def getEmptyRecipeUsage(bakes: Iterable[Bake]): RecipeUsage =
-    RecipeUsage(Seq.empty, Seq.empty, Seq.empty)
+    RecipeUsage(Seq.empty, Seq.empty, Seq.empty, Seq.empty)
 
   def getRecipeUsage(bakes: Iterable[Bake]): RecipeUsage = {
     val bakeUsageA =
-      BakeUsage(AmiId("ami-2"), oldBake2, None, Seq.empty, Seq.empty)
+      BakeUsage(AmiId("ami-2"), oldBake2, None, Seq.empty, Seq.empty, Seq.empty)
     val bakeUsageB =
-      BakeUsage(AmiId("ami-4"), newBake2, None, Seq.empty, Seq.empty)
-    RecipeUsage(Seq.empty, Seq.empty, Seq(bakeUsageA, bakeUsageB))
+      BakeUsage(AmiId("ami-4"), newBake2, None, Seq.empty, Seq.empty, Seq.empty)
+    RecipeUsage(Seq.empty, Seq.empty, Seq.empty, Seq(bakeUsageA, bakeUsageB))
   }
 
   "getOldUnusedBakes" should "return empty when all bakes are recent" in {


### PR DESCRIPTION
## What does this change?
We encountered an issue recently where AMIgo was reporting a recipe as unused, when it actually was in use but via a [launch template](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-templates.html) rather than a [launch configuration](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-configurations.html).

This PR should prevent that from happening again by adding launch template support to AMIgo - so that when it checks whether a bake is in use, it will also check for usages within launch templates.

## How to test
I tested this on AMIgo CODE against Prism CODE (with this branch https://github.com/guardian/prism/pull/918) by adding an AMIgo CODE AMI to a launch template and checking that the usage is picked up by AMIgo
