### PR TITLE
Add step to configure postgres apt repository to enable installation of postgresql 16

### DIFF
--- a/roles/kong/tasks/main.yml
+++ b/roles/kong/tasks/main.yml
@@ -5,6 +5,7 @@
       - postgresql-common
 
 - name: Configure postgres repository to enable download of latest postgres client
+  # Per https://wiki.postgresql.org/wiki/Apt
   script: /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
 
 - name: Install other Kong dependencies

--- a/roles/kong/tasks/main.yml
+++ b/roles/kong/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
-- name: Install Kong's dependencies
+- name: Install initial postgres dependencies
+  apt:
+    name:
+      - postgresql-common
+
+- name: Configure postgres repository to enable download of latest postgres client
+  script: /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+
+- name: Install other Kong dependencies
   apt:
     name:
     - netcat


### PR DESCRIPTION
## What does this change?

`postgresql-16` is not included in the apt repositories available in `[ubuntu-jammy (22.04 LTS)](https://amigo.gutools.co.uk/base-images/ubuntu-jammy%20(22.04%20LTS))`. This PR updates apt with the postgres repository as an initial step, to ensure `postgresql-16` is available.

## How to test

Run the bake locally with `multipass` per the README. It should succeed. Tested locally:

<img width="907" alt="Screenshot 2025-02-12 at 12 20 45" src="https://github.com/user-attachments/assets/deb9bb42-08a8-41cb-aa1f-34bce4dbd41a" />

## What is the value of this?

postgres 16 available for Kong.

## Have we considered potential risks?

The image will be well tested before being deployed to PROD services. A failed or incorrectly configured bake is low risk.