### PR TITLE
Update ImageCopier to  Aws SDK v2 

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java corretto-11.0.25.9.1
+java corretto-21.0.3.9.1

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,8 @@ scalaVersion := "2.13.15"
 
 Universal / javaOptions ++= Seq(
   s"-Dpidfile.path=/dev/null",
-  "-J-XX:MaxRAMFraction=2",
-  "-J-XX:InitialRAMFraction=2",
+  "-J-XX:InitialRAMPercentage=50",
+  "-J-XX:MaxRAMPercentage=50",
   "-J-XX:MaxMetaspaceSize=300m",
   "-J-DpackerHome=/opt/packer",
   "-J-Dlogger.resource=logback-PROD.xml",

--- a/build.sbt
+++ b/build.sbt
@@ -124,7 +124,7 @@ lazy val imageCopier = (project in file("imageCopier"))
     Universal / topLevelDirectory := None,
     Universal / packageName := normalizedName.value,
     libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk-ec2" % awsV1SdkVersion,
+      "software.amazon.awssdk" % "ec2" % awsV2SdkVersion,
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",
       "com.amazonaws" % "aws-lambda-java-events" % "3.14.0",
       "io.circe" %% "circe-parser" % circeVersion,

--- a/imageCopier/src/main/scala/com/gu/imageCopier/LambdaEntrypoint.scala
+++ b/imageCopier/src/main/scala/com/gu/imageCopier/LambdaEntrypoint.scala
@@ -2,7 +2,7 @@ package com.gu.imageCopier
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SNSEvent
-import com.amazonaws.services.ec2.{AmazonEC2, AmazonEC2ClientBuilder}
+import software.amazon.awssdk.services.ec2.Ec2Client
 import com.gu.imageCopier.attempt.{
   Attempt,
   ConfigurationFailure,
@@ -16,7 +16,7 @@ import scala.concurrent.duration._
 
 object LambdaEntrypoint {
   val configuration: Configuration = Configuration.fromEnvironment
-  implicit val ec2Client: AmazonEC2 = AmazonEC2ClientBuilder.defaultClient()
+  implicit val ec2Client: Ec2Client = Ec2Client.builder.build()
 }
 
 class LambdaEntrypoint {

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -13,7 +13,7 @@ deployments:
     app: amigo
     parameters:
       amiTags:
-        Recipe: arm64-jammy-java11-deploy-infrastructure
+        Recipe: arm64-jammy-java21-deploy-infrastructure
         AmigoStage: PROD
       amiEncrypted: true
       templateStagePaths:


### PR DESCRIPTION
## What does this change?

- Upgrade to `Java `21` using [amigo recipe](https://amigo.gutools.co.uk/recipes/arm64-jammy-java21-deploy-infrastructure) — 37d9f44
- Upgrade copier lambda to AWS SDK v2 — [1f80e21](https://github.com/guardian/amigo/commit/1f80e21647d3a3cfd4f2b85073242accf8c3c26a)
