### PR TITLE
Remove whisperx model fetch step from whisperx role

### DIFF
--- a/roles/whisperx/tasks/main.yml
+++ b/roles/whisperx/tasks/main.yml
@@ -15,18 +15,3 @@
     src: "{{ whisperx_venv }}/bin/whisperx"
     dest: /usr/local/bin/whisperx
     state: link
-
-# We use a python script to fetch the models which is owned by the transcription service. See the below PRs for details:
-#  -  https://github.com/guardian/amigo/pull/1607
-#  - https://github.com/guardian/transcription-service/pull/130
-- name: Download models script
-  shell: |
-    aws --quiet s3 cp s3://amigo-data-{{ model_script_stage.lower() }}/deploy/{{ model_script_stage }}/whisperx-model-fetch/download_whisperx_models.py /tmp/download_whisperx_models.py
-    exit 0
-
-# The script lives here https://github.com/guardian/transcription-service/blob/main/whisperx-model-fetch/download_whisperx_models.py
-# If you are changing these parameters it may be helpful to run it locally to test the changes.
-- name: Download whisperx models
-  command: "{{ whisperx_venv }}/bin/python /tmp/download_whisperx_models.py --whisper-models --diarization-models --torch-align-models --huggingface-token {{ huggingface_token }}"
-  become: yes
-  become_user: ubuntu


### PR DESCRIPTION
## What does this change?
We download models on startup straight to the NVMe drive here https://github.com/guardian/transcription-service/blob/7866d87543d50e441b4d537e3f32dac6903c6a01/packages/cdk/lib/transcription-service.ts#L359 so there's no need to bake them into the AMI anymore

## How to test
Tested on CODE - verified that transcription still works with the updated version of the role