### PR TITLE
Remove unused cloudformation parameter from image copier stack

### DIFF
--- a/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
+++ b/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
@@ -15,11 +15,6 @@ exports[`the lambda stack matches the snapshot 1`] = `
       "Description": "The SNS topic to subscribe to",
       "Type": "String",
     },
-    "KmsKeyArn": {
-      "Default": "",
-      "Description": "Override the default KMS key if required",
-      "Type": "String",
-    },
   },
   "Resources": {
     "HousekeepingLambda": {

--- a/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
+++ b/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
@@ -40,7 +40,7 @@ exports[`the lambda stack matches the snapshot 1`] = `
             },
             "ENCRYPTED_TAG_VALUE": "true",
             "KMS_KEY_ARN": {
-              "Ref": "KmsKeyArn",
+              "Fn::ImportValue": "amigo-imagecopier-key",
             },
           },
         },
@@ -220,7 +220,7 @@ exports[`the lambda stack matches the snapshot 1`] = `
             },
             "ENCRYPTED_TAG_VALUE": "true",
             "KMS_KEY_ARN": {
-              "Ref": "KmsKeyArn",
+              "Fn::ImportValue": "amigo-imagecopier-key",
             },
           },
         },
@@ -379,7 +379,7 @@ exports[`the lambda stack matches the snapshot 1`] = `
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "KmsKeyArn",
+                "Fn::ImportValue": "amigo-imagecopier-key",
               },
             },
           ],

--- a/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
+++ b/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
@@ -40,7 +40,7 @@ exports[`the lambda stack matches the snapshot 1`] = `
             },
             "ENCRYPTED_TAG_VALUE": "true",
             "KMS_KEY_ARN": {
-              "Fn::ImportValue": "amigo-imagecopier-key",
+              "Ref": "KmsKeyArn",
             },
           },
         },
@@ -220,7 +220,7 @@ exports[`the lambda stack matches the snapshot 1`] = `
             },
             "ENCRYPTED_TAG_VALUE": "true",
             "KMS_KEY_ARN": {
-              "Fn::ImportValue": "amigo-imagecopier-key",
+              "Ref": "KmsKeyArn",
             },
           },
         },
@@ -379,7 +379,7 @@ exports[`the lambda stack matches the snapshot 1`] = `
               ],
               "Effect": "Allow",
               "Resource": {
-                "Fn::ImportValue": "amigo-imagecopier-key",
+                "Ref": "KmsKeyArn",
               },
             },
           ],

--- a/cdk/lib/image-copier-lambda.ts
+++ b/cdk/lib/image-copier-lambda.ts
@@ -22,16 +22,13 @@ export class ImageCopierLambda extends GuStack {
 			'deploy-tools-dist',
 		);
 
-		const kmsKeyArnParameter = new CfnParameter(this, 'KmsKeyArn', {
+		new CfnParameter(this, 'KmsKeyArn', {
 			description: 'Override the default KMS key if required',
 			type: 'String',
 			default: '',
 		});
 
-		const kmsKeyArn =
-			kmsKeyArnParameter.valueAsString.length > 0
-				? kmsKeyArnParameter.valueAsString
-				: Fn.importValue('amigo-imagecopier-key');
+		const kmsKeyArn = Fn.importValue('amigo-imagecopier-key');
 
 		const housekeepingTopicParam = new CfnParameter(
 			this,
@@ -88,7 +85,7 @@ export class ImageCopierLambda extends GuStack {
 						'kms:GenerateDataKey*',
 						'kms:DescribeKey',
 					],
-					resources: [kmsKeyArn],
+					resources: [Fn.importValue('amigo-imagecopier-key')],
 				}),
 			],
 		});

--- a/cdk/lib/image-copier-lambda.ts
+++ b/cdk/lib/image-copier-lambda.ts
@@ -22,13 +22,16 @@ export class ImageCopierLambda extends GuStack {
 			'deploy-tools-dist',
 		);
 
-		new CfnParameter(this, 'KmsKeyArn', {
+		const kmsKeyArnParameter = new CfnParameter(this, 'KmsKeyArn', {
 			description: 'Override the default KMS key if required',
 			type: 'String',
 			default: '',
 		});
 
-		const kmsKeyArn = Fn.importValue('amigo-imagecopier-key');
+		const kmsKeyArn =
+			kmsKeyArnParameter.valueAsString.length > 0
+				? kmsKeyArnParameter.valueAsString
+				: Fn.importValue('amigo-imagecopier-key');
 
 		const housekeepingTopicParam = new CfnParameter(
 			this,
@@ -85,7 +88,7 @@ export class ImageCopierLambda extends GuStack {
 						'kms:GenerateDataKey*',
 						'kms:DescribeKey',
 					],
-					resources: [Fn.importValue('amigo-imagecopier-key')],
+					resources: [kmsKeyArn],
 				}),
 			],
 		});

--- a/cdk/lib/image-copier-lambda.ts
+++ b/cdk/lib/image-copier-lambda.ts
@@ -22,12 +22,6 @@ export class ImageCopierLambda extends GuStack {
 			'deploy-tools-dist',
 		);
 
-		new CfnParameter(this, 'KmsKeyArn', {
-			description: 'Override the default KMS key if required',
-			type: 'String',
-			default: '',
-		});
-
 		const kmsKeyArn = Fn.importValue('amigo-imagecopier-key');
 
 		const housekeepingTopicParam = new CfnParameter(


### PR DESCRIPTION
## What does this change?
Somewhere along the road of the CDK migration (I'm assuming) we stopped respecting the KmsKeyArn cloudformation parameter in the image copier CDK. I initially set about to get it working again, but, because I was scared of pushing out a change that would impact teams who had unknowingly set that parameter, I've instead removed it entirely.

## How to test
This should be a noop, I've tested it on the investigations account