### PR TITLE
feat: update image copier lambda

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -2,7 +2,7 @@ import { App } from "aws-cdk-lib";
 import type { AmigoProps } from "../lib/amigo";
 import { AmigoStack } from "../lib/amigo";
 import { ImageCopierKMSKey } from "../lib/image-copier-kms";
-import { ImageCopierLambda } from "../libImageCopierLambdaProps/image-copier-lambda";
+import { ImageCopierLambda } from "../lib/image-copier-lambda";
 
 const app = new App();
 

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -2,7 +2,7 @@ import { App } from "aws-cdk-lib";
 import type { AmigoProps } from "../lib/amigo";
 import { AmigoStack } from "../lib/amigo";
 import { ImageCopierKMSKey } from "../lib/image-copier-kms";
-import { ImageCopierLambda } from "../lib/image-copier-lambda";
+import { ImageCopierLambda } from "../libImageCopierLambdaProps/image-copier-lambda";
 
 const app = new App();
 
@@ -40,5 +40,5 @@ new ImageCopierLambda(app, "imagecopier-lambda-stack", {
   stack: "deploy",
   stage: "PROD",
   description: "AMIgo image copier lambda",
-  version: "v3", // Update this when the lambda is updated.
+  version: "v4", // Update this when the lambda is updated.
 });

--- a/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
+++ b/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
@@ -30,7 +30,7 @@ exports[`the lambda stack matches the snapshot 1`] = `
       "Properties": {
         "Code": {
           "S3Bucket": "deploy-tools-dist",
-          "S3Key": "cdk/TEST/imagecopier/image-copier-v3.zip",
+          "S3Key": "cdk/TEST/imagecopier/image-copier-v4.zip",
         },
         "Description": "Lambda for housekeeping AMIgo baked AMIs in other accounts",
         "Environment": {
@@ -210,7 +210,7 @@ exports[`the lambda stack matches the snapshot 1`] = `
       "Properties": {
         "Code": {
           "S3Bucket": "deploy-tools-dist",
-          "S3Key": "cdk/TEST/imagecopier/image-copier-v3.zip",
+          "S3Key": "cdk/TEST/imagecopier/image-copier-v4.zip",
         },
         "Description": "Lambda for copying and encrypting AMIgo baked AMIs",
         "Environment": {

--- a/cdk/lib/image-copier-lambda.test.ts
+++ b/cdk/lib/image-copier-lambda.test.ts
@@ -8,7 +8,7 @@ describe("the lambda stack", () => {
     const stack = new ImageCopierLambda(app, "IntegrationTest", {
       stack: "cdk",
       stage: "TEST",
-      version: "v3",
+      version: "v4",
     });
     const template = Template.fromStack(stack);
     expect(template.toJSON()).toMatchSnapshot();

--- a/imageCopier/README.md
+++ b/imageCopier/README.md
@@ -45,7 +45,8 @@ This is done as part of the main `tools::amigo` RiffRaff build.
 
 **YOU MUST RENAME THE ARTIFACT:** the lambda will not update (even if the file
 uploads to S3) unless the name is also changed. To do this bump the
-`ImageCopierLambdaProps.version`, which is set in `bin/cdk.ts`.
+`ImageCopierLambdaProps.version`, which is set in `bin/cdk.ts`, and rename the 
+uploaded artifact in S3 to match.
 
 **For PROD:** no action required; `tools::amigo` deploys to PROD automatically
 whenever changes are merged into `main`.

--- a/imageCopier/README.md
+++ b/imageCopier/README.md
@@ -46,7 +46,7 @@ This is done as part of the main `tools::amigo` RiffRaff build.
 **YOU MUST RENAME THE ARTIFACT:** the lambda will not update (even if the file
 uploads to S3) unless the name is also changed. To do this bump the
 `ImageCopierLambdaProps.version`, which is set in `bin/cdk.ts`, and rename the 
-uploaded artifact in S3 to match.
+uploaded artifact in S3 to match. Also update the version in the test to match.
 
 **For PROD:** no action required; `tools::amigo` deploys to PROD automatically
 whenever changes are merged into `main`.


### PR DESCRIPTION
## What does this change?

- Updates the version of the image copier lambda 
- Updates the README to reflect the steps required to rename the artifact

## How to test

Once the stackset has been redeployed, we should see a reduction vulnerabilities reported by Inspector for this lambda.

## What is the value of this?

To ensure that the latest version with the latest dependencies is deployed when we redeploy the stackset.

