### PR TITLE
Removes the Ophan Dist S3 bucket dependency from the friendly hostnames role

### DIFF
--- a/roles/friendly-hostnames/README.md
+++ b/roles/friendly-hostnames/README.md
@@ -7,8 +7,7 @@ and it isn't necessary to name them. Sometimes you want to treat them more like 
 Perhaps they hold data meaning there is a risk associated with indiscriminately killing them and replacing them with 
 another. You may benefit from knowing which server you have up at a given time.
 
-The feature sets the hostname for your server and applies an AWS "Name" tag. The name is chosen from a list of names, 
-defaulting to ~3000 names at `https://s3-eu-west-1.amazonaws.com/ophan-dist/ophan/elasticsearch/hostnames.txt`.
+The feature sets the hostname for your server and applies an AWS "Name" tag. The name is chosen from a list of ~3000 feminists names.
         
 You will need to run the following script in your cloud init
 
@@ -19,13 +18,6 @@ You will need to run the following script in your cloud init
 A hostname will be chosen at random and formatted to a 
 [valid hostname](https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames), 
 only including the characters [^A-Za-z].  
-
-If you would like to override the default list and supply your own names you will need to specify your hostnames URL, 
-for example
-
-```
-hostnames_url: https://example.com/hostnames.txt
-```
 
 You might need to consider the [birthday problem](https://en.wikipedia.org/wiki/Birthday_problem) when choosing your 
 list size. For a cluster of size `s`, and a probability of `p` of a name clash (hopefully low, less than `0.05`), you'll

--- a/roles/friendly-hostnames/defaults/main.yml
+++ b/roles/friendly-hostnames/defaults/main.yml
@@ -1,2 +1,0 @@
----
-hostnames_url: https://s3-eu-west-1.amazonaws.com/ophan-dist/ophan/elasticsearch/hostnames.txt

--- a/roles/friendly-hostnames/files/hostnames.txt
+++ b/roles/friendly-hostnames/files/hostnames.txt
@@ -1,0 +1,3141 @@
+ë¦¬ì •í¬
+ã‚ªãƒŽãƒ»ãƒ¨ãƒ¼ã‚³
+à¬¸à¬°à­‹à¬œà¬¿à¬¨à­€ à¬¸à¬¾à¬¹à­
+Aadel Lampe
+Aaron Bastani
+Abby Scott Baker
+Abby Tomlinson
+Abigail Adams
+Acija AlfireviÄ‡
+Ada Bittenbender
+Ada, Countess of Lovelace
+Ada E. Yonath
+Ada Florence Remfry Hitchins
+Ada Hayden
+Ada Hitchins
+Ada Jafarey
+Ada Jafri
+Ada Lovelace
+Ada Maria Isasi-Diaz
+Ada MarÃ­a Isasi-DÃ­az
+Adam Yauch
+Ada Yonath
+Addie L. Ballou
+Addie L. Wyatt
+Adelaide Casely-Hayford
+Adelaide Johnson
+Adela Pankhurst
+Adela Walsh
+Adela Zamudio
+Adele
+Adele Ann Wilby
+Adele Balasingham
+AdÃ¨le Daminois
+Adele Goldberg
+Adele Goldstine
+Adelheid Popp
+Adriana Cavarero
+Adriana Monti
+Adrianne Wadewitz
+"Adrienne Rich
+Agatha Chapman
+Agathe L. van Beverwijk
+Agda Ã–stlund
+Agnes Campbell Macphail
+Agnes Deans Cameron
+Agnes Giberne
+Agnes Macphail
+Agnes Mary Clerke
+Agnes Mary Mansour
+Agnes Pareiyo
+Agnes Pockels
+AgnÃ¨s Varda
+Agnia Sergeyevna Losina-Losinskaja
+Aida El-Kashef
+Ailsa McKay
+Aisha Abd al-Rahman
+Aisha Rateb
+Akhtar Riazuddin
+Akiko DÅmoto
+Akiko Yosano
+Alan Alda
+Alanis Morissette
+Alba CalderÃ³n
+Alba Maria Zaluar
+Alba Zaluar
+Alcira Argumedo
+Alejandro Jodorowsky
+Alenka Puhar
+Alenoush Terian
+Alenush Terian
+Aletta Jacobs
+Alexandra David-NÃ©el
+Alexandra Elbakyan
+Alexandra Kollontai
+Alexandrina Cantacuzino
+Alexis Hunter
+Alexis Nour
+Alice Abadam
+Alice Alldredge
+Alice Amelia Chown
+Alice Augusta Ball
+Alice Ball
+Alice Caroline Franklin
+Alice Catherine Evans
+Alice C. Evans
+Alice Crary
+Alice Dudeney
+Alice Eastwood
+Alice Elizabeth Kober
+Alice Elvira Freeman Palmer
+Alice Faber Tryon
+Alice Franklin
+Alice Freeman Palmer
+Alice Kober
+Alice L. Kibbe
+Alice Manfield
+Alice Mary Cassie
+Alice Middleton Boring
+Alice Moore Hubbard
+Alice Mossie Brues
+Alice Paul
+Alice Stewart
+Alice Stone Blackwell
+Alice T. Schafer
+Alice Vibert Douglas
+Alice Walker
+Alice Wilson
+Alice Yotopoulos-Marangopoulos
+Alicia Nash
+Alifa Rifaat
+Alina JÃ¤gerstedt
+Aline Valette
+Alison Jolly
+Alix Dobkin
+Alka Kriplani
+A.L. Kathleen King
+Allie Vibert Douglas
+Allison Wolfe
+Alma Bridwell White
+Alma Dolens
+Alma Joslyn Whiffen-Barksdale
+Alma Routsong
+Alva Belmont
+Alva Myrdal
+Alwina Gossauer
+Alycia Kaback
+Ama Ata Aidoo
+Amalie Skram
+Amanda Chessell
+Amanda Marcotte
+Amanda Palmer
+Amartya Sen
+Amelia Bloomer
+Amelia Earhart
+Amelia Greenhall
+Amelia Jones
+Amelia Valcarcel
+Amelia ValcÃ¡rcel
+Amey Daldy
+Amina Tyler
+Amina Wadud
+Amparo Poch y GascÃ³n
+Amrita Pritam
+Amy Brenneman
+Amy Jacot Guillarmod
+Amy Poehler
+Amy Richards
+Ana Aslan
+Ana Betancourt
+Ana Castillo
+Ana de Castro OsÃ³rio
+Ana Figuero
+Anahita Ratebzad
+Ana Mendieta
+Anamika
+Ana Montenegro
+Anandibai Joshi
+Anandi Gopal Joshi
+Ana Roque de Duprey
+Ana Rosa ChacÃ³n
+Ana Rosa Tornero
+Anastasiya Verbitskaya
+Anat Hoffman
+Anbara Salam Khalidi
+Anbara Salam Khalidy
+Anders Borg
+Andrea Dworkin
+Andrea Echeverri
+Andrew N. Shearer
+Andy Burnham
+Andy Murray
+Ãngela AcuÃ±a Braun
+Angela Carter
+Angela McRobbie
+Angelica Balabanoff
+Angelina Emily GrimkÃ©
+Angelina GrimkÃ©
+AngÃ©lique Arnaud
+AngÃ©lique Arvanitaki
+Angie Beckwith
+Angie Maria Beckwith
+Angioletta Coradini
+Anilda LeÃ£o
+Anita Augspurg
+Anita Borg
+Anita B. Roberts
+Anita Hill
+Anita Roberts
+Anita Roddick
+Anita Sarkeesian
+Anja Meulenbelt
+Anna Baetjer
+Annabelle Jaramillo
+Anna Bugge
+Anna Chandy
+Anna Doyle Wheeler
+Anna Haslam
+Anna Howard Shaw
+Anna Hutsol
+Anna Hvoslef
+Anna Jane Harrison
+Anna J. Harrison
+Anna Kendrick
+Ann A. Kiessling
+Anna Kingsford
+Anna Kontula
+Anna Kuliscioff
+Anna Leonowens
+Anna-Lise Williamson
+Anna Lord Strauss
+Anna Mani
+Anna Marcet Haldeman
+Anna Maria Haslam
+Anna M. Baetjer
+Anna Morandi Manzolini
+Anna MuriÃ 
+Anna Pappritz
+Annapurni Subramaniam
+Anna Schchian
+Anna Semenovna Schchian
+Anna Span
+Anna Stang
+Anna Suk-Fong Lok
+Anna Thynne
+Anna Wheeler
+Ann Bishop
+Ann Conolly
+Ann Dunham
+Anne Anastasi
+Anne B. Newman
+Anne Bradstreet
+Anne Briscoe
+Anne Dejean-AssÃ©mat
+Anne Eggebroten
+Anne Eidemiller Rudloe
+Anne Elizabeth Ball
+Anne Hope Jahren
+Anneke Levelt Sengers
+Anne Koedt
+Anne-Marie du Boccage
+Anne-Marie Slaughter
+Anne McLaren
+Anne Nicol Gaylor
+Anne Pride
+Anne Roiphe
+Anne Rudloe
+Annette Frances Braun
+Annette Lu
+Ann Friedman
+Ann Garry
+Ann Haven Morgan
+Ann Heberlein
+Annie Besant
+Annie Easley
+Annie E. Clark
+Annie Jump Cannon
+Annie Laurie Gaylor
+Annie Lennox
+Annie Louisa Robinson Swynnerton
+Annie Peck
+Annie Shepherd Swan
+Annie Smith Peck
+Annie S. SwanCBE
+Annie Swynnerton
+Ann Kiessling
+Ann L. Friedman
+Ann Oakley
+Ann Rosamund Oakley
+Anohni
+Antoinette Brown Blackwell
+Antoinette Pirie
+Antonia Novello
+Antonia Pantoja
+Antonieta Rivas Mercad
+Antonieta Rivas Mercado
+Antonina Ivanovna Pojarkova
+Antonina Pojarkova
+Anusuya Chinsamy-Turan
+Aoki Yayoi
+Aphra Behn
+Archana Bhattacharyya
+Arfa Karim
+Argentina DÃ­az Lozano
+Ariel Schrag
+Aroti Dutt
+Aryeh A. Frimer
+Aryeh Frimer
+Asa Akira
+As'ad AbuKhalil
+Asha Haji Elmi
+Ashawna Hailey
+Ashley Judd
+Asima Chatterjee
+A.S. Losina-Losinskaja
+Asma Jahangir
+Asra Nomani
+Assia Djebar
+Astrid Cleve
+Astrid Cleve von Euler
+Atlas Saarikoski
+Audre Lorde
+Audrey Smith
+Audrey Stevens Niyogi
+August Bebel
+Auguste Fickert
+Auguste Soesastro
+Aurelio Saffi
+Aurora Levins Morales
+Aurora Quezon
+Aurora QuezÃ³n
+Avedon Carol
+Averil Margaret Lysaght
+Avital Ronell
+Avra Theodoropoulou
+Avril de Sainte-Croix
+Ayaan Hirsi Ali
+Aya Saad Eldeen
+Ayaz Latif Palijo
+Aziz Ansari
+Banoo Jehangir Coyaji
+Barack Obama
+Barbara Anne Macdonald
+Barbara Askins
+Barbara Bergmann
+Barbara Bodichon
+Barbara Branden
+Barbara Farnsworth Heslop
+Barbara Haney Irvine
+Barbara Heslop
+Barbara Jordan
+Barbara Kruger
+Barbara Liskov
+Barbara Macdonald
+Barbara McClintock
+Barbara McMartin
+Barbro Alving
+Bea Arthur
+Bea Schwarz
+Beatrice Ask
+Beatrice Blackwood
+Beatrice Brigden
+Beatrice Greig
+Beatrice Tinsley
+Beatrix Campbell
+Begum Akhtar Riazuddin
+Begum Anwar Ahmed
+Begum Faiz-un-Nissa Choudhurani
+Begum Sufia Kamal
+Belinda Jack
+Bella Abzug
+Belle Case La Follette
+bell hooks
+Belva Ann Lockwood
+Benedict Cumberbatch
+Bengt Westerberg
+Benjamin Cook
+Benny Andersson
+BenoÃ®te Groult
+Berit Ã…s
+Bernice Eddy
+Bernie Sanders
+Berta Karlik
+Bertha Braunthal
+Bertha Braunthal-Clark
+Bertha Cady
+Bertha Clark
+Bertha Lutz
+Bertha Maria JÃºlia Lutz
+Bertha Pappenheim
+Bertha Swirles
+Beth Ditto
+Betsey Wright
+Betsy Ancker-Johnson
+Betsy Struthers
+Bettina Gorton
+Betty Dodson
+Betty Friedan
+Betty Hay
+Betty Holberton
+Beverly Guy-Sheftall
+Bhama Srinivasan
+Bhawana Somaaya
+Biancamaria Frabotta
+Bice Sechi-Zorn
+Bidisha
+Bilkisu Yusuf
+Bill Bailey
+Bill Baird
+Billie Jean King
+Billy Karren
+Birgit Brock-Utne
+Birgit BrÃ¼el
+Birgit Grodal
+Birgitta Ohlsson
+BirutÄ— Galdikas
+BirutÄ— Marija Filomena Galdikas
+Bishakha Datta
+Bisi Adeleye-Fayemi
+Bitch
+BjÃ¸rg Krane Bostad
+BjÃ¸rg Vik
+Blanche Oelrichs
+Blessed
+Bobbi Starr
+Bonnie Raitt
+BoÅ¾ena BeneÅ¡ovÃ¡
+Bracha L. Ettinger
+Bracha Lichtenberg Ettinger
+Brenda Baker
+Brenda S. Baker
+Brianna Wu
+Brigid Balfour
+Brigid Brophy
+Brigitte Askonas
+Caitlin Moran
+Camille Crespin du Gast
+Camille du Gast
+Camille Paglia
+Camryn Manheim
+Candace Beebe Pert
+Candace Pert
+Candida Royalle
+Carden Wallace
+Caresse Crosby
+Carina Isabel Vance Mafla
+Carina Vance Mafla
+Carlos RodrÃ­guez
+Carlota Pereira de QueirÃ³s
+Carmel Humphries
+Carmen da Silva
+Carmen Dolores
+Carmen Pujals
+Carmen RodrÃ­guez
+Carmen SÃ¡nchez de Bustamante Calvo
+Carmen Vela
+Carme Torras
+Carmina Virgili
+Carole C. Noon
+Carole Cooney Noon
+Carolee Schneemann
+Carole Jordan
+Carole Pateman
+Carole Roussopoulos
+Carol Gilligan
+Carol Greider
+Carolina Beatriz Ã‚ngelo
+Caroline Bingham
+Caroline Coroneos "Carrie" Dormon
+Caroline Criado-Perez
+Caroline de Barrau
+Caroline Dormon
+Caroline Flint
+Caroline Fourest
+Caroline Herschel
+Caroline Herzenberg
+Caroline Lucas
+Caroline Priscilla Bingham
+Caroline RÃ©my de Guebhard
+Carol J. Adams
+Carol Smart
+Carolyn Gold Heilbrun
+Carolyn Jessop
+Carolyn Porco
+Carolyn Widney Greider
+Carrie Chapman Catt
+Carrie Derick
+Carrie Matilda Derick
+Casey Calvert
+Cassie Mitchell
+Cate Blanchett
+Catharina Ahlgren
+Catharine Macaulay
+Catharine Macfarlane
+Catharine Parr Traill
+Catharine van Tussenbroek
+Catherine Feuillet
+Catherine Filene Shouse
+Catherine Gage
+Catherine G. Wolf
+Catherine Littlefield Greene
+Catherine Malabou
+Catherine Shipe East
+Catherine Spence
+Catherine Winkworth
+Cathy Young
+Cat Smith
+CÃ©cile Brunschvicg
+CÃ©cile DeWitt-Morette
+Cecile Hoover Edwards
+Cecile Richards
+Cecilia Alvarez
+Cecilia Bouzat
+Cecilia ConcepciÃ³n Alvarez
+Cecilia Grierson
+Cecilia MalmstrÃ¶m
+Cecilia Payne-Gaposchkin
+Cecilia Todd
+Cecilie Thoresen Krog
+Celia Cruz
+Celia Grillo Borromeo
+CÃ©line Renooz
+Chandramukhi Basu
+Chantal Mouffe
+Charles Fourier
+Charli XCX
+Charlotta FrÃ¶lich
+Charlotte Anderson
+Charlotte Auerbach
+Charlotte Carmichael Stopes
+Charlotte Cortlandt Ellis
+Charlotte Despard
+Charlotte Elliott
+Charlotte Gower Chapman
+Charlotte Haldane
+Charlotte Laura Chapman
+Charlotte Moore Sitterly
+Charlotte Norrie
+Charlotte Perkins Gilman
+Charlotte Raven
+Charusita Chakravarty
+Chaviva HoÅ¡ek
+Chen Ran
+Cherie Currie
+Cherry A. Murray
+Cherry Ann Murray
+Cheryl Benard
+Cheryl Clarke
+Cheryl Lynn Clarke
+Chien-Shiung Wu
+Chimamanda Ngozi Adichie
+Chitra Naik
+ChloÃ« Grace Moretz
+Chris Bartlett
+Christabel Pankhurst
+Christia Mercer
+Christiane Bonnelle
+Christiane Linster
+Christiane NÃ¼sslein-Volhard
+Christiane Rochefort
+Christian Isobel Johnstone
+Christian Maclagan
+Christina Hoff Sommers
+Christina Kirk Henderson
+Christina Roccati
+Christine Buisman
+Christine Delphy
+Christine de Pizan
+Christine Kehoe
+Christine Ladd-Franklin
+Christine Mannhalter
+Christine Ross
+Christine Tamblyn
+Christine Williams
+Christopher D. Bartlett
+Chrystal Macmillan
+Chung Chil-sung
+Cindy Gallop
+Claire Bonenfant
+Claire Epstein
+Claire Fagin
+Claire F. Gmachl
+Claire Kelly Schultz
+Claire Penn
+Clara GonzÃ¡lez
+Clara Henriette Hasse
+Clara H. Hasse
+Clara Immerwahr
+Clara Ottesen
+Clara S. Foltz
+Clara Shortridge Foltz
+Clara Thue Ebbell
+Clara Zetkin
+Clare Daly
+Clare Short
+Clarinda
+Claudia Alexander
+Claudia Jones
+Claudine Guyton de Morveau
+Claudine Monteil
+Claudine Picardet
+Claudine Rinner
+Clelia Duel Mosher
+Clelia Durazzo Grimaldi
+ClÃ©mentine Autain
+CleofÃ© CaldÃ©ron
+CleofÃ© Elsa CalderÃ³n
+Clotilde Tambroni
+Colette Guillaumin
+ConcepciÃ³n Felix
+ConcepciÃ³n Felix Roque
+Concha AlÃ³s
+Concha Michel
+Connie Cepko
+Constance Cepko
+Constance Stone
+Consuelo Zavala
+Consuelo Zavala Castillo
+Cora Sadosky
+Coretta Scott King
+Corina RodrÃ­guez LÃ³pez
+Corinne ChaponniÃ¨re
+Courtney Love
+Cristina Husmark Pehrsson
+Cristina Possas
+Cris Williamson
+Crystal Eastman
+Cyba Audi
+Dagny Caroline KiÃ¦r
+Daisy HernÃ¡ndez
+Dakky KiÃ¦r
+Damaris Cudworth Masham
+Damaris Masham
+Dame Jean Thomas
+Dame Jenni Murray
+Dame Jocelyn Bell Burnell
+Dame Kathleen Ollerenshaw
+Dame Patricia Bergquist
+Dame Rebecca West
+Dame Valerie Beral
+Damien Walter
+Dana DeArmond
+Daphne Berdahl
+Daphne Hampson
+Daphne Jackson
+Darshan Ranganathan
+Dave Zirin
+Davida Teller
+Davida Young Teller
+Dawn Jeannine Wright
+Dawn Wright
+Debbie Friedman
+Deborah Estrin
+Deborah Fisher Wharton
+Deborah Martin-Downs
+Debra Elmegreen
+Debra Meloy Elmegreen
+Deepa Kumar
+Deeyah
+Deeyah Khan
+Del Martin
+Demi Lovato
+Deng Yuzhi
+Denise Marshall
+Devra G. Kleiman
+Dewi Sartika
+Dhammananda
+Dhammananda Bhikkhuni
+Diana E. H. Russell
+Diana Kingsmill Wright
+Diana Mara Henry
+Diana Marcela BolaÃ±os Rodriguez
+Diana Marcela BolaÃ±os RodrÃ­guez
+Diana Russell
+Diane Abbott
+Diane Bond
+Diane Loretta Bond
+Dian Fossey
+Dina Katabi
+Dixy Lee Ray
+Dolores Alexander
+Dolores Huerta
+Dolores JimÃ©nez y Muro
+Dolores Richard Spikes
+Domitila Barrios de ChÃºngara
+Domitila ChÃºngara
+DoÃ±a Manuela SÃ¡enz
+Donella Meadows
+Donita Sparks
+Donna M. Hughes
+Dora, Countess Russell
+Dora Lush
+Dora Marsden
+Dora Russell
+Dorchen Leidholdt
+Doria Shafik
+Doria Shafiq
+Doris Anderson
+Doris Calloway
+Doris Fleischman
+Doris Hilda Anderson
+Doris Holmes Blake
+Doris Kermack
+Doris Kuhlmann-Wilsdorf
+Doris Mable Cochran
+Doris Mary Kermack
+Doris Stevens
+Dorothea Erxleben
+Dorothea Jameson
+Dorothea Klumpke
+Dorothea Klumpke Roberts
+Dorothy Day
+Dorothy Hansine Andersen
+Dorothy Hill
+Dorothy Hodgkin
+Dorothy Jewson
+Dorothy Johnson Vaughan
+Dorothy Kenyon
+Dorothy Levitt
+Dorothy Ray Healey
+Dorothy Richardson
+Dorothy Vaughan
+Dorrit Hoffleit
+Dossie Easton
+Douglas Booth
+Dr Brigid Balfour
+Dr Caroline Lucas
+Dr. Elvira Rawson de Dellepiane
+Dr Fiona Wood
+Dr. Justine Saade-Sergent
+Dr Kamini A. Rao
+Dr. Margaret Pittman
+Dr Mary Winifred Parke
+Dr. MichÃ¨le A. Pujol
+Dr. Mitali Mukerji
+Dr. Muthulakshmi Reddy
+Dr Phyllis E. M. Clinch
+Dr. Sharada Srinivasan
+Dr. Sophia Jex-Blake
+Dr. S. Revathi
+Dr. Taha El Hakem
+Drucilla Cornell
+Drusilla Modjeska
+Dubravka UgreÅ¡iÄ‡
+Dulari Qureshi
+Ebba Haslund
+Ebba Witt-BrattstrÃ¶m
+Eddie Vedder
+Edith Anne Stoney
+Edith Anrep
+Edith BÃ¼lbring
+Edith Clements
+Edith Ellis
+Edith Gertrude Schwartz
+Edith Hirsch Luchins
+Edith Irby Jones
+Edith Katherine Cash
+Edith Layard Stephens
+Edith Mansell Moullin
+Edith New
+Edith Penrose
+Edith Quimby
+Edith Searle Grossmann
+Edith Smaw Hinckley Quimby
+Edith Stein
+Edith Summerskill, Baroness Summerskill
+Ed Miliband
+Edna H. Fawcett
+Edna P. Plumstead
+Efua Sutherland
+Eija-Liisa Ahtila
+Eijun Linda Cutts
+Eileen Hendriks
+Eileen McCracken
+Ela Bhatt
+Elaine Anderson
+Elaine Bullard
+Elaine Rebecca Bullard
+Elaine Ryan Hedges
+Elaine Showalter
+Elaine Storkey
+Eleanora Frances Bliss Knopf
+Eleanora Knopf
+Eleanor Anne Ormerod
+Eleanor Anne Young
+Eleanor Antin
+Eleanor Carothers
+Eleanor D. Acheson
+Eleanor Dean Acheson
+Eleanor Marion Bennett
+Eleanor Marx
+Eleanor R. Adair
+Eleanor Raskin
+Eleanor Rathbone
+Eleanor Roosevelt
+Eleanor Smeal
+Eleanor Wachtel
+Elena Cornaro Piscopia
+Elena SÃ¡nchez Valenzuela
+Eleni Antoniadou
+Elfriede Jelinek
+Eliane Montel
+Ã‰liane Montel
+Elida CampodÃ³nico
+Elif Åžafak
+Elinor Burkett
+Elinor Francis Vallentin
+Elin WÃ¤gner
+Elisa AcuÃ±a
+Elisa AcuÃ±a Rossetti
+Ã‰lisabeth Badinter
+Elisabeth Beskow
+Elisabeth Binder
+Elisabeth Ivanova Kara-Michailova
+Elisabeth of the Palatinate
+Elisabeth RÃ¶hl
+Elisabeth Vrba
+Elisa Hall de Asturias
+Elisa Oricchio
+Elise Bauman
+Elise F. Harmon
+Elise Harmon
+Elise L'Esperance
+Ã‰lise L'Esperance
+Elise Ottesen-Jensen
+EliÅ¡ka KrÃ¡snohorskÃ¡
+Eliska Vincent
+Elizabeth Alexander
+Elizabeth Anne Reid
+Elizabeth Anne Voigt
+Elizabeth Ann Louisa Mackay
+Elizabeth A. Wood
+Elizabeth Bates
+Elizabeth Blackburn
+Elizabeth Blackwell
+Elizabeth Blackwell, M.D.
+Elizabeth Burgoyne Corbett
+Elizabeth Cady Stanton
+Elizabeth Caradus
+Elizabeth Caroline Crosby
+Elizabeth C. Crosby
+Elizabeth Clarke Wolstenholme Elmy
+Elizabeth Dexter "Betty" Hay
+Elizabeth Eiloart
+Elizabeth Garrett Anderson
+Elizabeth Hawes
+Elizabeth Herriott
+Elizabeth Holloway Marston
+Elizabeth Kaahumanu
+Elizabeth Kenny
+Elizabeth Laird
+Elizabeth Lee Hazen
+Elizabeth L. Nicholls
+Elizabeth Maria Molteno
+Elizabeth Marvelly
+Elizabeth M. Boyer
+Elizabeth M. Ward
+Elizabeth Nicholls
+Elizabeth Parker
+Elizabeth Press
+Elizabeth Riddle Graves
+Elizabeth Robins
+Elizabeth Rona
+Elizabeth Sackler
+Elizabeth Selden Rogers
+Elizabeth Stern
+Elizabeth W. Crandall
+Elizabeth Williamson
+Eliza Grew Jones
+Elizaveta Karamihailova
+Ella Cara Deloria
+Ella Orr Campbell
+Ellen Elizabeth Ellis
+Ellen Louise Mertz
+Ellen Malcolm
+Ellen Melville
+Ellen Page
+Ellen Schulz Quillin
+Ellen Stofan
+Ellice Hopkins
+Elliott Smith
+Elma Danielsson
+Elmina Wilson
+Eloise Blaine Cram
+Elsa Beata Bunge
+Elsa GuÃ°bjÃ¶rg VilmundardÃ³ttir
+Elsa G. VilmundardÃ³ttir
+Elsa Wiezell
+Elsie Bowerman
+Elsie Locke
+Elsie Widdowson
+E. Lucy Braun
+Elvia Carillo Puerto
+Elvia Carrillo Puerto
+Elvira Rawson
+Elzada Clover
+Elzada U. Clover
+EmÃ­lia Moncorvo Bandeira de Melo
+Emilie Autumn
+Emilie de Morsier
+Ã‰milie de Morsier
+Ã‰milie du ChÃ¢telet
+Ã‰milie Du ChÃ¢telet
+EmÄ«lija Gudriniece
+Emily Anne Eliza Shirreff
+Emily Blackwell
+Emily Blackwell, M.D.
+Emily Davies
+Emily Greene Balch
+Emily Howard Jennings Stowe
+Emily Maguire
+Emily Murphy
+Emily Newell Blair
+Emily Patricia Gibson
+Emily Shirreff
+Emily Stackhouse
+Emily Stowe
+Emily Thornberry
+Emma Barnett
+Emma Castelnuovo
+Emma Goldman
+Emma Ihrer
+Emma Lehmer
+Emma Lucy Braun
+Emmanuelle Cosse
+Emma Parmee
+Emma Paterson
+Emma P. Carr
+Emma Phoebe Waterman Haas
+Emma Watson
+Emmeline Pankhurst
+Emmeline Pethick-Lawrence
+Emmy Noether
+EnikÅ‘ BollobÃ¡s
+Erich Neumann
+Eric Rofes
+Erin Pettit
+Erminnie A. Smith
+Ernestine Rose
+Eskil Erlandsson
+Estela Quesada
+Estelle Griswold
+Ester Graff
+Esther Byrnes
+Esther de Mezerville
+Esther De Mezerville
+Esther Lederberg
+Esther M. Conwell
+Esther Neira de Calvo
+Esther Peterson
+Esther Somerfeld-Ziskind
+Esther Szekeres
+Etel Adnan
+Ethel Bailey Higgins
+Ethel Currie
+Ethel Doidge
+Etheldred Benett
+Etheldred Bennett
+Ethel Gertrude Skeat
+Ethel Mary Doidge
+Ethel Skeat
+Ethelwynn Trewavas
+Ethel Zoe Bailey
+Etta Federn
+Etta Federn-Kohlhaas
+Etta Palm d'Aelders
+Eucharia Oluchi Nwaichi
+EugÃªnia Ãlvaro Moreyra
+Eugenia de Reuss Ianculescu
+Eugenia Kumacheva
+Eugenie Clark
+EugÃ©nie Niboyet
+Eulalia GuzmÃ¡n
+Eunice Golden
+Eunice Thomas Miner
+Eunice Thurston Thomas Miner
+Eva Ekeblad
+Eva J. Pell
+Eva Kolstad
+Eva Lundgren
+Eva-Maria Neher
+Eva Moberg
+Eva Neer
+Evangeline Anderson Rajkumar
+Evangeline Anderson-Rajkumar
+Evan Jones
+Eva PerÃ³n
+Eva Philbin
+Eva SykovÃ¡
+Eve Ensler
+Eve Kosofsky Sedgwick
+Eveline Willett Cunnington
+Evelyn Booth
+Evelyn Boyd Granville
+Evelyn Fox Keller
+Evelyn Lett
+Evelyn Mary Booth
+Evi Nemeth
+Excilia SaldaÃ±a
+Ezlynn Deraniyagala
+Ezra Heywood
+Fadela Amara
+Faezeh Hashemi
+Fahmida Riaz
+Faith Wilding
+Faizunnesa
+Fania Mindell
+Fannie Hurst
+Fanny Edelman
+Fanny Gates
+Farkhunda Zahra Naderi
+Farrokhroo Parsa
+Farrokhroo Parsay
+Fatema Mernissi
+Fatima
+Fatima Ahmed Ibrahim
+Fatima Mernissi
+Fatma Aliye Topuz
+Fawzia Koofi
+Fay Ajzenberg-Selove
+Felisa RincÃ³n de Gautier
+Fenia Chertkoff
+Fernanda Nissen
+Ferron
+Fiona Apple
+Fiona Wood
+Flora McMillan Forde
+Florbela Espanca
+Florence Ada Mary Lamb Polson
+Florence Bascom
+Florence Brooks Whitehouse
+Florence B. Seibert
+Florence Dixie
+Florence E. Meier Chase
+Florence Emeline Wall
+Florence E. Wall
+Florence Farr
+Florence Kelley
+Florence Meier Chase
+Florence van Straten
+Florence Yeldham
+Florentina Ioana Mosora
+Florentina Mosora
+Frances Adams Le Sueur
+Frances Balfour
+Frances B. Hugle
+Francesca Bonnemaison
+Francesca Bonnemaison i Farriols
+Frances E. Allen
+Frances Elizabeth "Fran" Allen
+Frances Hugle
+Frances Julia Wedgwood
+Frances M. Beal
+Frances McConnell-Mills
+Frances Power Cobbe
+Frances Willard
+Frances Wright
+Frances Wright/Fanny Wright
+France Winddance Twine
+Francisca Praguer Froes
+Francisca Praguer FrÃ³es
+Francis Marion Beynon
+Franciszka Arnsztajnowa
+FranÃ§oise David
+FranÃ§oise Giroud
+FranÃ§oise Loranger
+FrantiÅ¡ka PlamÃ­nkovÃ¡
+Freda Brown
+Freda du Faur
+Freda Du Faur
+Freda Mary Cook
+Freda Yetta Brown
+Frederica Annis Lopez de Leo de Laguna
+Frederica de Laguna
+Frederick Douglass
+FrÃ©dÃ©rique Bel
+Fredrika Bremer
+Fredrikke Marie Qvam
+Fredrikke Waaler
+Friedrich Engels
+Funmilayo Ransome Kuti
+Funmilayo Ransome-Kuti
+Gabriela LaperriÃ¨re de Coni
+Gabriela Mistral
+Gabrielle DuchÃªne
+Gabriel Rothblatt
+Gaby Dunn
+Gadis Arivia
+Gail G. Hanson
+Gail Hanson
+Gayatri Chakravorty Spivak
+G. B. Jones
+Geena Davis
+Geetanjali Misra
+Genevieve Grotjan Feinstein
+George Egerton
+George Lansbury
+George Sand
+Geraldine Ferraro
+Geraldine Pittman Woods
+Gerda Lerner
+Gerda Lundequist
+Germaine Greer
+Germaine Joplin
+Germaine Poinso-Chapuis
+Gertrude B. Elion
+Gertrude Elion
+Gertrude Guillaume-Schack
+Gertrude Maud Robinson
+Gertrude Rand
+Gertrude Richardson
+Gertrude Scharff Goldhaber
+Gertrud Theiler
+Gerty Cori
+Gesine Becker
+Ghada al-Samman
+Ghada Al-Samman
+Giannina Braschi
+Gillian Anderson
+Gillian Bates
+Gillian Matthewson
+Gillian Rose
+Gill Matthewson
+Gina Krog
+Ginger Brooks Takahashi
+Girijabai Kelkar
+Girijabai Madhav Kelkar
+Gisela Mosig
+GisÃ¨le Halimi
+Giuliana Cavaglieri Tesoro
+Giuliana Tesoro
+Gladys Anderson Emerson
+Gladys Dick
+Gladys Elizabeth Baker
+Gladys L. A. Emerson
+Gladys Rowena Henry Dick
+Glenda Jackson
+Gloria Allred
+Gloria Bonder
+Gloria Feldt
+Gloria Hollister
+Gloria Hollister Anable
+Gloria Leonard
+Gloria Lim
+Gloria Steinem
+Gloria ValerÃ­n RodrÃ­guez
+GÃ¶ran Persson
+Grace Belden Wilbur Trout
+Grace Evelyn Pickford
+Grace Hopper
+Grace Murray Hopper
+Grace Oladunni Taylor
+Grace Olive Wiley
+Grace Pickford
+Grace Ross
+Grace Wilbur Trout
+Graciela Iturbide
+Graciela Quan
+Greta Barbara Stevenson
+Greta Christina
+Greta Stevenson
+Grete Mostny
+Grethe Rytter Hasle
+Grillo Borromeo Arese Clelia
+Grimes
+Gudrun Ensslin
+Gudrun Schyman
+Gumercinda PÃ¡ez
+Gunhild Vehusheia
+Gwendolyn Wilson Fowler
+Habiba Djahnine
+Haja Zainab Hawa Bangura
+Haleh Afshar
+Haley Webb
+Halide Edib AdÄ±var
+Halszka OsmÃ³lska
+Hameeda Hossain
+Hamida Javanshir
+Han Myeong-sook
+Hanna Bieber-BÃ¶hm
+Hannah HÃ¶ch
+Hannah Tracy Cutler
+Harilyn Rousso
+Harriet Brooks
+Harriet Dunlop Prenter
+Harriet Edquist
+Harriet Fisher Mole
+Harriet Harman
+Harriet Irene Dunlop Prenter
+Harriet Law
+Harriet Martineau
+Harriet Pilpel
+Harriet Shaw Weaver
+Harriet Williams Russell Strong
+Harryette Mullen
+Harry Styles
+Hattie Alexander
+Hayao Miyazaki
+Hazel Bishop
+Hazel Marguerite Schmoll
+Hazel Schmoll
+Heather Anita Couper
+Heather Boushey
+Heather Couper
+Heba Gamal Kotb
+Heba Kotb
+Hedvig Charlotta Nordenflycht
+Hedy d'Ancona
+Heinrich Cornelius Agrippa
+Heleen Mees
+Helena Alexandrovna Timofeeff-Ressovsky
+Helena Leiva de Holst
+Helen Alma Newton Turner
+Helen A. Newton Turner
+Helena Patursson
+Helen Battle
+Helen Belyea
+Helen Brewster Owens
+Helen Clark
+Helen Codere
+Helen Connon
+Helen Dinerman
+Helen Dodson Prince
+Helen Dyer
+Helene Bresslau
+HÃ©lÃ¨ne Brion
+HÃ©lÃ¨ne Cixous
+Helene J. Kantor
+HÃ©lÃ¨ne Sparrow
+HÃ©lÃ¨ne van Zuylen
+Helen Frances Codere
+Helen Giri
+Helen Gorrill
+Helen Hamilton Gardener
+Helen H. Gardener
+Helen Kim
+Helen Longino
+Helen Mary Mayo
+Helen Matusevich Oujesky
+Helen Mayo
+Helen M. Duncan
+Helen Megaw
+Helen Morgenthau Fox
+Helen Muir
+Helen NiÃ±a Tappan Loeblich
+Helen Pitts
+Helen Pitts Douglass
+Helen Porter
+Helen Quinn
+Helen Reddy
+Helen Rodriguez-Trias
+Helen RodrÃ­guez TrÃ­as
+Helen Sawyer Hogg
+Helen Schneider Dinerman
+Helen Taylor
+Helen T. Edwards
+Helen T. Parsons
+Helga Charlotte Norrie
+Helga Hernes
+Hena Das
+Hendrika Johanna van Leeuwen
+Henrietta Edwards
+Henrietta Hill Swope
+Henrietta Louise Muir Edwards
+Henrietta Rodman
+Henrietta Swan Leavitt
+Henriette Avram
+Henriette Bie Lorentzen
+Henriette Goldschmidt
+Henry Browne Blackwell
+Henryka ÅazowertÃ³wna
+Henry Salt
+Henry Sidgwick
+Henry Stephens Salt
+Hermila Galindo
+Hermila Galindo Acosta
+Hertha Marks Ayrton
+Hertha Sponer
+Hertha Wambacher
+Hester A. Davis
+Hester Ashmead Davis
+He Zehui
+Hilary Kahn
+Hilda Bernstein
+Hilda Phoebe Hudson
+Hildegard Burjan
+Hildegarde Howard
+Hilde Levi
+Hilde Mangold
+Hillary Clinton
+Hilligje Kok-Bisschop
+Hind Nawfal
+Hoda Barakat
+Holly Near
+Honor Fell
+Hope Hibbard
+Hope Jahren
+Hortense Powdermaker
+Houda Ezra Ebrahim Nonoo
+Houda Nonoo
+Hua Eleanor Yu
+Humaira Begum
+Husn Banu Ghazanfar
+Ibtesam Badhrees
+Ibtissam Lachgar
+Ida Barney
+Ida B. Wells
+Ida Halley
+Ida Halpern
+Ida Helen Ogilvie
+Ida Noddack
+Ida Pauline Rolf
+Ida Rauh
+Ida Rolf
+Ida Shepard Oldroyd
+Idina Menzel
+Idit Zehavi
+Idola Saint-Jean
+Iffat Ara
+Ilse Rosenthal-Schneider
+Imogene King
+Indira Chakravarty
+Indira Hinduja
+Indira Nath
+Indrani Bose
+Inessa Armand
+Inez Milholland
+Inge Lehmann
+Ingerid GjÃ¸stein Resi
+IngibjÃ¶rg SÃ³lrÃºn GÃ­sladÃ³ttir
+Ingrid Daubechies
+Ingrid Michaelson
+Ingrid of Sweden
+Ingrid van Houten-Groeneveld
+Ipsita Roy Chakraverti
+Irena Krzywicka
+Irene Ayako Uchida
+Irene Bauer
+Irene Bernasconi
+Irene Crespin
+Irene E. Ryan
+Irene Fischer
+IrÃ¨ne Joliot-Curie
+Irene K. Fischer
+Irene Parlby
+Irene Uchida
+Irin Carmon
+Iris Anna Runge
+Iris Bannochie
+Iris M. Ovshinsky
+Iris Runge
+Irmgard Enderle
+Irmtraud Elfriede Morgner
+Irmtraud Morgner
+Irshad Manji
+Isabel Allende
+Isabel Andreu de Aguilar
+Isabel Bassett Wasson
+Isabella Abbott
+Isabella Aiona Abbott
+Isabelle Bogelot
+Isabelle Stone
+Isabel MontaÃ±ez
+Isabel P. MontaÃ±ez
+Isadora Cerullo
+Isala Van Diest
+Isa Noyola
+Ishmael Bernal
+Isobel Bennett
+Isobel Warren
+Isolde Hausser
+ItÅ Noe
+Ivy May Parker
+Ivy Parker
+Izabela Jaruga-Nowacka
+Izabela Sadoveanu-Evan
+Izetta Jewel
+Jacoba van den Brande
+Jacqueline Ceballos
+Jacqueline Michot Ceballos
+Jacqueline Nancy Mary Adam
+Jacquetta Hawkes
+James Mellaart
+Jamila Bey
+Jamil Sidqi al-Zahawi
+Janaki Ammal
+Jan BjÃ¶rklund
+Jane Addams
+Jane Alpert
+Jane A. McKeating
+Janeane Garofalo
+Jane Anger
+Jane Arden
+Jane Brotherton Walker
+Jane Cobden
+Jane Colden
+Jane Cunningham Croly
+Jane C. Wright
+Jane Ellen Harrison
+Jane Elliott
+Jane E. Parker
+Jane Fonda
+Jane Goodall
+Jane Hamilton Hall
+Janelle Saffin
+Jane Misme
+Jane Stafford
+Janet AkyÃ¼z Mattei
+Janet Biehl
+Janet Darbyshire
+Janet H. Darbyshire
+Janet Kelso
+Janet Marshall Stevenson
+Janet Mbugua
+Janet Niven
+Janet Rowley
+Janet Scudder
+Janet Stevenson
+Janette Bertrand
+Janet Vaughan
+Jani Allan
+Janie Allan
+Janine Connes
+Janine O'Leary Cobb
+Jan Lisa Huttner
+Janne Blichert-Toft
+JD Samson
+Jean Allison Stuntz
+Jean A. Stuntz
+Jean Bartik
+Jean Begg
+Jeane Porter Hester
+Jeanette Williams
+Jean Hanson
+Jeanne Chauvin
+Jeanne-Elizabeth Schmahl
+Jeanne MÃ©lin
+Jeanne Schmahl
+Jeannette Rankin
+Jeannette Wing
+Jean Thomas
+Jee Hyun Kim
+Jehan Sadat
+Jelica BeloviÄ‡-Bernadzikovska
+Jelica BeloviÄ‡-Bernardzikowska
+Jeni Bojilova-Pateva
+Jennette Arnold
+Jennifer Baumgardner
+Jennifer Doudna
+Jennifer Lawrence
+Jennifer Pozner
+Jennifer Tour Chayes
+Jenni Murray
+Jenni Williams
+Jenny Hirsch
+Jenny P. Glusker
+Jenny Rosenthal Bramley
+Jeremy Bentham
+Jeremy Corbyn
+JerÃ´nima Mesquita
+Jessica Alba
+Jessica Chastain
+Jessicka
+Jessie A. Ackermann
+Jessie Ackermann
+Jessie Boucherett
+Jessie J
+Jessie Jack Hooper
+Jessie Kahnweiler
+Jessie Marguerite Williamson
+Jessie Maye Smith
+Jessie Street
+Jewel
+Jiko Linda Cutts
+Jill Craigie
+Jill Soloway
+Jill Stein
+Jill Tarter
+Jill Tweedie
+Jincey Lumpkin
+Jiranun Sakultangphaisal
+Joan Alison Smith
+Joan Beauchamp Procter
+Joan Curran
+Joan du Plat Taylor
+Joan Jett
+Joan Kelly
+Joan Kerr
+Joan Mabel Frederica Du Plat Taylor
+Joan Maie Freeman
+Joan M. Freeman
+Joan Murrell Owens
+Joanna Russ
+Joanne M. Holden
+Joanne Simpson
+Joann Kealiinohomoku
+Joan Robinson
+Joan Semmel
+Joan Smith
+Joan Wiffen
+Jobeda Ali
+Jo Brand
+Jocelyn Bell Burnell
+Jocelyn Crane
+Jocelyn Gill
+JoÃ«lle LÃ©andre
+Johanna Budwig
+Johanna DÃ¶bereiner
+Johanna Fateman
+Johanna Kinkel
+JÃ³hanna SigurÃ°ardÃ³ttir
+Johanna "Tilly" Edinger
+Johanna Westerdijk
+Johannes Wijngaards
+John Lennon
+Johnnie Tillmon
+John Scalzi
+John Stuart Mill
+John Wijngaards
+Jole Bovio
+Jole Bovio Marconi
+Josefina Valencia MuÃ±oz
+JosÃ© Luis RodrÃ­guez Zapatero
+Josepha Abiertas
+Joseph Antoine Toussaint Dinouart
+JosÃ©phine Marchand
+Josephine Silone Yates
+Joss Whedon
+Joyanti Chutia
+Joyce Banda
+Joyce Chopra
+Joyce Lambert
+Joyce Mildred Lambert
+Joy Crisp
+Joy Picus
+Juana de Ibarbourou
+Juana InÃ©s de la Cruz
+Jude Milhon
+Judi Bari
+Judith Amaechi
+Judith Butler
+Judith Edelman
+Judith Milhon
+Judith Sealy
+Judith Sulzberger
+Judy Chicago
+Judy Grahn
+Judy Minx
+Judy Rae Grahn
+Judy Rebick
+Judy R. Franz
+Julia Anna Gardner
+Julia Gardner
+Julia Kristeva
+Julia Lermontova
+Julia Solly
+Julia TuÃ±Ã³n Pablos
+Julia Ward Howe
+Julie A. Nelson
+Julie Bindel
+Julie Delpy
+Julie Kent
+Julie Nelson
+Julieta Kirkwood
+Julieta Lanteri
+Julieta MontaÃ±o
+Juliet Lee-Franzini
+Julie Vinter Hansen
+Julius Motteler
+June Almeida
+June Dalziel Almeida
+June Lascelles
+Justine Caines
+Justine Sergent
+Justine Siegemund
+Justin Sane
+Justin Trudeau
+KaÊ»ahumanu
+Kaari Utrio
+Kadambini Ganguly
+Kadra Yosuf
+Kadra Yusuf
+K. Ajitha
+Kakan Hermansson
+Kakani Katija Young
+Kalpana Chawla
+Kamala Sohonie
+Kamal Ranadive
+Kameron Hurley
+Kamini A. Rao
+Kamini Roy
+Kamla Pant
+Kang Tongbi
+Kanno Sugako
+Kapila Vatsyayan
+Kara Hultgreen
+Kara Spears Hultgreen
+Karen Burns
+Karen C. Johnson
+Karen DeCrow
+Karen Grude Koht
+Karen J. Warren
+Karen SpÃ¤rck Jones
+Karen Vousden
+Karen Wetterhahn
+Karin Dreijer Andersson
+Karin Hannak
+Karin KjÃ¸lbro
+Karin Stoltenberg
+Kari SkjÃ¸nsberg
+Karolina SvÄ›tlÃ¡
+Kartini
+Kasturi Rajadhyaksha
+Kata DalstrÃ¶m
+Kat Blaque
+Kate Capshaw
+Kate Clinton
+Kate Dillon Levin
+Kate Gleason
+Kate Millett
+Kate Nash
+Kate Sheppard
+Kate Smurthwaite
+Katharina Rutschky
+Katharina Scheven
+Katharine Bartlett
+Katharine Burr Blodgett
+Katharine Dexter McCormick
+Katharine Martha Houghton Hepburn
+Katharine McCormick
+Katharine Murray Lyell
+Katharine Way
+Katherine Bitting
+Katherine Dunham
+Katherine Esau
+Katherine G. Langley
+Katherine Golden Bitting
+Katherine Gudger Langley
+Katherine Johnson
+Katherine Pollak Ellickson
+Katherine Sanford
+Katherine Spillar
+Katherine Zappone
+Kathie Sarachild
+Kathinka Zitz-Halein
+Kathi Wilcox
+Kathleen Baxter
+Kathleen Curtis
+Kathleen E. Carpenter
+Kathleen Hanna
+Kathleen I. Pritchard
+Kathleen King
+Kathleen Lonsdale
+Kathleen Maisey Curtis
+Kathleen Mary Drew-Baker
+Kathleen O'Grady
+Kathleen Ollerenshaw
+Kathleen Shannon
+Kathrin Barboza Marquez
+Kathrine S. French
+Kathryn D. Sullivan
+Kathryn Ferguson Fink
+Kathryn M Chaloner
+Kathryn M. Chaloner
+Kathryn Sullivan
+Kathy Acker
+Kathy Aoki
+Kathy Lette
+Kathy Najimy
+Katia and Maurice Krafft
+Katsuko Saruhashi
+Katy Deepwell
+Katy Perry
+Kay Mills
+Kay Tye
+Kazimiera Szczuka
+Kazuyo Katsuma
+Kelly Jemison
+Kenia Arias
+Kerrie Mengersen
+Kerry Noonan
+Ketayun Ardeshir Dinshaw
+Khadeeja Mumtaz
+Khadija Mumtaz
+Khalida Ghous
+Khalida Toumi
+Khanim Latif
+Khanim Rahim Latif
+Khawla Dunia
+Kim Gandy
+Kim Gordon
+Kim Hyesoon
+Kim Il-yeop
+Kim Iryeop
+Kim Myung-sun
+Kinga Dunin
+Kira Cochrane
+Kiran Martin
+Kiran Mazumdar-Shaw
+Kirsten Dunst
+Kishwar Naheed
+Kitty Bugge
+Kiyomi Tsujimoto
+Kjellaug Pettersen
+Klara Dan von Neumann
+KolbrÃºn HalldÃ³rsdÃ³ttir
+Kristina Keneally
+Krisztina Morvai
+Kshama Metre
+Kurt Cobain
+Kushboo
+Kutti Revathi
+Kwon In Suk
+Kyle DiFulvio
+Laci Green
+Lady Anne Monson
+Lady Constance Bulwer-Lytton
+Lady Constance Georgina Bulwer-Lytton
+Lady Florence Dixie
+Lady Walton
+Lakshmi Sahgal
+Lalithambika Antharjanam
+Lanying Lin
+Lars Leijonborg
+Lars Ohly
+Latifa al-Zayyat
+Laura Bassi
+Laura Bates
+Laura Bendfeldt
+Laura Cereta
+Laura de Force Gordon
+Laura Goode
+Laura Hughes
+Laura Molina
+Laura Quilter
+Laura Sabia
+Laura Wexler
+Laura Whitehorn
+Laurence Lanfumey
+Laurence Lanfumey-Mongredien
+Lauren Mayberry
+Lauretta Ngcobo
+Laurie Penny
+LaVerne Krause
+Layla Balabakki
+Leanne Wood
+Leda Rafanelli
+Lee Jeong-hee
+Lee Jung-hee
+Leela Sumant Moolgaokar
+Leila J. Rupp
+Lela E. Buis
+LÃ©lia Gonzalez
+Lena Dunham
+Leona Florentino
+Leona Woods
+Leona Woods Marshall Libby
+Leonora A. Hohl
+Leonora Bilger
+Leonore Tiefer
+LÃ©on-Pierre Richer
+LÃ©on Richer
+Leopoldina Fortunati
+LÃ©opold Lacour
+Lera Boroditsky
+Lesbia Soravilla
+Lesley Sibner
+Leslie Barnett
+Lettie Annie Allen
+Letty Cottin Pogrebin
+Lewis H. Morgan
+Leyla Zana
+Liana K
+Li Ang
+Libbie Henrietta Hyman
+Libbie Hyman
+Lida Gustava Heymann
+Lidia FernÃ¡ndez
+Lidia Gueiler
+Lidia Gueiler Tejada
+Lidija LiepiÅ†a
+Lierre Keith
+Liliane Ackermann
+Lilian Jane Gould
+Lilian Sheldon
+Lilian Tintori
+Lillian Beynon Thomas
+Lillian Mary Harris
+Lillian Mary Pickford
+Lillian Masediba Ngoyi
+Lillian Ngoyi
+Lillian Wald
+Lily Allen
+Lily Braun
+Lily Mae
+Lily May Perry
+Lily Mazahery
+Lina Morgenstern
+Linda B. Buck
+Linda Bellos
+Linda Braidwood
+Linda Buck
+Linda Fairstein
+Linda Lovelace
+Linda Nochlin
+Linda P.B. Katehi
+Linda SÃ¡nchez
+Linda Schreiber Braidwood
+Linda Stein
+Linda Walsh
+Lindsey Doe
+Lindy West
+Line Rochefort
+LinnÃ©a EngstrÃ¶m
+Lin Zongsu
+Lisa Bloom
+Lisa Jardine
+Lisa Kaltenegger
+Lisa Ling
+Lisa Loeb
+Lisa M. Diamond
+Lisa Randall
+Lisbeth Haas
+Lise Meitner
+Lise Payette
+Liu-Wang Liming
+Liv Buck
+Liv KÃ¸ltzow
+Li Yinhe
+Liza Donnelly
+Liza Marklund
+Liz Carpenter
+LizÃ© Santana
+Liz Phair
+Lizzie Marvelly
+Lizzy Lind af Hageby
+Lizzy Lind Af Hageby
+Lizzy van Dorp
+Ljubov Rebane
+Lois Irene Scott
+Lois Roden
+Lolita LebrÃ³n
+Londa Schiebinger
+Loney Clinton Gordon
+Loney Gordon
+Loraine Hutchins
+Lorde
+Lorella Jones
+Lorella M. Jones
+Loren Legarda
+Lori Perkins
+Lorna Casselton
+Lorna Dee Cervantes
+Lorraine Michael
+Lorraine Murray
+Lotika Sarkar
+Lotte Strauss
+Louisa Garrett Anderson
+Louisa Hubbard
+Louisa Lawson
+Louise A. Giblin
+Louise Armstrong
+Louise Bodin
+Louise Bryant
+Louise Burfitt-Dons
+Louise Caroline Alberta
+Louise Giblin
+Louise Johnson
+Louise McKinney
+Louise Mensch
+Louise Michel
+Louise Saumoneau
+Louise Slaughter
+Louise Weiss
+Louise Welsh
+Loujain Alhathloul
+Lourdes VÃ¡zquez
+L. Ruth Guy
+Luce Irigaray
+Lucila Gamero de la Medina
+Lucila Gamero de Medina
+Lucila Luciani de PÃ©rez DÃ­az
+Lucila Rubio
+Lucila Rubio de Laverde
+Lucile Quarry Mann
+Lucille Farrier Stickel
+Lucretia Mott
+Lucrezia Marinella
+Lucy Beatrice Moore
+Lucy Burns
+Lucy Cranwell
+Lucy Frey
+Lucy Goodison
+Lucy Mair
+Lucy Masey Smith
+Lucy Oommen
+Lucy Stone
+Lucy Weston Pickett
+Luisa Capetillo
+Luise KÃ¤hler
+Luise Meyer-SchÃ¼tzmeister
+Luke Newberry
+Luke Pasqualino
+Lupita Nyong'o
+Luz Argentina Chiriboga
+Luz MarÃ­a "Luzma" Umpierre
+Luz MarÃ­a Umpierre
+Luz MÃ©ndez de la Vega
+Lyda Verstegen
+Lydia Becker
+Lydia Cacho
+Lydia E. Pinkham
+Lydia Maria Child
+Lydia Moss Bradley
+Lydia Pinkham
+Lydia T. Black
+Lydia Villa-Komaroff
+Lydia Welti-Escher
+Lynne Segal
+Lynn Margulis
+Lynn Randolf
+Lynn Randolph
+Lynn Sherr
+Lyn Wadley
+Mabel Cook Cole
+Mabel Elizabeth Cook Cole
+Mabel Hokin
+Mabel Potter Daggett
+Mabel R. Hokin
+Mabel Sine Wadsworth
+Mabel Vernon
+Mab Segrest
+Madalena Barbosa
+Madalyn Murray O'Hair
+Madeleine Pelletier
+Madeleine Vernet
+Madeline Kneberg Lewis
+Madigan Shive
+Maga MagazinoviÄ‡
+Magda Ericson
+Magda Galula Ericson
+Magdalena SpÃ­nola
+Magdalena Åšroda
+Magda Staudinger
+Maggie Chapman
+Magnus Hirschfeld
+Mahala Andrews
+Maharani Chakravorty
+Mahnaz Afkhami
+MÃ¡irin de ValÃ©ra
+Maisie Carr
+Malalai Joya
+Malala Yousafzai
+Malati Choudhury
+Mallika Sengupta
+Malvika Sabharwal
+Malwida von Meysenbug
+Manal al-Sharif
+Manasi Pradhan
+Mandy Chessell
+Mangala Narlikar
+Manjula Anagani
+Manju Ray
+Manju Sharma
+Manuela SÃ¡enz
+Mara Dicle Neusel
+Mara Neusel
+Marcia Anna Keith
+Marcia Keith
+Marcia McNutt
+Marcia Neugebauer
+Marcia P. Sward
+Mareta West
+Margaret A. Kennard
+Margaret Altmann
+Margaret Anne LeMone
+Margaret Anne Mitchell
+Margaret Atwood
+Margareta Winberg
+Margaret Bastock
+Margaret Benston
+Margaret Brown
+Margaret Bullock
+Margaret Burbidge
+Margaret Chan
+Margaret Daphne Hampson
+Margaret D. Foster
+Margaret di Menna
+Margarete Bonnevie
+Margarete Kahn
+Margaret Ekpo
+Margaret Eliza Maltby
+Margaret Fuller
+Margaret G. Kivelson
+Margaret Gowing
+Margaret Harwood
+Margaret Hoover
+Margaret Kennard
+Margaret Leinen
+Margaret Levyns
+Margaret Lowe Benston
+Margaret MacDonald
+Margaret Mansfield, Baroness Sandhurst
+Margaret Mayall
+Margaret Mead
+Margaret Mitchell
+Margaret Morse Nice
+Margaret Newton
+Margaret Pittman
+Margaret Rae Morrison Luckock
+Margaret Reed Lewis
+Margaret R. Fox
+Margaret Sandhurst
+Margaret Sanger
+Margaret Sibthorp
+Margaret Sievwright
+Margaret Skinnider
+Margaret Sloan-Hunter
+Margaretta D'Arcy
+Margaretta Ruth D'Arcy
+Margaret Thatcher
+Margaret Traxler
+Margaret Vale
+MÄƒrgÄƒrita Miller-Verghy
+Margarita Nelken
+Margarita Nelken Mansberger
+Margit Slachta
+Margo St. James
+Margrethe Vestager
+Marguerite de la SabliÃ¨re
+Marguerite de Witt-Schlumberger
+Marguerite Duras
+Marguerite Perey
+Marguerite Pichon-Landry
+Margunn BjÃ¸rnholt
+Maria Abbracchio
+Maria Alyokhina
+MarÃ­a Andrea Casamayor
+Maria-Antonietta Macciocchi
+Maria Arbatova
+MarÃ­a Arias Bernal
+Maria Arrillaga
+MarÃ­a Arrillaga
+Maria Benedita Bormann
+Maria Benedita CÃ¢mara Bormann
+Maria Carmela Lico
+MarÃ­a Corina Machado
+Maria Cotera
+MarÃ­a Cristina Perceval
+MarÃ­a Currea
+MarÃ­a Currea Manrique
+Maria da Penha
+MarÃ­a de Echarri
+MarÃ­a de los Angeles Alvarino Gonzalez
+Maria Elizabeth Holland
+Maria Eugenia Cotera
+MarÃ­a Eugenia Rojas
+MarÃ­a Eugenia Rojas Correa
+MarÃ­a Felicidad GonzÃ¡lez
+Maria Gaetana Agnesi
+Maria Georgina Grey
+Maria Goeppert Mayer
+Maria Goeppert-Mayer
+MarÃ­a JesÃºs Alvarado Rivera
+Maria Klenova
+Maria Kovacs
+MarÃ­a LarraÃ­n de VicuÃ±a
+Maria Larsson
+MarÃ­a LejÃ¡rraga
+MarÃ­a Luisa Bemberg
+Mariama BÃ¢
+Maria Margarethe Kirch
+Mariam Ghani
+Maria Mitchell
+Marian Engel
+Marian Koshland
+Marianne Allen Tasker
+Marianne Ehrmann
+Marianne Grunberg-Manago
+Marianne Hainisch
+Marianne Menzzer
+Marianne Rauze
+MarÃ­a Perceval
+Maria Petrou
+Maria Pia Abbracchio
+Maria Reiche
+MarÃ­a Rivera Urquieta
+MarÃ­a Ruiz de Burton
+Maria Shriver
+Maria Sibylla Merian
+MÃ¡ria Telkes
+MarÃ­a Teresa Ferrari
+Maria T. Zuber
+Maria VÃ©rone
+Maria Wetterstrand
+Maria Wilman
+Maria Zuber
+Mariblanca Sabas AlomÃ¡
+Marie-Anne de Roumier-Robert
+Marie-Anne Libert
+Marie Baum
+Marie Beatrice Schol-Schwarz
+Marie Bonnevial
+Marie Clark Taylor
+Marie-Claude Vaillant-Couturier
+Marie Curie
+Marie Equi
+Marie Goegg-Pouchoulin
+Marie Guillot
+Marie Huot
+Marie Janson
+Marie Juchacz
+Marie-Laure Sauty de Chalon
+Marie-Louise von Franz
+Marie MajerovÃ¡
+Marie Maugeret
+Marie Maynard Daly
+Marie Morisawa
+Marie Popelin
+Marie SkÅ‚odowska Curie
+Marie-Sophie Germain
+Marie Souvestre
+Marie Stopes
+Marie Taylor
+Marie Tharp
+Marietta Blau
+Marija AuÅ¡rinÄ— PavilionienÄ—
+Marija Gimbutas
+Marija Å imanska
+Marilyn Chin
+Marilyn E. Jacox
+Marilyn French
+Marilyn Waring
+Marina and the Diamonds
+Marina Baker
+Marina Salye
+Marina Yevgenyevna Salye
+Marion Bernstein
+Marion Cameron Gray
+Marion Coates Hansen
+Marion Gray
+Marit Aarum
+Marita Ulvskog
+Marjorie A. Hoy
+Marjorie Courtenay-Latimer
+Marjorie F. Lambert
+Marjorie Hoy
+Marjorie Mussett
+Marjorie Townsend
+Marjorie Van de Water
+Marjorie Violet Mussett
+Marjory Stephenson
+Mark Kermode
+Marleen Gorris
+Marleen S. Barr
+Marquesa del Ter
+Marta Vergara
+Martha Albertson Fineman
+Martha Burk
+Martha Burkhardt
+Martha Chase
+Martha Coffin Wright
+Martha Cowls Chase
+Martha Daniell Logan
+Martha Fineman
+Martha Griffiths
+Martha P. Haynes
+Martha Rhoads Bell
+Marthe Bigot
+Marthe Gosteli
+Marthe Vogt
+Martine Billard
+Marusya Bociurkiw
+Marvalee Wake
+Marvi Sirmed
+Mary A. Appelhof
+Marya ChÃ©liga-Loevy
+Mary Agard Pocock
+Mary Ainsworth
+Maryam Namazie
+Mary Anning
+Mary Archer
+Mary Arlene Appelhof
+Mary Baker Eddy
+Mary Barber
+Mary Beth Edelson
+Mary BrÃ¼ck
+Mary Bunting
+Mary Calderone
+Mary Cartwright
+Mary C. Lobban
+Mary Daly
+Mary Davis Treat
+Mary-Dell Chilton
+Mary Dominica Legge
+Mary Dora Rogick
+Mary Eleanor Brackenridge
+Mary Eleanor Power
+Mary Elizabeth Barber
+Mary Elizabeth Kinnear
+Mary Ellen Jones
+Mary Emilie Holmes
+Mary F. Lyon
+Mary Frances McDonald
+Mary Golda Ross
+Mary Gordon Calder
+Mary G. Ross
+Mary Haas
+Mary Harriet Bate
+Mary Horner Lyell
+Mary Jean Harrold
+Mary Jeanne Kreek
+Mary Katharine Gaillard, nÃ©e Ralph
+Mary Kelly
+Mary Kenneth Keller
+Mary Kenneth Keller,B.V.M.
+Mary K. Gaillard
+Mary Layne Boas
+Mary L. Boas
+Mary Leakey
+Mary Letitia Caldwell
+Mary Livingston Ripley
+Mary Lou Zoback
+Mary Loveless
+Mary Lura Sherrill
+Mary Lyon
+Mary MacSwiney
+Mary McCarthy
+Mary McLeod Bethune
+Mary Mulvihill
+Mary Pannbacker
+Mary Parke
+Mary Peters Fieser
+Mary Pickford
+Mary Poonen Lukose
+Mary Puthisseril Verghese
+Mary R. Calvert
+Mary R. Haas
+Mary Richardson
+Mary Ritter Beard
+Mary Roberts Rinehart
+Mary Robinson
+Mary-Russell Ferrell Colton
+Mary Shaw Shorb
+Mary Shelley
+Mary Sherman Morgan
+Mary Somerville
+Mary S. Sherman
+Mary Stocks
+Mary Stocks, Baroness Stocks
+Mary Stott
+Mary Teresa BrÃ¼ck
+Mary Treat
+Mary van Kleeck
+Mary Van Rensselaer Buell
+Mary Verghese
+Mary Wharton
+Mary Wollstonecraft
+Marzia Basel
+Massimilla "Milla" Baldo-Ceolin
+Massouda Jalal
+Mathilde BensaÃºde
+Mathilde Franziska Anneke
+Mathilde SchjÃ¸tt
+Mathilde Vaerting
+Matilda Joslyn Gage
+Matilda Ridout Edgar
+Matilda Roalfe
+Matilde Bajer
+Matilde BensaÃºde
+Matilde Cantos
+Matilde FernÃ¡ndez
+Matt Dillahunty
+Maude Barlow
+Maude Victoria Barlow
+Maud Gonne
+Maud Leonora Menten
+Maud Menten
+Maud Olofsson
+Maud Russell England
+Maud Wood Park
+Maud Younger
+Maura Scannell
+Maureen McTeer
+Mavis Leno
+Maya Angelou
+Maya Jribi
+May Edith Evelyn Furey
+Mayim Bialik
+May Ling Su
+Mayly SÃ¡nchez
+May Owen
+May Sinclair
+May Stevens
+May Theilgaard Watts
+May Wright Sewall
+May Ziade
+Meena Keshwar Kamal
+Meera Kosambi
+Megan Andelloux
+Meghan Trainor
+Megumi Igarashi
+Melba Phillips
+Melissa Etheridge
+Melissa Farley
+Mercedes Valdivieso
+Mercy B. Jackson
+Meredith Haaf
+Meredith Stern
+Meridel Le Sueur
+Mica Mosbacher
+Michael Kimmel
+Michael Messner
+Michal Har'el
+Michalina Anna WisÅ‚ocka
+Michalina WisÅ‚ocka
+MichÃ¨le Pujol
+Michelle Anderson
+Michelle J. Anderson
+Midge Costanza
+Mihaela Miroiu
+Mildred Allen
+Mildred Catherine Rebstock
+Mildred Cohn
+Mildred Dresselhaus
+Mildred Fahrni
+Mildred Rebstock
+Mildred Trotter
+Mileva MariÄ‡
+Miley Cyrus
+Milla Baldo-Ceolin
+Millicent Fawcett
+Millicent Preston-Stanley
+Milly Witkop
+Mimi Sverdrup Lunden
+Mina Loy
+Minna Canth
+Minnie Abercrombie
+Minnie Fisher Cunningham
+Mira Datta Gupta
+Mira Dutta Gupta
+Miranda July
+Miriam Elizabeth Simpson
+Miriam Louisa Rothschild
+MÃ­riam Martinho
+Miriam Rothschild
+Miriam Schapiro
+Mirjana MarkoviÄ‡
+Mirra Komarovsky
+Miss Piggy
+Mitali Mukerji
+Mitsuye Yamada
+Mizuho Fukushima
+Moira Dunbar
+Molara Ogundipe
+Molly Haskell
+Mona Eltahawy
+MÃ³nica Bettencourt-Dias
+Monique Wittig
+Montserrat Roig
+Montserrat Roig i Fransitorra
+Mridula Mukherjee
+"Mrs. William Grey"
+M. Subhadra Nair
+Mukhtaran Bibi
+Muma Gee
+Muna AbuSulayman
+Murasaki Yamada
+Muriel Duckworth
+Muriel M. Seyfert
+Muriel Mussells Seyfert
+Muriel Robertson
+Muriel Rukeyser
+Muriel Wheldale Onslow
+Musine Kokalari
+Muthulakshmi Reddi
+Muzi Epifani
+M. V. Padma Srivastava
+Myeong-Hee Yu
+Myra Keen
+Myriam Merlet
+Myrtle Bachelder
+Nadezhda Tolokonnikova
+Nadine Barrie Smith
+Naela Chohan
+Na Hye-sok
+Najma Sadeque
+Nanci Griffith
+Nancy Adams
+Nancy Astor, Viscountess Astor
+Nancy Dinah Elly Khedouri
+Nancy Fraser
+Nancy Keenan
+Nancy Khedouri
+Nancy Ruth
+Nandini Mundkur
+Naomi Esther Jaffe
+Naomi Jaffe
+Naomi Mary Margaret Mitchison
+Naomi McClure-Griffiths
+Naomi Mitchison
+Naomi Wolf
+Narcyza Å»michowska
+Nasir Aslam Zahid
+Natalia Bekhtereva
+Natalia Lafourcade
+Natalie Bennett
+Natascha Artin Brunswick
+Natasha Walter
+Natividad Almeda-Lopez
+Natividad Almeda-LÃ³pez
+Navamani Elia Peter
+Navanethem Pillay
+Nawab Faizunnesa
+Nawal El Saadawi
+Nazik Al-Malaika
+Neelam Kler
+Neena Gupta
+Nellie May Naylor
+Nellie McClung
+Nellie M. Payne
+Nellie Wong
+Nesta Helen Webster
+Nettie Stevens
+Nick Clegg
+Nicolas de Condorcet
+Nicole Grasset
+Nicole PÃ©ry
+Nicole Prause
+Nicole-Reine Lepaute
+Nielsine Nielsen
+Niki Albon
+Nikki Craft
+Nilofar Sakhi
+Nil Yalter
+Nina Burleigh
+Nina Etkin
+Nina Hartley
+Nise da Silveira
+Nizar Qabbani
+Nobuko Yoshiya
+Noe ItÅ
+Nomy Lamm
+Noor Al-Hussein
+Nora Fisher McMillan
+Nora Lilian Alcock
+Nora Lilian Lepard Alcock
+Nora Stanton Blatch Barney
+Nora Volkow
+Noreen Murray
+Norma Cruz
+Nuriye Ulviye Mevlan Civelek
+Odilia Castro Hidalgo
+Ofelia Hooper
+Ofelia Hooper Polo
+Oksana Shachko
+Olaug LÃ¸ken
+Olena Pchilka
+Olga Aleksandrovna Ladyzhenskaya
+Olga Arsenievna Oleinik
+Olga Fedchenko
+Olga FÃ©dchenko
+Olga Ladyzhenskaya
+Olga MÃ¡tÃ©
+Olga NÃºÃ±ez Abaunza
+Olga Shapir
+Olha Kobylianska
+Olha Petrivna Kosach
+Olive Schreiner
+Olof Dreijer
+Olof Palme
+Olympe de Gouges
+Omowunmi Sadik
+on. Maria Antonietta Macciocchi
+Orlandina de Oliveira
+Orshi Drozdik
+Ottilie Assing
+Ousmane SembÃ¨ne
+Ovidie
+Owen Jones
+OyÃ¨rÃ³nkáº¹Ì OyÄ›wÃ¹mÃ­
+Oyinkan Abayomi
+Oyinkansola Abayomi
+Paca Navas
+Padma Gole
+Pak Hon-yong
+PÃ¡lnÃ© Veres
+Pamela B. Davis
+Pamela Colman Smith
+Pamela L. Gay
+Pandita Ramabai
+Pan Yuliang
+Papiya Ghosh
+Paquita la del Barrio
+Paquita La Del Barrio
+Paramjit Khurana
+Paris Lees
+Park Indeok
+Park In-deok
+Pascual H. Poblete
+Pat Benatar
+Pat Califia
+Pat Murphy
+Patricia Barchas
+Patricia Bergquist
+Patricia Clarke
+Patricia Giles
+Patricia Goldman-Rakic
+Patricia Heaton
+Patricia McFadden
+Patricia R. Barchas
+Patrick Califia
+Patrick Stewart
+Pat Rosier
+Patsy Mink
+Paula Gunn Allen
+Paulette Nardal
+Paulina Lebl-Albala
+Paulina Luisi
+Pauline Gracia Beery Mack
+Pauline Matilde Theodora Bajer
+Pauline Morrow Austin
+Paul Robin
+Peaches
+Pearl Kendrick
+Peggy McIntosh
+Peggy Seeger
+Peg Yorkin
+Penelope Boston
+Peng Wan-ru
+Peter Eriksson
+Peter Wilby
+Petra Kelly
+Petra Wilder-Smith
+Philippa Schuyler
+Phoebe S. Leboy
+Phoebe Snetsinger
+Phoebe Waterman Haas
+Phyllis Birkby
+Phyllis Chesler
+Phyllis Clinch
+Phyllis Kennedy
+Phyllis Lyon
+Phyllis Ross
+Phyllis Starkey
+Pia Nalli
+Piedad CÃ³rdoba
+Pilar Jorge de Tella
+Polina Suslova
+Polly Toynbee
+Poly Styrene
+Prabha Chatterji
+Pregs Govender
+Prem Chowdhry
+Princess Charlotte
+Princess Charlotte of Saxe-Meiningen
+Princess Elisabeth
+Princess Lalla Aicha
+Princess Lalla Aicha of Morocco
+Princess Louise
+Princess Louise, Duchess of Argyll
+Priscilla Susan Bury
+Priyambada Mohanty Hejmadi
+Priyamvada Natarajan
+Priya Natarajan
+Professor Isabella Helen Mary Muir
+Professor Jane A. McKeating
+Prof. Martha P. Haynes
+Prof Sarah Joanna Tabrizi
+Prudence Hero Napier
+Prue Hyman
+Pupul Jayakar
+PZ Myers
+Qamar Rahman
+Qandeel Baloch
+Qian Xiuling
+Qiu Jin
+Queen Noor of Jordan
+Queen Rania of Jordan
+Ra'ana Liaquat Ali Khan
+Rachel Barrett
+Rachel Carson
+Rachel Dolezal
+Rachel Fuller Brown
+Rachel Lloyd
+Rachel Makinson
+Rada Ivekovic
+Rada IvekoviÄ‡
+Raden Adjeng Kartini
+Radha Balakrishnan
+Radhia Cousot
+Radio Sloan
+Radka Donnell
+Rae Luckock
+Ragna Nielsen
+Raissa L. Berg
+Raissa L'vovna Berg
+RajaÃ¢ Cherkaoui El Moursli
+Rajammal P. Devadas
+Rajeshwari Chatterjee
+Raluca Ripan
+Rama Govindarajan
+Raman Parimala
+Randi Blehr
+Rania al-Abdullah
+Rania Al-Abdullah
+Rani Dhavan Shankardass
+Raquel Dzib Cicero
+Rasa von Werder
+Rasha Omran
+Raufa Hassan al-Sharki
+Raya Dunayevskaya
+Razan Zaitouneh
+Rebecca Ann King
+Rebecca Davis Lee Crumpler
+Rebecca Lancefield
+Rebecca Latimer Felton
+Rebecca Lee Crumpler
+Rebecca Walker
+Rebecca Watson
+Rebecca West
+Regula Rytz
+Remziye Hisar
+Renate Stendhal
+Renee M Borges
+Renee M. Borges
+Rha Hye-seok
+Rhonda Patrick
+Rhonda Perciavalle Patrick
+Riane Eisler
+Riane Tennenhaus Eisler
+Rica Erickson
+Richard Dawkins
+Risa Hontiveros
+Rita Banerji
+Rita Gross
+Rita Levi-Montalcini
+Rita MacNeil
+Rita Mae Brown
+Rita Ora
+Rita Vorperian
+Ritt Bjerregaard
+Ritu Menon
+Roberta Bondar
+Roberta FernÃ¡ndez
+Roberta MacAdams
+Roberta maria Macadams price
+Robin Kelley
+Roewan Crowe
+Roger Arliner Young
+Rohini Godbole
+Romelia AlarcÃ³n Folgar
+Romola Garai
+Roquia Sakhawat Hussain
+Rosa Beddington
+Rosa Genoni
+Rosa Julieta MontaÃ±o Salvatierra
+Rosalie Slaughter Morton
+Rosalind Elsie Franklin
+Rosalind Franklin
+Rosalind Gill
+Rosalind Pitt-Rivers
+Rosa Luxemburg
+Rosalyn Baxandall
+Rosalynn Carter
+Rosalyn Sussman Yalow
+Rosa Manus
+Rosa Maria Arquimbau
+Rosa Mayreder
+Rosa MerilÃ¤inen
+Rosa Olga Sansom
+Rosario Castellanos
+Rosario Morales
+Rosa Smith Eigenmann
+Rosa Torre GonzÃ¡lez
+Rose Aguilar
+Rose Dieng Kuntz
+Rose Dieng-Kuntz
+Rose Epstein Frisch
+Rose Frisch
+Rose Jackson
+Rosemarie Putnam Tong
+Rosemarie Tong
+Rosemary Hutton
+Rosemary Kyburz
+Rosemary Murray
+Rosetta Lulah Baume
+Rose Whelan Sedgewick
+Rosi Braidotti
+Rosie Boycott
+Rosika Schwimmer
+Rounaq Jahan
+Rowan Blanchard
+Roxana Judkins Stinchfield Ferris
+Roxana Stinchfield Ferris
+Roxanne Dunbar-Ortiz
+Roxie Collie Laybourne
+Ruby Hirose
+Ruby Payne-Scott
+Ruchama Marton
+Rupi Kaur
+Ruqaiya Hasan
+Ruth Benedict
+Ruth Charney
+Ruth Dixon Turner
+Ruth Fairfax
+Ruth Fincher
+Ruth First
+Ruth Fulton Benedict
+Ruth Landes
+Ruth L. Lockhart
+Ruth Lockhart
+Ruth Mary Rogan Benerito
+Ruth Mountaingrove
+Ruth Murray Underhill
+Ruth Patrick
+Ruth R. Benerito
+Ruth Sanger
+Ruth Smith Lloyd
+Ruth Turner
+Ruth Underhill
+Ruth Westheimer
+Ryder Skye
+Sabrina Chap
+Sadie Benning
+Sahar Khalifeh
+Saira Afzal Tarar
+Saiza Nabarawi
+Sakina Akhundzadeh
+Sally Hacker
+Sally Haslanger
+Sally Kristen Ride
+Sally L. Hacker
+Sally Miller Gearhart
+Sally Ride
+Sally Shlaer
+Salman Rushdie
+Salma Sobhan
+Samantha Scarlette
+Samar Badawi
+Sameera Moussa
+Samira Negrouche
+Sammy Albon
+Sam Smith
+Sandra Bernhard
+Sandra Faber
+Sandra Fluke
+Sandra G. Harding
+Sandra Harding
+Sandra M. Faber
+Sandra Morgen
+Sandra Saouaf
+Sandra Steingraber
+Sara Alpern
+Sara Bard Field
+Sara Bareilles
+Sarah A. Drake
+Sarah Ann Drake
+Sarah Bedichek Pipkin
+Sarah Burke
+Sarah Ellen Oliver Snow
+Sarah Emily Davies
+Sarah GrimkÃ©
+Sarah Haskins
+Sarah Hayward
+Sarah Margaret Fuller
+Sarah Millican
+Sarah Monod
+Sarah Moore GrimkÃ©
+Sarah Ratner
+Sarah Stewart
+Sarah Tabrizi
+Sara K. Gould
+Sarala Devi Chaudhurani
+Sara Pascoe
+Sarojini Sahoo
+Saroj Nalini Dutt
+Sarungbam Bimola Kumari Devi
+Savitribai Phule
+Sayaka Osakabe
+Sebahat Tuncel
+Seetha Coleman-Kammula
+Selma LagerlÃ¶f
+Senal Sarihan
+Åženal SarÄ±han
+Serenity
+Shafi Goldwasser
+Shafrira Goldwasser
+Shaha Riza
+Shakuntala Devi
+Shani Boianjiu
+Shannon Bell
+Sharada Dwivedi
+Sharada Srinivasan
+Sharon Barker
+Sharon Bridgforth
+Sharon E. Barker
+Sharon Maeda
+Sharon Mosher
+Shary Flenniken
+Shashi Wadhwa
+Shawna LeneÃ©
+Sheila Sherlock
+Shere Hite
+Shiela Mehra
+Shimizu Shikin
+Shingai Shoniwa
+Shirin Darasha
+Shirin Ebadi
+Shirin Framroze Darasha
+Shirin M. Rai
+Shirin Neshat
+Shirley Ann Jackson
+Shirley Chisholm
+Shirley Jackson
+Shirley Jeffrey
+Shirley Winifred Jeffrey
+Shiva Nazar Ahari
+Shobhana Narasimhan
+Showry
+Shukria Barakzai
+Shulamith Firestone
+Sia Furler
+Sibylle GÃ¼nter
+Sibyl Martha Rock
+Sibyl M. Rock
+Sidnie Manton
+Sigrun Hoel
+Silvina Bullrich
+Simone de Beauvoir
+Simone Veil
+Simon Pegg
+Sinah Estelle Kelley
+S. I. Padmavati
+Siri Hangeland
+Sir Patrick Stewart
+Sister Margaret Traxler, S.S.N.D.
+Siv FriÃ°leifsdÃ³ttir
+SnjeÅ¾ana KordiÄ‡
+SofÃ­a Isabel Montenegro AlarcÃ³n
+Sofia Kovalevskaya
+SofÃ­a Montenegro
+Sofia Simmonds
+Sojourner Truth
+Soledad Acosta
+Soledad Acosta Kemble
+Somaly Mam
+Sonia Alconini
+Sonia Andrade
+Sonia Mary Cole
+Sonia Romero
+Sonja Ashauer
+Sonja Davies
+Sophia Dobson Collet
+Sophia Eckerson
+Sophia Jex-Blake
+Sophia S. Simmonds
+Sophie Charlotte Ducker
+Sophie Germain
+Sophie Liebknecht
+Soraya Tarzi
+Sor Juana InÃ©s de la Cruz, O.S.H.
+Specioza Kazibwe
+Staceyann Chin
+È˜tefania MÄƒrÄƒcineanu
+Stella Creasy
+Stella Grace Maisie Carr
+Stella May Henderson
+Stephanie A. Burns
+Stephanie Burns
+Stephanie Kwolek
+Stephanie L. Kwolek
+Steven Pinker
+Stuart Hall
+Sudha Bhattacharya
+Sudha Murthy
+Sudhira Das
+Sudipta Sengupta
+Sue Black
+Sue Ford
+Sue Kedgley
+Sufia Kamal
+Suhad Bahajri
+Suhaila Seddiqi
+Suhaila Siddiq
+Suhayr al-Qalamawi
+Suheir al-Atassi
+Suheir Atassi
+Sujatha Ramdorai
+Sulamith Goldhaber
+Sulochana Gadgil
+Sultana Kamal
+Suman Sahai
+Susana, Lady Walton
+Susan B. Anthony
+Susan B. Boyd
+Susan B. Horwitz
+Susan Blackmore
+Susan Boyd
+Susan Brownell Anthony
+Susan Brownmiller
+Susan D. Shaw
+Susan Ellen Stern
+Susan Estrich
+Susan Faludi
+Susan Greenfield
+Susan Hough
+Susan Lim
+Susan Lim Lee Hong
+Susan Miller Rambo
+Susan Moller Okin
+Susanna de Vries
+Susanne Helene Winslow
+Susan Powter
+Susan Sarandon
+Susan Solomon
+Susan Sontag
+Susan Stern
+Susan Walker Fitzgerald
+Susie Bright
+Suzan Kahramaner
+Suzanne Cory
+Suzanne Duigan
+Suzanne Voilquin
+Suze Groeneweg
+Svava JakobsdÃ³ttir
+Sylvia Agnes Sophia Tait
+Sylvia Fedoruk
+Sylvia Pankhurst
+Sylvia Porter
+Sylvia Rivera
+Sylvia Sleigh
+Sylvia Tamale
+Taha El Hakem
+TÃ¡hirih
+Takamure Itsue
+Tamara Awerbuch-Friedlander
+Tamara Eugenia Awerbuch-Friedlander
+Tamara Horowitz
+Tammy Bruce
+Tamsin Wilton
+Tang Qunying
+Tanja OstojiÄ‡
+Tanya Atwater
+Tarab Abdul Hadi
+Tarabai Shinde
+Tara Hurley
+Taraneh Alidoosti
+Tarif Khalidi
+Taslima Nasrin
+Tatiana Birshtein
+Tatyana Fazlalizadeh
+Tatyana M. Velikanova
+Tatyana Velikanova
+Taylor Momsen
+Taylor Swift
+Tebello Nyokong
+Tee A. Corinne
+Tee Corinne
+Tellervo Koivisto
+Teresa Noce
+TerÃ©z Karacs
+Terry Ann Plank
+Terry Neese
+Terry O'Neill
+Terry Plank
+Tessy Thomas
+Thanjavur Santhanakrishna Kanaka
+Thea D. Hodge
+The Baroness Afshar
+The Baroness Greenfield
+The Baroness Hayter of Kentish Town
+The Baroness Summerskill
+The Baroness Thatcher
+The Duchess of Sutherland
+Thelma Cazalet-Keir
+Thelma Estrin
+Theodora Lisle Prankerd
+Theo van Gogh
+Theresa Clay
+ThÃ©rÃ¨se Casgrain
+ThÃ©rÃ¨se Forget Casgrain
+ThÃ©rÃ¨se Kuoh-Moukouri
+Thereza Dillwyn Llewelyn
+Thereza Mary Dillwyn Llewelyn
+The Viscountess Astor
+The Viscountess Rhondda
+Thit Jensen
+Tiffany Million
+Tillie Olsen
+Tilly Edinger
+Tina Campt
+Tobi Vail
+Tom Copley
+Tom Hiddleston
+Tom Watson
+Toni Carabillo
+Tonie Nathan
+Tony Benn
+Torild Skard
+Toril Moi
+Toshiko Tamura
+Tracey Emin
+Tracey Moberly
+Trinh T. Minh-ha
+Tsering Landol
+T. S. Kanaka
+Tsuda Umeko
+Tyne Daly
+Ulla Mitzdorf
+Una Lucy Fielding
+Una Marson
+Una M. Ryan
+Una Ryan
+Urani Rumbo
+Ursula B. Marvin
+Ursula Franklin
+Ursula G. Bower
+Ursula Graham Bower
+Ursula Koch
+Urvashi Butalia
+Urvashi Vaid
+Valentina Borok
+Valerie Aurora
+Valerie Beral
+Valerie Mizrahi
+Valerie Solanas
+Valerie Wise
+Valery Troitskaya
+Vallalarpuram Sennimalai Natarajan
+Vanaja Iyengar
+Vandana Shiva
+Vange Leonel
+Vasanti N. Bhat-Nayak
+Vasanti N. Nayak
+Veena Tandon
+Vela Blagoeva
+Vera Fedorovna Gaze
+Vera Gaze
+Vera Hingorani
+Vera Nikolaevna Maslennikova
+Vera Popova
+Vera Rubin
+Verena Stefan
+Veres PÃ¡lnÃ©
+VerÃ³nica Cruz SÃ¡nchez
+Veronica de Klerk
+Veronica Seton-Williams
+Veronica Vera
+Veronika BromovÃ¡
+VÃ©ronique Gouverneur
+Vesela Blagoeva
+Vesselina Breskovska
+Vicki Funk
+Victoire LÃ©odile BÃ©ra
+Victoria Ann Funk
+Victoria Kimani
+Victoria Woodhull
+Vijayalakshmi Ravindranath
+Vilma EspÃ­n
+Vina Mazumdar
+Viola Shelly Shantz
+Violette Cordery
+Virginia Apgar
+Virginia Bolten
+Virginia \\\\Ginny\\\\ Montes
+Virginia Held
+Virginia Montes
+Virginia Woolf
+Virginie Despentes
+Voltairine de Cleyre
+Wajeha al-Huwaider
+Waka Yamada
+Wanda Kirkbride Farr
+Wanda Margarite Kirkbride Farr
+Wangari Maathai
+Wangari Muta Maathai
+Waris Dirie
+Wendy Brown
+Wendy McElroy
+Whitney Crothers Dilley
+Wilhelmina Sherriff Bain
+Willa Muir
+William Moulton Marston
+William Thompson
+Wilma Mankiller
+Wil van Gogh
+Wil Wheaton
+Wim Hora Adema
+Winifred Asprey
+Winifred Curtis
+Winifred Goldring
+Winifred Holtby
+Winifred Pennington
+Winifred Tutin
+Winifred Watkins
+Winnifred Harper Cooley
+Winona LaDuke
+Wu Qing
+Xiao Meili
+Yamada Waka
+Yamakawa Kikue
+Yamuna Krishnan
+Yara Sallam
+Yasmin Alibhai-Brown
+Yawa Hansen-Quao
+Yayoi Aoki
+YÃ©sica SÃ¡nchez Maya
+Yevheniya Yaroshynska
+Yi Kwang-su
+Yoko Hayashi
+Yoko Ono
+Yolanda Blanco
+Yona Wallach
+Yoshioka Yayoi
+Yuasa Yoshiko
+Yuriko Miyamoto
+Yu Zhengxie
+Yvette Boucher Rousseau
+Yvette Cauchois
+Yvette Cooper
+Yvonne Barr
+Yvonne Choquet-Bruhat
+Yvonne Rainer
+Zaida MuxÃ­
+Zainab Bangura
+Zana Ramadani
+Zara Larsson
+Zarina Baloch
+Zaruhi Kalemkaryan
+Zeng Baosun
+Zerelda Gray Sanders Wallace
+Zerelda G. Wallace
+Zhang Jie
+ZinaÃ¯da Aksentieva
+Zinaida Botschantzeva
+Zinaida Petrovna Botschantzeva
+Zoe Williams
+Zofia DaszyÅ„ska-GoliÅ„ska
+Zofia Kielan-Jaworowska
+Zofia NaÅ‚kowska
+Zofka Kveder
+Zora Neale Hurston
+Zorica JevremoviÄ‡ MunitiÄ‡
+Zorica Mrsevic
+Zorica MrÅ¡eviÄ‡
+Zuleika Alambert
+Zuzanna Ginczanka
+ÃžÃ³rhildur ÃžorleifsdÃ³ttir
+ÃžÃ³runn SveinbjarnardÃ³ttir
+Ú†ÙŠÙ‡Ø§Ù† Ø§Ù„Ø³Ø§Ø¯Ø§Øª
+Ø³Ø­Ø± Ø®Ù„ÙŠÙØ©
+Ø´ÛŒÙˆØ§ Ù†Ø¸Ø±Ø¢Ù‡Ø§Ø±ÛŒ
+Ø·Ø±ÙŠÙ Ø§Ù„Ø®Ø§Ù„Ø¯ÙŠ
+Ù‡Ø¯Ù‰ Ø¨Ø±ÙƒØ§Øª
+ÙˆØ§Ø±ÙŠØ³ Ø¯ÙŠØ±ÙŠ
+Ð“Ð°Ð½Ð½Ð° Ð“ÑƒÑ†Ð¾Ð»
+ÐœÐ°Ñ€Ð¸Ð½Ð° Ð¡Ð°Ð»ÑŒÐµ
+ÐžÐºÑÐ°Ð½Ð° Ð¨Ð°Ñ‡ÐºÐ¾
+à´…à´¨àµà´¨ à´®à´¾à´£à´¿
+å®®æœ¬ ç™¾åˆå­
+ã‚„ã¾ã  ç´«

--- a/roles/friendly-hostnames/tasks/main.yml
+++ b/roles/friendly-hostnames/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - file: path=/opt/features/friendly-hostnames state=directory mode=0755
 
-- name: Install friendly hostnames
-  get_url: url={{hostnames_url}} dest=/opt/features/friendly-hostnames/hostnames.txt mode="a+r"
+- name: Copy friendly hostnames
+  copy: src=hostnames.txt dest=/opt/features/friendly-hostnames/hostnames.txt mode="a+r"
 
 - name: Copy script for assigning hostnames and make executable
   copy: src=set-hostname.sh dest=/opt/features/friendly-hostnames/set-hostname.sh mode="a+x"


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR is intended to remove a direct dependency between the `friendly-hostnames` role and the Ophan Dist S3 bucket, which is currently required to be public for this to work. 

The change takes the resource from the Ophan Dist bucket and provides it directly as a resource in the role. 

[Relates to GChat Thread.](https://chat.google.com/room/AAAAwc4LMKU/Cs6jpX_Iu3s/Cs6jpX_Iu3s?cls=10)

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
I will test this on CODE to confirm it works as expected. 

[Test bake here.](https://amigo.code.dev-gutools.co.uk/recipes/elasticsearch-7-arm-test/bakes/1)
## What is the value of this?

<!-- Why are these changes being made? -->
This changes will allow us to remove the S3 dependency of the `friendly-hostnames` role and set the bucket to private. 

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Worst case scenario, this could cause issues for our ElasticSearch clusters, namely CAPI and Ophan, the consumers of this role. 

<img width="328" alt="image" src="https://github.com/user-attachments/assets/52df72ba-cceb-4819-a64d-c1a766c46204">
