### PR TITLE
Set frequency to quarterly

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,6 +1,6 @@
 updatePullRequests = "always"
 
-pullRequests.frequency = "30 days"
+pullRequests.frequency = "0 0 1 jan,apr,jul,oct ?"
 
 pullRequests.grouping = [
   { name = "non_aws_minor_patch", "title" = "chore(deps): Non-AWS minor and patch version dependency updates", "filter" = [{"version" = "minor"}, {"version" = "patch"}] },


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Aligns the scala steward schedule to be the same as dependabot: once a quarter, on the first day of the quarter.
