### PR TITLE
Switch back to master branch for eotk role

### DIFF
--- a/roles/eotk-jammy/tasks/main.yml
+++ b/roles/eotk-jammy/tasks/main.yml
@@ -3,7 +3,7 @@
   git:
     repo: 'https://github.com/guardian/eotk.git'
     dest: /usr/local/eotk
-    version: 'ubuntu-jammy'
+    version: 'master'
     force: yes
 
 - name: Move into eotk directory and run the set up script


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/amigo/pull/1644 we created this new eotk-jammy role pointing at a WIP branch for testing the ubuntu jammy build. We can now point to the master branch once https://github.com/guardian/eotk/pull/4 is merged.

