### PR TITLE
the url for downloading Kong has moved

### DIFF
--- a/roles/kong/defaults/main.yml
+++ b/roles/kong/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-kong_version: 1.5.1
+kong_version: 3.1.1
 kong_user: content-api
 postgres_version: 12
-kong_arch: amd64
-kong_repo: gateway-3.x-ubuntu-focal
+kong_arch: arm64
+kong_repo: gateway-31

--- a/roles/kong/tasks/main.yml
+++ b/roles/kong/tasks/main.yml
@@ -12,7 +12,8 @@
 
 - name: Install Kong package
   apt:
-    deb: https://download.konghq.com/{{ kong_repo }}/pool/all/k/kong/kong_{{ kong_version }}_{{ kong_arch }}.deb
+    # https://packages.konghq.com/public/gateway-31/deb/ubuntu/pool/focal/main/k/ko/kong_3.1.1/kong_3.1.1_amd64.deb
+    deb: https://packages.konghq.com/public/{{ kong_repo }}/deb/ubuntu/pool/focal/main/k/ko/kong_{{ kong_version }}/kong_{{ kong_version }}_{{ kong_arch }}.deb
     state: present
 
 - name: Create user for Kong

--- a/roles/kong/tasks/main.yml
+++ b/roles/kong/tasks/main.yml
@@ -12,7 +12,6 @@
 
 - name: Install Kong package
   apt:
-    # https://packages.konghq.com/public/gateway-31/deb/ubuntu/pool/focal/main/k/ko/kong_3.1.1/kong_3.1.1_amd64.deb
     deb: https://packages.konghq.com/public/{{ kong_repo }}/deb/ubuntu/pool/focal/main/k/ko/kong_{{ kong_version }}/kong_{{ kong_version }}_{{ kong_arch }}.deb
     state: present
 


### PR DESCRIPTION
## What does this change?

As part of our `kong` [role](https://amigo.gutools.co.uk/roles#kong), we download the application [Kong](https://konghq.com/) from a known URL (this is an essential application that implements the API keys for CAPI).

However, a few months ago, this stopped working. A bit of digging revealed that the Kong team had changed the URL for the download.

I have updated the URL for the role, and I have tested that it now works by first running the role locally with `multipass` and then deploying this branch to code and [re-running the build](https://amigo.code.dev-gutools.co.uk/recipes/kong-v3-arm/bakes/2). I also confirmed in the former case that if I ssh onto the box I can see that kong is installed.

I have also [deployed](https://riffraff.gutools.co.uk/deployment/view/3171679b-7eae-4f84-85b3-dcb6267ea19c) a [branch](https://github.com/guardian/content-api/tree/pmr/tmp-deploy-code-ami) to Kong `CODE` which uses the AMI from the `CODE` Amigo recipe above and I have confirmed that Kong is still working:

![image](https://github.com/user-attachments/assets/a219058d-b336-4b5b-938c-1ab3cff68922)

![image](https://github.com/user-attachments/assets/aa86875e-7c66-49be-b5d6-ac2ccbeac836)

I am also updating some of the default params to better match what we actually use.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Build the image, make sure it works and installs Kong OK.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## What is the value of this?

Our AMI for Kong has not been updated in over 40 days because the build has been failing.

## Have we considered potential risks?

We are the only consumers of this role and it currently isn't working at all.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

> **Note**
> If this change adds, updates or removes a role or recipe please note that in your PR and assign appropriate reviewers for the team that will be impacted by those changes.
