### PR TITLE
chore(roles): Update fluentbit package name

### DIFF
--- a/roles/cdk-base/README.md
+++ b/roles/cdk-base/README.md
@@ -114,6 +114,6 @@ as this allows tag lookup without requiring remote AWS API calls at runtime._
     Set this to `false` if you do not want log shipping to start automatically.
     This is useful if you will add or change the log shipping config supplied by
     `devx-logs`. If you have set this to `false` you are now responsible for
-    starting `td-agent-bit.service` in your user data script
-    (by running `systemctl start td-agent-bit.service` after all config files
+    starting `fluent-bit.service` in your user data script
+    (by running `systemctl start fluent-bit.service` after all config files
     have been created), and if you fail to do so logs will not be shipped.

--- a/roles/cdk-base/tasks/main.yml
+++ b/roles/cdk-base/tasks/main.yml
@@ -31,7 +31,7 @@
 - name: Add start Fluentbit script
   shell: |
     NAME=start-fluentbit
-    printf '#!/bin/bash\nsystemctl start td-agent-bit.service' > /var/lib/cloud/scripts/per-instance/02-$NAME
+    printf '#!/bin/bash\nsystemctl start fluent-bit.service' > /var/lib/cloud/scripts/per-instance/02-$NAME
     chmod +x /var/lib/cloud/scripts/per-instance/02-$NAME
   when:
     - ansible_os_family == "Debian"

--- a/roles/fluentbit/README.md
+++ b/roles/fluentbit/README.md
@@ -16,7 +16,7 @@ We recommend you set both vars explicitly in Amigo.
 
 To start the agent:
 
-    $ service td-agent-bit start
+    $ service fluent-bit start
 
-By default it loads config from `/etc/td-agent-bit/td-agent-bit.conf` so
+By default it loads config from `/etc/fluent-bit/fluent-bit.conf` so
 overwrite that with your own config in your userdata/startup scripts.

--- a/roles/fluentbit/tasks/main.yml
+++ b/roles/fluentbit/tasks/main.yml
@@ -9,5 +9,5 @@
 
 - name: Install
   apt:
-    name: td-agent-bit={{version}}
+    name: fluent-bit={{version}}
     update_cache: yes


### PR DESCRIPTION
## What does this change?
Updates the package name of the `fluent-bit` package:

> From version 1.9, `td-agent-bit` is a deprecated package and is removed after 1.9.9. The correct package name to use now is `fluent-bit`.
> – https://docs.fluentbit.io/manual/installation/linux

## How to test
- [Deploy to CODE](https://riffraff.gutools.co.uk/deployment/view/1ad4c43d-7d85-4b10-8ac0-d47330a3682f)
- [Bake a recipe](https://amigo.code.dev-gutools.co.uk/recipes/arm64-jammy-java11-deploy-infrastructure/bakes/10) that uses the `cdk-base` role (which depends on the fluentbit role)
- Launch an instance from the resulting AMI
- Observe logs continuing to ship to Central ELK

## What is the value of this?
Using the latest version.

## Have we considered potential risks?
???
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

> **Note**
> If this change adds, updates or removes a role or recipe please note that in your PR and assign appropriate reviewers for the team that will be impacted by those changes.
