### PR TITLE
chore: Update `ImageCopier` version for new release

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -46,5 +46,5 @@ new ImageCopierLambda(app, 'imagecopier-lambda-stack', {
 	stack: 'deploy',
 	stage: 'PROD',
 	description: 'AMIgo image copier lambda',
-	version: 'v4', // Update this when the lambda is updated.
+	version: 'v5', // Update this when the lambda is updated.
 });

--- a/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
+++ b/cdk/lib/__snapshots__/image-copier-lambda.test.ts.snap
@@ -25,7 +25,7 @@ exports[`the lambda stack matches the snapshot 1`] = `
       "Properties": {
         "Code": {
           "S3Bucket": "deploy-tools-dist",
-          "S3Key": "cdk/TEST/imagecopier/image-copier-v4.zip",
+          "S3Key": "cdk/TEST/imagecopier/image-copier-v5.zip",
         },
         "Description": "Lambda for housekeeping AMIgo baked AMIs in other accounts",
         "Environment": {
@@ -205,7 +205,7 @@ exports[`the lambda stack matches the snapshot 1`] = `
       "Properties": {
         "Code": {
           "S3Bucket": "deploy-tools-dist",
-          "S3Key": "cdk/TEST/imagecopier/image-copier-v4.zip",
+          "S3Key": "cdk/TEST/imagecopier/image-copier-v5.zip",
         },
         "Description": "Lambda for copying and encrypting AMIgo baked AMIs",
         "Environment": {

--- a/cdk/lib/image-copier-lambda.test.ts
+++ b/cdk/lib/image-copier-lambda.test.ts
@@ -8,7 +8,7 @@ describe('the lambda stack', () => {
 		const stack = new ImageCopierLambda(app, 'IntegrationTest', {
 			stack: 'cdk',
 			stage: 'TEST',
-			version: 'v4',
+			version: 'v5',
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();


### PR DESCRIPTION
Following https://github.com/guardian/amigo/tree/main/imageCopier#deploying to release a new version after https://github.com/guardian/amigo/pull/1841.