### PR TITLE
Correct Kong URL with additional parameter for Ubuntu release

### DIFF
--- a/roles/kong/defaults/main.yml
+++ b/roles/kong/defaults/main.yml
@@ -3,4 +3,5 @@ kong_version: 3.1.1
 kong_user: content-api
 postgres_version: 12
 kong_arch: arm64
+kong_ubuntu_release: jammy
 kong_repo: gateway-31

--- a/roles/kong/tasks/main.yml
+++ b/roles/kong/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: Install Kong package
   apt:
-    deb: https://packages.konghq.com/public/{{ kong_repo }}/deb/ubuntu/pool/focal/main/k/ko/kong_{{ kong_version }}/kong_{{ kong_version }}_{{ kong_arch }}.deb
+    deb: https://packages.konghq.com/public/{{ kong_repo }}/deb/ubuntu/pool/{{ kong_ubuntu_release }}/main/k/ko/kong_{{ kong_version }}/kong_{{ kong_version }}_{{ kong_arch }}.deb
     state: present
 
 - name: Create user for Kong


### PR DESCRIPTION
## What does this change?

Corrects the URL from which we fetch Kong, with an additional parameter for the Ubuntu release — we're now on Jammy.

Also adds the missing configuration file for 3.9.0.

## How to test

The bake should succeed with the appropriate parameters bumped for 3.9.0:

```
---
kong_version: 3.9.0
kong_user: content-api
postgres_version: 16
kong_arch: arm64
kong_ubuntu_release: jammy
kong_repo: gateway-39
```

Tested locally 👍 

<img width="879" alt="Screenshot 2025-02-12 at 17 32 24" src="https://github.com/user-attachments/assets/c6c9ba90-cf39-4af7-90e1-255e50febd8c" />