### PR TITLE
Add multimedia to list of allowed users

### DIFF
--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -344,7 +344,7 @@ class AppComponents(context: Context, identity: AppIdentity)
   // Membership in at least one of these groups is required to pass authentication.
   val googleGroupsToCheck = Set(
     configuration.get[String]("auth.google.departmentGroupId"),
-    configuration.get[String]("auth.google.dataScientistsGroupId")
+    configuration.get[String]("auth.google.dataScientistsGroupId"),
     configuration.get[String]("auth.google.multimediaGroupId")
   )
 


### PR DESCRIPTION
## What does this change?

Multimedia manage multiple recipes in amigo (ones that are still running Ubuntu 20.04 and need to be updated) but they do not have access. This PR adds it (and it requires a new SSM parameter to be added `/${STAGE}/deploy/amigo/auth.google.multimediaGroupId`
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I've deployed this to CODE and asked an engineer from multimedia to try and access it, and it worked!