### PR TITLE
Upgrade to latest versions of Guardian libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ val jacksonV2Version = "2.21.3"
 val circeVersion = "0.14.15"
 
 val awsV2SdkVersion = "2.44.4"
-val playSecretRotationVersion = "17.0.5"
+val playSecretRotationVersion = "18.0.0"
 
 /*
  * To test whether any of these entries are redundant:
@@ -100,7 +100,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "simple-configuration-ssm" % "10.0.1",
   "com.gu.play-secret-rotation" %% "play-v30" % playSecretRotationVersion,
   "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % playSecretRotationVersion,
-  "com.gu.play-googleauth" %% "play-v30" % "36.1.0",
+  "com.gu.play-googleauth" %% "play-v30" % "39.0.0",
   // Pin play-bootstrap because it is tied to the bootstrap version
   "com.adrianhurt" %% "play-bootstrap" % "1.6.1-P28-B3", // scala-steward:off
   "org.quartz-scheduler" % "quartz" % "2.5.2",


### PR DESCRIPTION
Replaces https://github.com/guardian/amigo/pull/1843, which won't build.

https://github.com/guardian/play-secret-rotation/releases
https://github.com/guardian/play-googleauth/releases

The `play-secret-rotation` change looks like a major version update but the [actual changes are minimal](https://github.com/guardian/play-secret-rotation/compare/v17.0.5...v18.0.0).

Similarly, the `play-googleauth` change only contains [dependency updates](https://github.com/guardian/play-googleauth/compare/v36.1.0...v39.0.0).

I've [deployed this change to `CODE`](https://riffraff.gutools.co.uk/deployment/view/77807a97-0615-4f47-afc7-3812d45bbdda) and confirmed that I can still log in (via an Incognito window).