### PR TITLE
feat: Update Packer from 1.8.5 to 1.13.1

### DIFF
--- a/app/packer/PackerRunner.scala
+++ b/app/packer/PackerRunner.scala
@@ -15,6 +15,7 @@ import scala.collection.mutable
 import scala.concurrent.{Future, Promise}
 import scala.concurrent.ExecutionContext.Implicits.global
 
+import scala.jdk.CollectionConverters._
 import scala.jdk.StreamConverters._
 import scala.util.Try
 
@@ -111,7 +112,12 @@ class PackerRunner(maxInstances: Int) extends Loggable {
       .directory(new File(System.getProperty("java.io.tmpdir")))
     packerBuilder
       .environment()
-      .put("PACKER_CACHE_DIR", packerCacheDir.toAbsolutePath.toString)
+      .putAll(
+        Map(
+          "PACKER_CACHE_DIR" -> packerCacheDir.toAbsolutePath.toString,
+          "PACKER_PLUGIN_PATH" -> "/opt/packer/.plugins"
+        ).asJava
+      )
     val packerProcess = packerBuilder.start()
 
     val exitValuePromise = Promise[Int]()

--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`The Amigo stack matches the snapshot 1`] = `
 {
@@ -1211,7 +1211,7 @@ exports[`The Amigo stack matches the snapshot 1`] = `
                 "",
                 [
                   "#!/bin/bash -ev
-wget -P /tmp https://releases.hashicorp.com/packer/1.8.5/packer_1.8.5_linux_arm64.zip
+wget -P /tmp https://releases.hashicorp.com/packer/1.13.1/packer_1.13.1_linux_arm64.zip
 mkdir /opt/packer
 unzip -d /opt/packer /tmp/packer_*_linux_arm64.zip
 echo 'export PATH=\${!PATH}:/opt/packer' > /etc/profile.d/packer.sh

--- a/cdk/lib/__snapshots__/amigo.test.ts.snap
+++ b/cdk/lib/__snapshots__/amigo.test.ts.snap
@@ -1215,6 +1215,10 @@ wget -P /tmp https://releases.hashicorp.com/packer/1.13.1/packer_1.13.1_linux_ar
 mkdir /opt/packer
 unzip -d /opt/packer /tmp/packer_*_linux_arm64.zip
 echo 'export PATH=\${!PATH}:/opt/packer' > /etc/profile.d/packer.sh
+export PACKER_PLUGIN_PATH=/opt/packer/.plugins
+/opt/packer/packer plugins install github.com/hashicorp/amazon
+/opt/packer/packer plugins install github.com/hashicorp/ansible
+echo PACKER_PLUGIN_PATH=$PACKER_PLUGIN_PATH >> /etc/environment
 wget -P /tmp https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_arm64/session-manager-plugin.deb
 dpkg -i /tmp/session-manager-plugin.deb
 mkdir /amigo

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -44,7 +44,7 @@ import {
 	StringParameter,
 } from 'aws-cdk-lib/aws-ssm';
 
-const packerVersion = '1.8.5';
+const packerVersion = '1.13.1';
 
 export interface AmigoProps extends GuStackProps {
 	domainName: string;

--- a/cdk/lib/amigo.ts
+++ b/cdk/lib/amigo.ts
@@ -286,6 +286,18 @@ export class AmigoStack extends GuStack {
 					'mkdir /opt/packer',
 					'unzip -d /opt/packer /tmp/packer_*_linux_arm64.zip',
 					"echo 'export PATH=${!PATH}:/opt/packer' > /etc/profile.d/packer.sh",
+
+					/*
+					By default, Packer installs plugins in the user's home directory using $HOME.
+					The value of $HOME is not yet known in the UserData script, so set PACKER_PLUGIN_PATH to a custom directory.
+					See https://developer.hashicorp.com/packer/docs/plugins/install#installation-directory.
+					 */
+					'export PACKER_PLUGIN_PATH=/opt/packer/.plugins',
+					'/opt/packer/packer plugins install github.com/hashicorp/amazon',
+					'/opt/packer/packer plugins install github.com/hashicorp/ansible',
+					// Ensure the custom directory is known to all users, so they can find the plugin. Useful for debugging.
+					'echo PACKER_PLUGIN_PATH=$PACKER_PLUGIN_PATH >> /etc/environment',
+
 					'wget -P /tmp https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_arm64/session-manager-plugin.deb',
 					'dpkg -i /tmp/session-manager-plugin.deb',
 


### PR DESCRIPTION
Relates to https://github.com/guardian/amigo/pull/1661.

## What does this change?
Update to the latest version of Packer.

## How to test
1. Deploy this branch to CODE
2. Confirm this branch is running on CODE by checking the build number on https://amigo.code.dev-gutools.co.uk/healthcheck
3. Bake a recipe
4. Launch an instance using the AMI produced from step 3

I've [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/8a8a3715-b127-496c-af3f-c68e72948c0d) and [successfully baked an image](https://amigo.code.dev-gutools.co.uk/recipes/arm64-jammy-java11-deploy-infrastructure/bakes/41) and used it on https://github.com/guardian/cdk-playground/pull/752.

## What is the value of this?
Keeping up to date.

## Have we considered potential risks?
From the [CHANGELOG](https://github.com/hashicorp/packer/blob/main/CHANGELOG.md) the only breaking change that impacts AMIgo is a change to how Packer builders are provided - we now need to explicitly install plugins. There are likely to be some improvements/optimisations we can make use of too, but that's for future PRs.