### PR TITLE
feat(packer): Enforce IMDSv2 for launched instances

### DIFF
--- a/app/models/packer/PackerBuilderConfig.scala
+++ b/app/models/packer/PackerBuilderConfig.scala
@@ -36,7 +36,8 @@ case class PackerBuilderConfig(
     security_group_id: Option[String],
     //  Needed for long running bakes
     //  See https://developer.hashicorp.com/packer/integrations/hashicorp/amazon#resourcenotready-error
-    aws_polling: Option[AwsPolling]
+    aws_polling: Option[AwsPolling],
+    metadata_options: Map[String, String]
 )
 
 object PackerBuilderConfig {

--- a/app/packer/PackerBuildConfigGenerator.scala
+++ b/app/packer/PackerBuildConfigGenerator.scala
@@ -78,7 +78,12 @@ object PackerBuildConfigGenerator {
       ami_block_device_mappings = disk,
       launch_block_device_mappings = disk,
       security_group_id = packerConfig.securityGroupId,
-      aws_polling = awsPolling
+      aws_polling = awsPolling,
+      metadata_options = Map(
+        "http_endpoint" -> "enabled",
+        "http_tokens" -> "required",
+        "http_put_response_hop_limit" -> "1"
+      )
     )
 
     val baseImage = bake.recipe.baseImage.linuxDist.getOrElse(Ubuntu)


### PR DESCRIPTION
## What does this change?
The FSBP control EC2.8 requires EC2 instances should use Instance Metadata Service Version 2 (IMDSv2). This change updates the Packer configuration to meet this requirement.

This configuration option was added in [v1.2.2](https://github.com/hashicorp/packer-plugin-amazon/releases/tag/v1.2.2). We're using v1.3.9:

```console
❯ ssm cmd --profile deployTools -t amigo,deploy,CODE -c "/opt/packer/packer plugins installed | grep packer-plugin-amazon"

/opt/packer/.plugins/github.com/hashicorp/amazon/packer-plugin-amazon_v1.3.9_x5.0_linux_arm64
```

See also https://developer.hashicorp.com/packer/integrations/hashicorp/amazon/v1.3.9/components/builder/ebs#enforce-instance-metadata-service-v2.

## How to test
- [Deploy to CODE](https://riffraff.gutools.co.uk/deployment/view/32289033-0de2-4db8-bb69-360938c65f56)
- Start a [bake](https://amigo.code.dev-gutools.co.uk/recipes/akash-test/bakes/17) and observe the IMDS configuration of the launched instance:

<img width="416" height="595" alt="image" src="https://github.com/user-attachments/assets/9654b979-bc39-44f4-8c09-8bd5518f2274" />
