### PR TITLE
Fix cuda cleanup role

### DIFF
--- a/roles/cuda-cleanup/defaults/main.yml
+++ b/roles/cuda-cleanup/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-desired_cuda_version: 12.8
+desired_cuda_version: "12.8"

--- a/roles/cuda-cleanup/tasks/main.yml
+++ b/roles/cuda-cleanup/tasks/main.yml
@@ -11,4 +11,4 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ cuda_installations.files }}"
-  when: item.path != "/usr/local/cuda-" + desired_cuda_version
+  when: item.path != "/usr/local/cuda-" + desired_cuda_version | string

--- a/roles/cuda-cleanup/tasks/main.yml
+++ b/roles/cuda-cleanup/tasks/main.yml
@@ -11,4 +11,4 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ cuda_installations.files }}"
-  when: item.path != "/usr/local/cuda-" + desired_cuda_version | string
+  when: item.path != "/usr/local/cuda-" ~ desired_cuda_version


### PR DESCRIPTION
## What does this change?
In the [final commit](https://github.com/guardian/amigo/pull/1828/changes/ef5ce502006a63497bf3271bc6aa1fff76415d47) of this PR https://github.com/guardian/amigo/pull/1828 which added a new 'cuda cleanup' role to save disk space, I messed up - the jinja2 syntax was needed to turn a number into a string

This fixes the problem by using the ~ concatenation operator to join the two things. ~ automatically converts both sides to astring
