### PR TITLE
Correct task property

### DIFF
--- a/roles/kong/tasks/main.yml
+++ b/roles/kong/tasks/main.yml
@@ -46,7 +46,7 @@
   copy: src=nginx.template dest=/usr/local/kong/nginx.template
 
 - name: Create error template directory
-  copy: path=/usr/local/kong/templates state=directory
+  file: path=/usr/local/kong/templates state=directory
 
 - name: Copy error html template
   copy: src=templates/error.html dest=/usr/local/kong/templates/error.html


### PR DESCRIPTION
## What does this change?

Corrects an incorrect task property in the `kong` recipe. Tested locally with multipass:

<img width="822" alt="Screenshot 2025-03-03 at 21 38 47" src="https://github.com/user-attachments/assets/fcc81490-6ab0-4bbf-87c7-f19883e8f877" />

## How to test

Run multipass locally to test the role. It should run without errors.