### PR TITLE
Add WhisperX Role

### DIFF
--- a/app/packer/PackerBuildConfigGenerator.scala
+++ b/app/packer/PackerBuildConfigGenerator.scala
@@ -37,8 +37,8 @@ object PackerBuildConfigGenerator {
     val instanceSize = if (requresXlargeBukder) "xlarge" else "small"
 
     val instanceType = sourceAmiMetadata.architecture match {
-      case "x86_64" => s"t3.${instanceSize}"
-      case "arm64"  => s"t4g.${instanceSize}"
+      case "x86_64" => s"t3.$instanceSize"
+      case "arm64"  => s"t4g.$instanceSize"
       case other =>
         throw new IllegalArgumentException(
           s"Don't know what instance type to use to bake an AMI for $other"

--- a/roles/whisperx/meta/main.yml
+++ b/roles/whisperx/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - pip3

--- a/roles/whisperx/meta/main.yml
+++ b/roles/whisperx/meta/main.yml
@@ -1,3 +1,6 @@
 ---
 dependencies:
   - pip3
+  - role: packages
+    packages:
+      - ffmpeg

--- a/roles/whisperx/tasks/main.yml
+++ b/roles/whisperx/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Upgrade packaging
+  pip:
+    name: "packaging"
+    state: "latest"
+    executable: pip3
+
+- name: Install whisperx dependencies
+  pip:
+    name:
+     - torch==2.0.0
+     - torchvision==0.15.1
+     - torchaudio==2.0.1
+    executable: pip3
+    extra_args: "--index-url https://download.pytorch.org/whl/cu118"
+
+- name: Install whisperx
+  pip:
+    name: whisperx
+    executable: pip3
+


### PR DESCRIPTION
## What does this change?
Depends on https://github.com/guardian/amigo/pull/1604

WhisperX is a transcription tool - see github repo here https://github.com/m-bain/whisperX. It is potentially a lot faster than the tool we currently use for transcription, and supports speaker identification which is a feature often requested by our users. 

This PR adds a role to AMIgo to install whisperx and associated dependencies. 

## How to test
Tested on CODE - I baked an AMI and then booted an instance with it and verified that whisperx worked