### PR TITLE
docs: Mark `cloudwatch-hardware-monitoring-cronjob` role as deprecated

### DIFF
--- a/roles/aws-cloud-watch-agent/README.md
+++ b/roles/aws-cloud-watch-agent/README.md
@@ -1,16 +1,56 @@
+# AWS CloudWatch Agent
+
 This role installs the [AWS Cloud Watch agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html).
+It is available for Ubuntu Linux running on AMD64 or ARM64 architectures.
 
-Currently the role does not assume anything about how the agent should be configured, nor does the role run the agent.
-Typically both of these actions would be performed in the [User Data](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-userdata)
-made available to EC2 instances.
+It does not configure or run the agent.
+Both of these actions should be performed in the [User Data](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-userdata) made available to EC2 instances.
 
-At the moment, the role is available for Ubuntu Linux running on AMD64 or ARM64 architectures.
+By default, this role will create metrics in the namespace `CWAgent`.
+It can be customised in [configuration](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html).
 
-The AWS documentation on Cloud Watch agent is fairly comprehensive, but scattered; for convenience, some relevant
-resources are listed below:
+The AWS documentation on CloudWatch Agent is fairly comprehensive, but scattered.
+For convenience, some relevant resources are listed below:
 
-- creating the Cloud Watch configuration file:
-    - [manually](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html)
-    - [using the wizard](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/create-cloudwatch-agent-configuration-file-wizard.html)
-- [running the Cloud Watch agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-common-scenarios.html)
- 
+- Creating the Cloud Watch configuration file:
+    - [Manually](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html)
+    - [Using the wizard](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/create-cloudwatch-agent-configuration-file-wizard.html)
+- [Running the Cloud Watch agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-common-scenarios.html)
+
+## Example configuration
+The following configuration will collect instance memory metrics. The metrics can be aggregated at the ASG level.
+
+```json
+{
+  "metrics": {
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}",
+      "AutoScalingGroupName":"${aws:AutoScalingGroupName}"
+    },
+    "aggregation_dimensions": [
+      ["AutoScalingGroupName"],
+      []
+    ],
+    "metrics_collected": {
+      "mem": {
+        "measurement": [
+          "available",
+          "total",
+          "used"
+        ]
+      }
+    }
+  }
+}
+```
+
+With this being the contents of the file `/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json` on an EC2 instance, we can add the following in the UserData to configure and start the agent:
+
+```bash
+amazon-cloudwatch-agent-ctl -a fetch-config -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+amazon-cloudwatch-agent-ctl -a start
+```
+
+Some example PRs:
+- https://github.com/guardian/discussion-modtools/pull/866
+- https://github.com/guardian/deploy-tools-platform/pull/843

--- a/roles/cloudwatch-hardware-monitoring-cronjob/README.md
+++ b/roles/cloudwatch-hardware-monitoring-cronjob/README.md
@@ -1,7 +1,15 @@
 # CloudWatch hardware monitoring cronjob
 
+> [!WARNING]
+> DEPRECATED.
+> This role is uses IMDSv1 and therefore violates [FSBP EC2.8](https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-8).
+> For that reason, it's considered to be deprecated.
+> Please use [`aws-cloud-watch-agent`](../aws-cloud-watch-agent) instead.
+
 Utilises [mon-put-instance-data.pl](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/mon-scripts.html) script to 
 collect and report to CloudWatch memory, swap and disk space utilization data. 
+
+This role creates metrics in the namespace `System/Linux`.
 
 Requires the instance to have `cloudwatch:PutMetricData` (probably on resource `*`). 
 
@@ -13,3 +21,5 @@ Example params: `monitor_memory_utilisation: true, monitor_disk_space_utilisatio
   path must be specified; else metrics won't be reported to CloudWatch
 - ensure that the EC2 instance on which the script is running has the correct permissions; as an example, see 
   [this](https://github.com/guardian/deploy-tools-platform/pull/114) PR
+- Be aware of differing CloudWatch metric namespaces when migrating to `aws-cloud-watch-agent`. 
+  You may want to use a custom namespace, or update your alarms and dashboard to use the new namespace.


### PR DESCRIPTION
## What does this change?
The `cloudwatch-hardware-monitoring-cronjob` role is not compatible with IMDSv2 and therefore violates [FSBP EC2.8](https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-8). This change marks the role as deprecated and points to using `aws-cloud-watch-agent` instead.

The docs for `aws-cloud-watch-agent` is updated too to provide an example configuration file for ease. The configuration was taken from https://github.com/guardian/deploy-tools-platform/pull/843.

## How to test
The ultimate test is to migrate from `cloudwatch-hardware-monitoring-cronjob` to `aws-cloud-watch-agent` and to comment on the helpfulness of the documentation.

## What is the value of this?
A clearer path for teams to resolve FSBP EC2.8 issues in their services.

## Have we considered potential risks?
N/A.