### PR TITLE
ci: Switch to using `guardian/actions-riff-raff`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,22 +12,36 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+
+      # These permissions are required by guardian/actions-riff-raff...
+      id-token: write # ...to exchange an OIDC JWT ID token for AWS credentials
+      pull-requests: write #...to comment on PRs
     steps:
       - uses: actions/checkout@v4
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
       - uses: actions/setup-node@v4 # This is required by cdk
         with:
           cache: 'npm'
           cache-dependency-path: 'cdk/package-lock.json'
           node-version-file: '.nvmrc'
       - uses: guardian/setup-scala@v1
-      - name: CI
+      - name: Seed build number from TeamCity
         run: |
           LAST_TEAMCITY_BUILD=3006
-          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          ./script/ci
+          echo BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD )) >> $GITHUB_ENV
+      - run: ./script/ci
+      - uses: guardian/actions-riff-raff@v4
+        with:
+          projectName: tools::amigo
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          buildNumber: ${{ env.BUILD_NUMBER }}
+          configPath: riff-raff.yaml
+          contentDirectories: |
+            cloudformation:
+              - cdk/cdk.out/AMIgo-CODE.template.json
+              - cdk/cdk.out/AMIgo-PROD.template.json
+            amigo:
+              - target/amigo_1.0-latest_all.deb
+            imagecopier:
+              - imageCopier/target/universal/image-copier.zip

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,8 +3,7 @@ addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.8")
 // sbt-native-packager cannot be updated to >1.9.9 until Play supports scala-xml 2
 addSbtPlugin(
   "com.github.sbt" % "sbt-native-packager" % "1.11.1"
-) // scala-steward:off
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
+)
 libraryDependencies += "org.vafer" % "jdeb" % "1.14" artifacts Artifact(
   "jdeb",
   "jar",

--- a/script/ci
+++ b/script/ci
@@ -2,7 +2,6 @@
 
 set -e
 
-# must be done first as sbt uses the CFN template that is generated
 (
  cd cdk
  npm ci
@@ -11,4 +10,11 @@ set -e
  npm run synth
 )
 
-sbt clean scalafmtSbtCheck scalafmtCheckAll compile test riffRaffUpload
+sbt clean scalafmtSbtCheck scalafmtCheckAll compile test
+
+# Create debian package of AMIgo Play app
+sbt "Debian / packageBin"
+
+# Create zip file of imageCopier lambda
+sbt "project imageCopier" "dist"
+mv imageCopier/target/universal/imagecopier.zip imageCopier/target/universal/image-copier.zip


### PR DESCRIPTION
## What does this change?
The SBT plugin https://github.com/guardian/sbt-riffraff-artifact is deprecated. This change switches to [guardian/actions-riff-raff](https://github.com/guardian/actions-riff-raff).

## How to test
### Compare artifacts
Compare the uploaded artifacts from [this branch](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=tools%3A%3Aamigo&id=4878) to that of [main](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=tools%3A%3Aamigo&id=4877). The filenames and directory structure should match. The file sizes should match too[^1]

### Compare the build info
The [/healthcheck endpoint](https://github.com/guardian/amigo/blob/cca21825f88ef2ed4116d5db0091ba175ae2d58f/app/controllers/RootController.scala#L14) returns the build info. After [deploying this branch to CODE](https://riffraff.gutools.co.uk/deployment/view/738ea54e-5eba-4813-8c85-591b9cae201b), check the values are still correct.

[^1]: The `.deb` file differs by 4 bytes, I can't work out why, but it's not significant.