### PR TITLE
Add 'requiresXLargeBuilder' field to base image

### DIFF
--- a/app/controllers/BaseImageController.scala
+++ b/app/controllers/BaseImageController.scala
@@ -56,7 +56,7 @@ class BaseImageController(
           image.amiId,
           image.linuxDist.getOrElse(Ubuntu),
           image.eolDate.getOrElse(DateTime.now).toLocalDate.toDate,
-          image.requiresXlargeBuilder
+          image.requiresXLargeBuilder
         )
       )
       Ok(views.html.editBaseImage(image, form, Roles.listIds))
@@ -80,7 +80,7 @@ class BaseImageController(
                     amiId,
                     linuxDist,
                     eolDate,
-                    requiresXlargeBuilder
+                    requiresXLargeBuilder
                   ) =>
                 val customisedRoles = parseEnabledRoles(request.body)
                 customisedRoles.fold(
@@ -94,7 +94,7 @@ class BaseImageController(
                       roles,
                       modifiedBy = request.user.fullName,
                       new DateTime(eolDate),
-                      requiresXlargeBuilder
+                      requiresXLargeBuilder
                     )
                     Redirect(routes.BaseImageController.showBaseImage(id))
                       .flashing("info" -> "Successfully updated base image")
@@ -123,7 +123,7 @@ class BaseImageController(
                 amiId,
                 linuxDist,
                 eolDate,
-                requiresXlargeBuilder
+                requiresXLargeBuilder
               ) =>
             BaseImages.findById(id) match {
               case Some(existingImage) =>
@@ -135,7 +135,7 @@ class BaseImageController(
                       amiId,
                       linuxDist,
                       eolDate,
-                      requiresXlargeBuilder
+                      requiresXLargeBuilder
                     )
                   )
                   .withError("id", "This base image ID is already in use")
@@ -153,7 +153,7 @@ class BaseImageController(
                       createdBy = request.user.fullName,
                       linuxDist,
                       Some(new DateTime(eolDate)),
-                      requiresXlargeBuilder
+                      requiresXLargeBuilder
                     )
                     Redirect(routes.BaseImageController.showBaseImage(id))
                       .flashing("info" -> "Successfully created base image")
@@ -188,7 +188,7 @@ class BaseImageController(
                       createdBy = request.user.fullName,
                       linuxDist = linuxDist,
                       eolDate = baseImage.eolDate,
-                      requiresXlargeBuilder = baseImage.requiresXlargeBuilder
+                      requiresXLargeBuilder = baseImage.requiresXLargeBuilder
                     )
                     Redirect(routes.BaseImageController.showBaseImage(newId))
                       .flashing("info" -> "Successfully cloned base image")
@@ -248,7 +248,7 @@ object BaseImageController {
         "amiId" -> amiId,
         "linuxDist" -> linuxDist,
         "eolDate" -> date("yyyy-MM-dd"),
-        "requiresXlargeBuilder" -> boolean
+        "requiresXLargeBuilder" -> boolean
       )
     )
 
@@ -260,7 +260,7 @@ object BaseImageController {
         "amiId" -> amiId,
         "linuxDist" -> linuxDist,
         "eolDate" -> date("yyyy-MM-dd"),
-        "requiresXlargeBuilder" -> boolean
+        "requiresXLargeBuilder" -> boolean
       )
     )
 

