### PR TITLE
feat(cdk): Remove the `WazuhSecurityGroup` security group

### DIFF
--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -1112,40 +1112,6 @@ exports[`The Amigo stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
-    "WazuhSecurityGroup": {
-      "Properties": {
-        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/amigo",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
     "deployPRODamigo77EB3561": {
       "DependsOn": [
         "InstanceRoleAmigo75944747",

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -30,7 +30,6 @@ import {
 	InstanceType,
 	Peer,
 	Port,
-	SecurityGroup,
 	UserData,
 } from 'aws-cdk-lib/aws-ec2';
 import {
@@ -360,19 +359,6 @@ export class AmigoStack extends GuStack {
 			domainName: domainName,
 			ttl: Duration.hours(1),
 			resourceRecord: guPlayApp.loadBalancer.loadBalancerDnsName,
-		});
-
-		// A temporary security group with a fixed logical ID, replicating the one removed from GuCDK v61.5.0.
-		const tempSecurityGroup = new SecurityGroup(this, 'WazuhSecurityGroup', {
-			vpc: guPlayApp.vpc,
-			// Must keep the same description, else CloudFormation will try to replace the security group
-			// See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-securitygroup.html#cfn-ec2-securitygroup-groupdescription.
-			description: 'Allow outbound traffic from wazuh agent to manager',
-		});
-		this.overrideLogicalId(tempSecurityGroup, {
-			logicalId: 'WazuhSecurityGroup',
-			reason:
-				"Part one of updating to GuCDK 61.5.0+ whilst using Riff-Raff's ASG deployment type",
 		});
 	}
 }


### PR DESCRIPTION
Builds on https://github.com/guardian/amigo/pull/1652.

## What does this change?
Removes the unused `WazuhSecurityGroup` security group. This is the second and last stage of updating to GuCDK v61.5.0. See https://github.com/guardian/cdk/releases/tag/v61.5.0.

## How to test
See the updated snapshot.

Successfully [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/b51571a4-4d04-4450-a7f7-78bbecc8906e).
