### PR TITLE
[await-tags] Provide authentication to instance metadata API

### DIFF
--- a/roles/aws-await-tags/templates/await_tags.sh
+++ b/roles/aws-await-tags/templates/await_tags.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 echo "Awaiting AWS tags..."
 
-INSTANCE_ID=$(curl --silent http://169.254.169.254/latest/meta-data/instance-id)
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" --silent http://169.254.169.254/latest/meta-data/instance-id)
 
 for i in {1..12}
 do


### PR DESCRIPTION
## What does this change?

Calls to the instance metadata API without authentication are no longer accepted. Adding the token effectively updates this from using IMDSv1 to IMDSv2. This should resolve FSBP EC2.8 for a number of services in the editorial tools space.

NB- this role is still deprecated, but it is quicker to upgrade it for FSBP compliance than to convince ourselves that it isn't needed

## How to test

- Bake the `ditorial-tools-focal-java11-ARM-WITH-cdk-base` recipe
- Redeploy workflow archiver
- Check logs and see that `AWS Tags not found after 1 minute` does not appear but `AWS tags loaded` does
- Check https://metrics.gutools.co.uk/d/de156avqnutj4d/am-i-using-imdsv1-or-imdsv2?orgId=1&refresh=5s&var-AwsAccount=lpcN6XMMz&var-AwsAccountId=753338109777&var-Stack=workflow&var-Stage=PROD&var-App=archiver&var-ASG=workflow-PROD-ProleAutoscalingGroup-EHT3JYOHS8NF&var-RiffRaffProject=&from=now-30d&to=now to see that no calls are made to IMDSv1


## What is the value of this?

Resolves FSBP EC2.8

## Have we considered potential risks?

This script is already broken because the existing INSTANCE_ID call fails, so this PR cannot make things worse.