--- a/app/data/BaseImages.scala
+++ b/app/data/BaseImages.scala
@@ -14,7 +14,8 @@ object BaseImages {
       builtinRoles: List[CustomisedRole],
       createdBy: String,
       linuxDist: LinuxDist,
-      eolDate: Option[DateTime]
+      eolDate: Option[DateTime],
+      requiresXlargeBuilder: Boolean
   )(implicit dynamo: Dynamo): BaseImage = {
     val now = DateTime.now()
     val baseImage = BaseImage(
@@ -27,7 +28,8 @@ object BaseImages {
       modifiedBy = createdBy,
       modifiedAt = now,
       Some(linuxDist),
-      eolDate
+      eolDate,
+      requiresXlargeBuilder
     )
 
     table.put(baseImage).exec()
@@ -41,7 +43,8 @@ object BaseImages {
       linuxDist: LinuxDist,
       builtinRoles: List[CustomisedRole],
       modifiedBy: String,
-      eolDate: DateTime
+      eolDate: DateTime,
+      requiresXlargeBuilder: Boolean
   )(implicit dynamo: Dynamo): Unit = {
     val updated = baseImage.copy(
       description = description,
@@ -50,7 +53,8 @@ object BaseImages {
       builtinRoles = builtinRoles,
       modifiedBy = modifiedBy,
       modifiedAt = DateTime.now(),
-      eolDate = Some(eolDate)
+      eolDate = Some(eolDate),
+      requiresXlargeBuilder = requiresXlargeBuilder
     )
     table.put(updated).exec()
   }

--- a/app/data/BaseImages.scala
+++ b/app/data/BaseImages.scala
@@ -15,7 +15,7 @@ object BaseImages {
       createdBy: String,
       linuxDist: LinuxDist,
       eolDate: Option[DateTime],
-      requiresXlargeBuilder: Boolean
+      requiresXLargeBuilder: Boolean
   )(implicit dynamo: Dynamo): BaseImage = {
     val now = DateTime.now()
     val baseImage = BaseImage(
@@ -29,7 +29,7 @@ object BaseImages {
       modifiedAt = now,
       Some(linuxDist),
       eolDate,
-      requiresXlargeBuilder
+      requiresXLargeBuilder
     )
 
     table.put(baseImage).exec()
@@ -44,7 +44,7 @@ object BaseImages {
       builtinRoles: List[CustomisedRole],
       modifiedBy: String,
       eolDate: DateTime,
-      requiresXlargeBuilder: Boolean
+      requiresXLargeBuilder: Boolean
   )(implicit dynamo: Dynamo): Unit = {
     val updated = baseImage.copy(
       description = description,
@@ -54,7 +54,7 @@ object BaseImages {
       modifiedBy = modifiedBy,
       modifiedAt = DateTime.now(),
       eolDate = Some(eolDate),
-      requiresXlargeBuilder = requiresXlargeBuilder
+      requiresXLargeBuilder = requiresXLargeBuilder
     )
     table.put(updated).exec()
   }

--- a/app/models/BaseImage.scala
+++ b/app/models/BaseImage.scala
@@ -111,7 +111,7 @@ case class BaseImage(
     modifiedAt: DateTime,
     linuxDist: Option[LinuxDist] = None,
     eolDate: Option[DateTime] = None,
-    requiresXlargeBuilder: Boolean = false
+    requiresXLargeBuilder: Boolean = false
 )
 
 sealed trait EolStatus

--- a/app/models/BaseImage.scala
+++ b/app/models/BaseImage.scala
@@ -111,7 +111,7 @@ case class BaseImage(
     modifiedAt: DateTime,
     linuxDist: Option[LinuxDist] = None,
     eolDate: Option[DateTime] = None,
-    requiresXlargeBuilder: Boolean = false,
+    requiresXlargeBuilder: Boolean = false
 )
 
 sealed trait EolStatus

--- a/app/models/BaseImage.scala
+++ b/app/models/BaseImage.scala
@@ -110,7 +110,8 @@ case class BaseImage(
     modifiedBy: String,
     modifiedAt: DateTime,
     linuxDist: Option[LinuxDist] = None,
-    eolDate: Option[DateTime] = None
+    eolDate: Option[DateTime] = None,
+    requiresXlargeBuilder: Boolean = false,
 )
 
 sealed trait EolStatus

--- a/app/packer/PackerBuildConfigGenerator.scala
+++ b/app/packer/PackerBuildConfigGenerator.scala
@@ -46,7 +46,7 @@ object PackerBuildConfigGenerator {
     }
 
     val builder = PackerBuilderConfig(
-      name = "{{user `recipe``}}",
+      name = "{{user `recipe`}}",
       `type` = "amazon-ebs",
       region = region,
       vpc_id = packerConfig.vpcId,

--- a/app/packer/PackerBuildConfigGenerator.scala
+++ b/app/packer/PackerBuildConfigGenerator.scala
@@ -23,7 +23,8 @@ object PackerBuildConfigGenerator {
       variables: PackerVariablesConfig,
       awsAccountNumbers: Seq[String],
       sourceAmiMetadata: AmiMetadata,
-      amigoDataBucket: Option[String]
+      amigoDataBucket: Option[String],
+      requresXlargeBukder: Boolean
   )(implicit packerConfig: PackerConfig): PackerBuildConfig = {
     val awsAccounts = awsAccountNumbers.mkString(",")
     val imageDetails = ImageDetails.apply(variables, packerConfig.stage)
@@ -33,9 +34,11 @@ object PackerBuildConfigGenerator {
       List(BlockDeviceMapping(volume_size = size))
     )
 
+    val instanceSize = if (requresXlargeBukder) "xlarge" else "small"
+
     val instanceType = sourceAmiMetadata.architecture match {
-      case "x86_64" => "t3.small"
-      case "arm64"  => "t4g.small"
+      case "x86_64" => s"t3.${instanceSize}"
+      case "arm64"  => s"t4g.${instanceSize}"
       case other =>
         throw new IllegalArgumentException(
           s"Don't know what instance type to use to bake an AMI for $other"
@@ -43,7 +46,7 @@ object PackerBuildConfigGenerator {
     }
 
     val builder = PackerBuilderConfig(
-      name = "{{user `recipe`}}",
+      name = "{{user `recipe``}}",
       `type` = "amazon-ebs",
       region = region,
       vpc_id = packerConfig.vpcId,

--- a/app/packer/PackerRunner.scala
+++ b/app/packer/PackerRunner.scala
@@ -72,7 +72,8 @@ class PackerRunner(maxInstances: Int) extends Loggable {
         packerVars,
         awsAccountNumbers,
         amiMetadata,
-        amigoDataBucket
+        amigoDataBucket,
+        bake.recipe.baseImage.requiresXlargeBuilder
       )
     val packerJson = Json.prettyPrint(Json.toJson(packerBuildConfig))
     val packerConfigFile =

--- a/app/packer/PackerRunner.scala
+++ b/app/packer/PackerRunner.scala
@@ -73,7 +73,7 @@ class PackerRunner(maxInstances: Int) extends Loggable {
         awsAccountNumbers,
         amiMetadata,
         amigoDataBucket,
-        bake.recipe.baseImage.requiresXlargeBuilder
+        bake.recipe.baseImage.requiresXLargeBuilder
       )
     val packerJson = Json.prettyPrint(Json.toJson(packerBuildConfig))
     val packerConfigFile =

--- a/app/views/editBaseImage.scala.html
+++ b/app/views/editBaseImage.scala.html
@@ -11,15 +11,8 @@
     @b3.text( form("amiId"), Symbol("_label") -> "AMI ID", Symbol("placeholder") -> "ami-a1b2c3d4" )
     @b3.select( form("linuxDist"), models.LinuxDist.all.toList.map{ case (k,v) => k -> v.name }, Symbol("_label") -> "Linux Distribution" )
     @b3.textarea( form("description"), Symbol("_label") -> "Description" )
-    <div class="row">
-      <div class="col-md-1"></div>
-    <div class="col-md-6">
-    @b3.date(form("eolDate"), Symbol("_label")-> "End of Life Date")
-    </div>
-      <div class="col-md-3">
-    <p>(Find Ubuntu support info <a href="https://wiki.ubuntu.com/Releases" target="_blank">here</a>)</p>
-      </div>
-    </div>
+    @b3.date(form("eolDate"), Symbol("_label")-> "End of Life Date", Symbol("_help") -> Html("""Find Ubuntu support info <a href="https://wiki.ubuntu.com/Releases" target="_blank">here</a>"""))
+    @b3.checkbox(form("requiresXLargeBuilder"), Symbol("_label") -> "Requires XLarge builder instance", Symbol("_help") -> "XLarge instances are 8x more expensive than normal AMIgo builders. Avoid where possible.")
     <div class="form-group">
       <label class="control-label col-md-2" for="builtin-roles">Builtin roles</label>
       <div class="col-md-10" id="builtin-roles">

--- a/app/views/newBaseImage.scala.html
+++ b/app/views/newBaseImage.scala.html
@@ -11,9 +11,8 @@
     @b3.text( form("amiId"), Symbol("_label") -> "AMI ID", Symbol("placeholder") -> "ami-a1b2c3d4" )
     @b3.select( form("linuxDist"), models.LinuxDist.all.toList.map{ case (k,v) => k -> v.name }, Symbol("_label") -> "Linux Distribution" )
     @b3.textarea( form("description"), Symbol("_label") -> "Description" )
-    @b3.date(form("eolDate"), Symbol("_label")-> "End of Life Date")
-    <p>(Find Ubuntu support info <a href="https://wiki.ubuntu.com/Releases">here</a></p>
-
+    @b3.date(form("eolDate"), Symbol("_label")-> "End of Life Date", Symbol("_help") -> Html("""Find Ubuntu support info <a href="https://wiki.ubuntu.com/Releases" target="_blank">here</a>"""))
+    @b3.checkbox(form("requiresXLargeBuilder"), Symbol("_label") -> "Requires XLarge builder instance", Symbol("_help") -> "XLarge instances are 8x more expensive than normal AMIgo builders. Avoid where possible.")
     <div class="form-group">
       <label class="control-label col-md-2" for="builtin-roles">Builtin roles</label>
       <div class="col-md-10" id="builtin-roles">

--- a/app/views/showBaseImage.scala.html
+++ b/app/views/showBaseImage.scala.html
@@ -32,6 +32,7 @@
       <p>Created @fragments.timestamp(image.createdAt, image.createdBy)</p>
       <p>Modified @fragments.timestamp(image.modifiedAt, image.modifiedBy)</p>
       @image.eolDate.map{eolDate => <p class="@BaseImage.eolStatusClass(image)">End of Life @eolDate.toString("dd/MM/yyyy")</p>}
+      @if(image.requiresXLargeBuilder){<p><i class="fa fa-usd" aria-hidden="true"></i> Requires XLarge builder instance</p>}
       <p>@image.description</p>
     </div>
   </div>

--- a/app/views/showBaseImage.scala.html
+++ b/app/views/showBaseImage.scala.html
@@ -32,7 +32,7 @@
       <p>Created @fragments.timestamp(image.createdAt, image.createdBy)</p>
       <p>Modified @fragments.timestamp(image.modifiedAt, image.modifiedBy)</p>
       @image.eolDate.map{eolDate => <p class="@BaseImage.eolStatusClass(image)">End of Life @eolDate.toString("dd/MM/yyyy")</p>}
-      @if(image.requiresXLargeBuilder){<p><i class="fa fa-usd" aria-hidden="true"></i> Requires XLarge builder instance</p>}
+      @if(image.requiresXLargeBuilder){<p>Requires XLarge builder instance</p>}
       <p>@image.description</p>
     </div>
   </div>


### PR DESCRIPTION
## What does this change?
I've been trying to build an AMI for https://github.com/m-bain/whisperX that includes all required Nvidia drivers. I've got this working by using the AWS Deep Learning Base AMI (https://aws.amazon.com/releasenotes/aws-deep-learning-base-gpu-ami-ubuntu-22-04/) along with a custom AMIgo role that installs the various python dependencies. 

However, the base AMI requires at least 70GB of disk, and the whisperx dependencies are also enormous. Using the standard AMIgo t3.small instance type results in the bake failing due to pip running out of memory whilst installing the various python dependencies. Bumping to a .large instance solves that, but the bake then times out whilst trying to snapshot (something a bit like this https://github.com/hashicorp/packer/issues/7719). Using a .xlarge instance solves the problem. 

I'd really like to use AMIgo to build our AMIs for all the various benefits it offers. With that in mind, this PR adds a new field to the 'base image' form which is called 'requires xlarge builder instance'. I decided to go for this rather than just parameterising the instance type because, in 8 years or so of amigo, this is the first time that the .small instance has been insufficient, so I think it's unlikely we'll have some bakes that need e.g. a t3.medium. 

As part of this change I've slightly simplified the base image form UI html, by using the "_help" property on the form elements. It looks like this:

<img width="1186" alt="Screenshot 2025-01-17 at 14 09 16" src="https://github.com/user-attachments/assets/a828f424-f092-44d8-a31f-e6e8e973d3c5" />
<img width="1195" alt="Screenshot 2025-01-17 at 14 08 58" src="https://github.com/user-attachments/assets/3a8fd206-a100-48e4-bb62-dedc535a468f" />


## How to test
Tested on AMIgo CODE
