### PR TITLE
feat(aws-tools)!: Remove support for RedHat

### DIFF
--- a/roles/aws-tools/tasks/install-pip-aws-cli-Debian.yml
+++ b/roles/aws-tools/tasks/install-pip-aws-cli-Debian.yml
@@ -1,6 +1,0 @@
----
-- name: Install pip3
-  apt: name=python3-pip state=present
-
-- name: Install latest AWS CLI
-  command: pip3 install awscli

--- a/roles/aws-tools/tasks/install-pip-aws-cli-RedHat.yml
+++ b/roles/aws-tools/tasks/install-pip-aws-cli-RedHat.yml
@@ -1,9 +1,0 @@
----
-- name: Enable IUS (ius.io) packages on RedHat
-  yum: name=https://centos6.iuscommunity.org/ius-release.rpm state=present
-
-- name: Install pip on centos
-  yum: name=python-pip state=present
-
-- name: Install latest AWS CLI
-  command: pip install awscli

--- a/roles/aws-tools/tasks/main.yml
+++ b/roles/aws-tools/tasks/main.yml
@@ -1,12 +1,13 @@
 ---
 - name: See what Ubuntu version we're running
-  set_fact: 
+  set_fact:
     post_focal: "{{ 'post-focal' if ( ansible_distribution_major_version|int >= 20 ) else 'older' }}"
 
-- name: Install pip and the latest AWS CLI
-  include: "{{ item }}"
-  with_first_found:
-    - "install-pip-aws-cli-{{ ansible_os_family }}.yml"
+- name: Install pip3
+  apt: name=python3-pip state=present
+
+- name: Install latest AWS CLI
+  command: pip3 install awscli
 
 - name: Install cloudformation tools
   include: "{{ item }}"
@@ -14,4 +15,3 @@
     - "install-cfn-tools-{{ ansible_distribution }}-{{ post_focal }}.yml"
     - "install-cfn-tools-{{ ansible_os_family }}.yml"
     - "install-cfn-tools.yml"
-  


### PR DESCRIPTION
## What does this change?
PR #66 updated the `aws-tools` role to work with RedHat. This was to enable the `s3-ssh-keys` on this distribution.

The `s3-ssh-keys` role has subsequently been removed (#388). Thus, we can simplify the `aws-tools` role by removing RedHat support.

## How to test
- [Deploy to CODE](https://riffraff.gutools.co.uk/deployment/view/1abe54f0-dcea-421b-9849-edb0478e9f22)
- [Bake an image and ensure the AWS CLI is still available](https://amigo.code.dev-gutools.co.uk/recipes/arm64-jammy-java11-deploy-infrastructure/bakes/12)

## What is the value of this?
Fewer code branches.

## Have we considered potential risks?
N/A - as noted above, the purpose for adding RedHat support has been removed.

> **Note**
> If this change adds, updates or removes a role or recipe please note that in your PR and assign appropriate reviewers for the team that will be impacted by those changes.
