### PR TITLE
Add new 'cleanup CUDA' role to cut size of deep learning AMIs

### DIFF
--- a/roles/cuda-cleanup/README.md
+++ b/roles/cuda-cleanup/README.md
@@ -1,0 +1,5 @@
+# Cuda Cleanup Role
+This role is for use with the AWS Deep Learning AMI. By default this AMI comes with multiple versions of the CUDA drivers
+installed, taking up a lot of disk space. This role removes all but one specified version passed via desired_cuda_version
+to free up disk space. This is particularly important when using an Amazon EBS Provisioned Rate for Volume Initialization
+as GB means $. Each version of CUDA is around 10GB.

--- a/roles/cuda-cleanup/defaults/main.yml
+++ b/roles/cuda-cleanup/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+desired_cuda_version: 12.8

--- a/roles/cuda-cleanup/tasks/main.yml
+++ b/roles/cuda-cleanup/tasks/main.yml
@@ -11,4 +11,4 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ cuda_installations.files }}"
-  when: item.path != "/usr/local/cuda-{{ desired_cuda_version }}"
+  when: item.path != "/usr/local/cuda-" + desired_cuda_version

--- a/roles/cuda-cleanup/tasks/main.yml
+++ b/roles/cuda-cleanup/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Find all CUDA installations in /usr/local
+  find:
+    paths: /usr/local
+    patterns: "cuda-*"
+    file_type: directory
+  register: cuda_installations
+
+- name: Remove CUDA versions other than {{ desired_cuda_version }}
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ cuda_installations.files }}"
+  when: item.path != "/usr/local/cuda-{{ desired_cuda_version }}"


### PR DESCRIPTION
## What does this change?
The AWS Deep Learning AMI comes with multiple versions of CUDA preinstalled on it. These are about 10GB each. By deleting unwanted versions we can save around 30GB of disk space on the output AMI.

This will save us 0.0036*30=$0.11 per instance boot if we set the maximum volume initialization rate - docs here https://docs.aws.amazon.com/ebs/latest/userguide/initalize-volume.html#volume-initialization-rate pricing details here https://aws.amazon.com/ebs/pricing/ under 'Amazon EBS Provisioned Rate for Volume Initialization'


## How to test
Tested on CODE