### PR TITLE
Tweaks to multipass scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If the Multipass VM is timing out, try deleting and then re-running the script:
 
     multipass stop amigo-test
     multipass delete amigo-test
-    multipass purge amigo-test
+    multipass purge
 
 You should also disconnect from the VPN too if using it.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ itself. This is often a lot easier than running Amigo itself.
 
 To test roles locally, run:
 
-    $ multipass/run.sh
+    multipass/run.sh
 
 This will install [Multipass](https://multipass.run/), a Canonical tool to
 manage Ubuntu VMs, and execute Ansible roles within it.
@@ -55,13 +55,13 @@ manage Ubuntu VMs, and execute Ansible roles within it.
 If you want to run commands/debug directly in the VM then (post installing
 things via run.sh), run:
 
-    $ multipass shell amigo-test
+    multipass shell amigo-test
 
 If the Multipass VM is timing out, try deleting and then re-running the script:
 
-    $ multipass stop amigo-test
-    $ multipass delete amigo-test
-    $ multipass purge amigo-test
+    multipass stop amigo-test
+    multipass delete amigo-test
+    multipass purge amigo-test
 
 You should also disconnect from the VPN too if using it.
 

--- a/multipass/clean.sh
+++ b/multipass/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -xe
 
 multipass stop amigo-test
 multipass delete amigo-test

--- a/multipass/clean.sh
+++ b/multipass/clean.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+multipass stop amigo-test
+multipass delete amigo-test
+multipass purge

--- a/multipass/run.sh
+++ b/multipass/run.sh
@@ -1,11 +1,10 @@
-#!/bin/bash
-
-set -e
+#!/bin/bash -xe
 
 script_dir=$(dirname "$0")
 target_dir=/home/ubuntu
 custom_playbook="playbook-custom.yaml"
 vm_name=amigo-test
+ubuntu_version=22.04
 
 if ! command -v multipass &> /dev/null
 then
@@ -24,9 +23,10 @@ fi
 if ! multipass list | grep $vm_name | grep Running > /dev/null
 then
     echo 'Creating and provisioning multipass VM...'
-    multipass launch --name $vm_name 20.04
-    multipass mount $script_dir/../roles $vm_name:$target_dir/.ansible/roles
-    multipass mount $script_dir $vm_name:$target_dir/test
+    multipass launch --name $vm_name $ubuntu_version
+    multipass stop $vm_name
+    multipass mount --type native $script_dir/../roles $vm_name:$target_dir/.ansible/roles
+    multipass mount --type native $script_dir $vm_name:$target_dir/test
     multipass exec $vm_name -- $target_dir/test/bootstrap-vm.sh
 fi
 


### PR DESCRIPTION
## What does this change?

Multipass has changed a bit since these scripts were originally written. I've updated the scripts and made some tweaks that made my life easier when getting this to run locally.

## How to test

Running `./multipass/run.sh` should work correctly up to the point it tries to execute an ansible role (the default one set in playbook.yml uses an artificial name to make it fail fast)