### PR TITLE
fix(dev): Install packer from tap

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,4 @@
-brew "packer"
+tap "hashicorp/tap"
+brew "hashicorp/tap/packer"
 cask "virtualbox"
 cask "vagrant"


### PR DESCRIPTION
## What does this change?
Updates the `Brewfile` to install packer from a tap.

Since https://github.com/Homebrew/homebrew-core/pull/150192, Homebrew no longer indexes packer due to a license change. We shouldn't be negatively impacted by this. From https://www.hashicorp.com/en/blog/hashicorp-adopts-business-source-license:

> End users can continue to copy, modify, and redistribute the code for all non-commercial and commercial use, except where providing a competitive offering to HashiCorp.

Install packer from the hashicorp tap as described in https://developer.hashicorp.com/packer/install#darwin.

## How to test
This is a change to one's local environment - CODE and PROD are not impacted. To test, run the [setup script](https://github.com/guardian/amigo/blob/main/script/setup); it should succeed.

<details><summary>Current setup script failure</summary>
<p>

![image](https://github.com/user-attachments/assets/8ad75f85-1c54-4fef-8e80-2247300dafdb)

</p>
</details> 