### PR TITLE
The recipe `hasUsage` function now includes launch template checks

### DIFF
--- a/app/prism/RecipeUsage.scala
+++ b/app/prism/RecipeUsage.scala
@@ -143,7 +143,9 @@ object RecipeUsage {
   def hasUsage(recipe: Recipe, usages: Map[Recipe, RecipeUsage]): Boolean = {
     usages
       .get(recipe)
-      .exists(u => u.launchConfigurations.nonEmpty || u.instances.nonEmpty)
+      .exists(u =>
+        u.launchTemplates.nonEmpty || u.launchConfigurations.nonEmpty || u.instances.nonEmpty
+      )
   }
 
   def amiUsages(recipeUsage: RecipeUsage, amiId: AmiId): RecipeUsage = {

--- a/test/prism/RecipeUsageSpec.scala
+++ b/test/prism/RecipeUsageSpec.scala
@@ -65,12 +65,36 @@ class RecipeUsageSpec extends AnyFlatSpec with Matchers with MockitoSugar {
   )
 
   val emptyUsage: RecipeUsage = RecipeUsage(Seq(), Seq(), Seq(), Seq())
-  val nonEmptyusage: RecipeUsage = RecipeUsage(
+  val instanceUsage: RecipeUsage = RecipeUsage(
     Seq(
       Instance("weatherwax", AmiId("a-tuin"), AWSAccount("Gaspode", "carrot"))
     ),
     Seq(),
     Seq(),
+    Seq()
+  )
+  val launchConfigurationUsage = RecipeUsage(
+    Seq(),
+    Seq(
+      LaunchConfiguration(
+        "launch-configuration-1",
+        AmiId("a-tuin"),
+        AWSAccount("Gaspode", "carrot")
+      )
+    ),
+    Seq(),
+    Seq()
+  )
+  val launchTemplateUsage: RecipeUsage = RecipeUsage(
+    Seq(),
+    Seq(),
+    Seq(
+      LaunchTemplate(
+        "lt-1",
+        AmiId("a-tuin"),
+        AWSAccount("Gaspode", "carrot")
+      )
+    ),
     Seq()
   )
 
@@ -175,14 +199,30 @@ class RecipeUsageSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     recipe3Usages.bakeUsage shouldBe Seq.empty
   }
 
-  "hasUsage" should "return true if a recipe is used" in {
+  "hasUsage" should "return true if a recipe is used by an instance" in {
     val recipe1 = fixtureRecipe("recipe1")
     val recipe2 = fixtureRecipe("recipe2")
-    val usages = Map(recipe1 -> emptyUsage, recipe2 -> nonEmptyusage)
+    val usages = Map(recipe1 -> emptyUsage, recipe2 -> instanceUsage)
 
     RecipeUsage.hasUsage(recipe1, usages) shouldBe false
     RecipeUsage.hasUsage(recipe2, usages) shouldBe true
-
   }
 
+  "hasUsage" should "return true if a recipe is used by a launch configuration" in {
+    val recipe1 = fixtureRecipe("recipe1")
+    val recipe2 = fixtureRecipe("recipe2")
+    val usages = Map(recipe1 -> emptyUsage, recipe2 -> launchConfigurationUsage)
+
+    RecipeUsage.hasUsage(recipe1, usages) shouldBe false
+    RecipeUsage.hasUsage(recipe2, usages) shouldBe true
+  }
+
+  "hasUsage" should "return true if a recipe is used by a launch template" in {
+    val recipe1 = fixtureRecipe("recipe1")
+    val recipe2 = fixtureRecipe("recipe2")
+    val usages = Map(recipe1 -> launchTemplateUsage, recipe2 -> emptyUsage)
+
+    RecipeUsage.hasUsage(recipe1, usages) shouldBe true
+    RecipeUsage.hasUsage(recipe2, usages) shouldBe false
+  }
 }


### PR DESCRIPTION
## What does this change?

Launch template support was added last year, but it doesn't look like the UI was fully updated to reflect this. This means a manual tidy up job might accidentally remove recipes that appear to be unused despite being referred to by launch templates.

We add this check to the logic, so that the "Unused recipes" section of the recipes index is correctly populated. This also improves the usage checks on base images page.


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

This adds a couple more tests for the `hasUsage` function, to cover non-instance usages explicitly.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## What is the value of this?

This should help prevent manual clear-ups from removing recipes that are still in use.

<!-- Why are these changes being made? -->

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

> **Note**
> If this change adds, updates or removes a role or recipe please note that in your PR and assign appropriate reviewers for the team that will be impacted by those changes.
