### PR TITLE
chore(deps): Update AWS SDK

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,7 @@ scalacOptions ++= Seq(
 val jacksonV2Version = "2.21.2"
 val circeVersion = "0.14.15"
 
-val awsV2SdkVersion = "2.42.41"
+val awsV2SdkVersion = "2.44.4"
 val playSecretRotationVersion = "17.0.5"
 
 /*


### PR DESCRIPTION
## What does this change?
See https://github.com/aws/aws-sdk-java-v2/releases/tag/2.44.4. Hoping this includes an update of the transitive `netty` dependencies as there are open vulnerabilities against them.

> [!NOTE]
> The `netty` issues are reported against the lambdas that are deployed in the StackSet. If the issues are resolved for the Play app, we'll need to perform a StackSet update too.